### PR TITLE
 Add missing fields to ExchangeInfo and CreateOrderResponse; FOK option; Single symbol bookTicker method

### DIFF
--- a/account_service_test.go
+++ b/account_service_test.go
@@ -71,7 +71,7 @@ func (s *accountServiceTestSuite) TestGetAccount() {
 
 func (s *accountServiceTestSuite) assertAccountEqual(e, a *Account) {
 	r := s.r()
-	r.Equal(e.MakerCommission, a.MakerCommission, "AakerCommission")
+	r.Equal(e.MakerCommission, a.MakerCommission, "MakerCommission")
 	r.Equal(e.TakerCommission, a.TakerCommission, "TakerCommission")
 	r.Equal(e.BuyerCommission, a.BuyerCommission, "BuyerCommission")
 	r.Equal(e.SellerCommission, a.SellerCommission, "SellerCommission")
@@ -80,7 +80,7 @@ func (s *accountServiceTestSuite) assertAccountEqual(e, a *Account) {
 	r.Equal(e.CanDeposit, a.CanDeposit, "CanDeposit")
 	r.Len(a.Balances, len(e.Balances))
 	for i := 0; i < len(a.Balances); i++ {
-		r.Equal(e.Balances[i].Asset, a.Balances[i].Asset, "Assert")
+		r.Equal(e.Balances[i].Asset, a.Balances[i].Asset, "Asset")
 		r.Equal(e.Balances[i].Free, a.Balances[i].Free, "Free")
 		r.Equal(e.Balances[i].Locked, a.Balances[i].Locked, "Locked")
 	}

--- a/client.go
+++ b/client.go
@@ -36,6 +36,7 @@ const (
 
 	TimeInForceGTC TimeInForce = "GTC"
 	TimeInForceIOC TimeInForce = "IOC"
+	TimeInForceFOK TimeInForce = "FOK"
 
 	timestampKey  = "timestamp"
 	signatureKey  = "signature"

--- a/client.go
+++ b/client.go
@@ -215,6 +215,11 @@ func (c *Client) NewListPricesService() *ListPricesService {
 	return &ListPricesService{c: c}
 }
 
+// NewBookTickerService init booking ticker service
+func (c *Client) NewBookTickerService() *BookTickerService {
+	return &BookTickerService{c: c}
+}
+
 // NewListBookTickersService init listing booking tickers service
 func (c *Client) NewListBookTickersService() *ListBookTickersService {
 	return &ListBookTickersService{c: c}

--- a/exchange_info_service.go
+++ b/exchange_info_service.go
@@ -26,6 +26,7 @@ func (s *ExchangeInfoService) Do(ctx context.Context, opts ...RequestOption) (re
 	if err != nil {
 		return
 	}
+
 	return
 }
 
@@ -36,9 +37,13 @@ type ExchangeInfo struct {
 
 // Symbol market symbol
 type Symbol struct {
-	Symbol             string `json:"symbol"`
-	BaseAsset          string `json:"baseAsset"`
-	BaseAssetPrecision int    `json:"baseAssetPrecision"`
-	QuoteAsset         string `json:"quoteAsset"`
-	QuotePrecision     int    `json:"quotePrecision"`
+	Symbol             string              `json:"symbol"`
+	Status             string              `json:"status"`
+	BaseAsset          string              `json:"baseAsset"`
+	BaseAssetPrecision int                 `json:"baseAssetPrecision"`
+	QuoteAsset         string              `json:"quoteAsset"`
+	QuotePrecision     int                 `json:"quotePrecision"`
+	OrderTypes         []string            `json:"orderTypes"`
+	IcebergAllowed     bool                `json:"icebergAllowed"`
+	Filters            []map[string]string `json:"filters"`
 }

--- a/exchange_info_service_test.go
+++ b/exchange_info_service_test.go
@@ -19,10 +19,14 @@ func (s *exchangeInfoServiceTestSuite) TestExchangeInfo() {
 		"symbols": [
 			{
 				"symbol": "ETHBTC",
+				"status": "TRADING",
 				"baseAsset": "ETH",
 				"baseAssetPrecision": 8,
 				"quoteAsset": "BTC",
-				"quotePrecision": 8
+				"quotePrecision": 8,
+				"orderTypes":["LIMIT","LIMIT_MAKER","MARKET","STOP_LOSS_LIMIT","TAKE_PROFIT_LIMIT"],
+				"icebergAllowed": true,
+				"filters":[{"filterType":"PRICE_FILTER","minPrice":"0.00000100","maxPrice":"100000.00000000","tickSize":"0.00000100"},{"filterType":"LOT_SIZE","minQty":"0.00100000","maxQty":"100000.00000000","stepSize":"0.00100000"},{"filterType":"MIN_NOTIONAL","minNotional":"0.00100000"}]
 			}
 		]
 	}`)
@@ -38,10 +42,18 @@ func (s *exchangeInfoServiceTestSuite) TestExchangeInfo() {
 		Symbols: []Symbol{
 			{
 				Symbol:             "ETHBTC",
+				Status:             "TRADING",
 				BaseAsset:          "ETH",
 				BaseAssetPrecision: 8,
 				QuoteAsset:         "BTC",
 				QuotePrecision:     8,
+				OrderTypes:         []string{"LIMIT", "LIMIT_MAKER", "MARKET", "STOP_LOSS_LIMIT", "TAKE_PROFIT_LIMIT"},
+				IcebergAllowed:     true,
+				Filters: []map[string]string{
+					{"filterType": "PRICE_FILTER", "minPrice": "0.00000100", "maxPrice": "100000.00000000", "tickSize": "0.00000100"},
+					{"filterType": "LOT_SIZE", "minQty": "0.00100000", "maxQty": "100000.00000000", "stepSize": "0.00100000"},
+					{"filterType": "MIN_NOTIONAL", "minNotional": "0.00100000"},
+				},
 			},
 		},
 	}
@@ -50,12 +62,34 @@ func (s *exchangeInfoServiceTestSuite) TestExchangeInfo() {
 
 func (s *exchangeInfoServiceTestSuite) assertExchangeInfoEqual(e, a *ExchangeInfo) {
 	r := s.r()
-	for i := 0; i < len(a.Symbols); i++ {
+	for i, currentSymbol := range a.Symbols {
 		if a.Symbols[i].Symbol == e.Symbols[0].Symbol {
-			r.Equal(e.Symbols[i].BaseAsset, a.Symbols[i].BaseAsset, "BaseAsset")
-			r.Equal(e.Symbols[i].BaseAssetPrecision, a.Symbols[i].BaseAssetPrecision, "BaseAssetPrecision")
-			r.Equal(e.Symbols[i].QuoteAsset, a.Symbols[i].QuoteAsset, "QuoteAsset")
-			r.Equal(e.Symbols[i].QuotePrecision, a.Symbols[i].QuotePrecision, "QuotePrecision")
+			r.Equal(e.Symbols[i].Status, currentSymbol.Status, "Status")
+			r.Equal(e.Symbols[i].BaseAsset, currentSymbol.BaseAsset, "BaseAsset")
+			r.Equal(e.Symbols[i].BaseAssetPrecision, currentSymbol.BaseAssetPrecision, "BaseAssetPrecision")
+			r.Equal(e.Symbols[i].QuoteAsset, currentSymbol.QuoteAsset, "QuoteAsset")
+			r.Equal(e.Symbols[i].QuotePrecision, currentSymbol.QuotePrecision, "QuotePrecision")
+			r.Len(currentSymbol.OrderTypes, len(e.Symbols[i].OrderTypes))
+			r.Equal(e.Symbols[i].OrderTypes, currentSymbol.OrderTypes, "OrderTypes")
+			r.Equal(e.Symbols[i].IcebergAllowed, currentSymbol.IcebergAllowed, "IcebergAllowed")
+			r.Len(currentSymbol.Filters, len(e.Symbols[i].Filters))
+			for fi, currentFilter := range currentSymbol.Filters {
+				r.Len(currentFilter, len(e.Symbols[i].Filters[fi]))
+				switch currentFilter["filterType"] {
+				case "PRICE_FILTER":
+					r.Equal(e.Symbols[i].Filters[fi]["minPrice"], currentFilter["minPrice"], "minPrice")
+					r.Equal(e.Symbols[i].Filters[fi]["maxPrice"], currentFilter["maxPrice"], "maxPrice")
+					r.Equal(e.Symbols[i].Filters[fi]["tickSize"], currentFilter["tickSize"], "tickSize")
+				case "LOT_SIZE":
+					r.Equal(e.Symbols[i].Filters[fi]["minQty"], currentFilter["minQty"], "minQty")
+					r.Equal(e.Symbols[i].Filters[fi]["maxQty"], currentFilter["maxQty"], "maxQty")
+					r.Equal(e.Symbols[i].Filters[fi]["stepSize"], currentFilter["stepSize"], "stepSize")
+				case "MIN_NOTIONAL":
+					r.Equal(e.Symbols[i].Filters[fi]["minNotional"], currentFilter["minNotional"], "minNotional")
+				}
+
+			}
+
 			return
 		}
 

--- a/order_service.go
+++ b/order_service.go
@@ -130,6 +130,13 @@ type CreateOrderResponse struct {
 	OrderID       int64  `json:"orderId"`
 	ClientOrderID string `json:"clientOrderId"`
 	TransactTime  int64  `json:"transactTime"`
+	Price            string `json:"price"`
+	OrigQuantity     string `json:"origQty"`
+	ExecutedQuantity string `json:"executedQty"`
+	Status           string `json:"status"`
+	TimeInForce      string `json:"timeInForce"`
+	Type             string `json:"type"`
+	Side             string `json:"side"`
 }
 
 // ListOpenOrdersService list opened orders

--- a/order_service.go
+++ b/order_service.go
@@ -126,10 +126,10 @@ func (s *CreateOrderService) Test(ctx context.Context, opts ...RequestOption) (e
 
 // CreateOrderResponse define create order response
 type CreateOrderResponse struct {
-	Symbol        string `json:"symbol"`
-	OrderID       int64  `json:"orderId"`
-	ClientOrderID string `json:"clientOrderId"`
-	TransactTime  int64  `json:"transactTime"`
+	Symbol           string `json:"symbol"`
+	OrderID          int64  `json:"orderId"`
+	ClientOrderID    string `json:"clientOrderId"`
+	TransactTime     int64  `json:"transactTime"`
 	Price            string `json:"price"`
 	OrigQuantity     string `json:"origQty"`
 	ExecutedQuantity string `json:"executedQty"`

--- a/order_service_test.go
+++ b/order_service_test.go
@@ -54,17 +54,17 @@ func (s *orderServiceTestSuite) TestCreateOrder() {
 		Price(price).NewClientOrderID(newClientOrderID).Do(newContext())
 	s.r().NoError(err)
 	e := &CreateOrderResponse{
-		Symbol:        "LTCBTC",
-		OrderID:       1,
-		ClientOrderID: "myOrder1",
-		TransactTime:  1499827319559,
-		Price: "0.0001",
-		OrigQuantity: "12.00",
+		Symbol:           "LTCBTC",
+		OrderID:          1,
+		ClientOrderID:    "myOrder1",
+		TransactTime:     1499827319559,
+		Price:            "0.0001",
+		OrigQuantity:     "12.00",
 		ExecutedQuantity: "10.00",
-		Status: "FILLED",
-		TimeInForce: "GTC",
-		Type: "LIMIT",
-		Side: "BUY",
+		Status:           "FILLED",
+		TimeInForce:      "GTC",
+		Type:             "LIMIT",
+		Side:             "BUY",
 	}
 	s.assertCreateOrderResponseEqual(e, res)
 

--- a/order_service_test.go
+++ b/order_service_test.go
@@ -16,11 +16,18 @@ func TestOrderService(t *testing.T) {
 
 func (s *orderServiceTestSuite) TestCreateOrder() {
 	data := []byte(`{
-        "symbol":"LTCBTC",
-        "orderId": 1,
-        "clientOrderId": "myOrder1",
-        "transactTime": 1499827319559
-    }`)
+		"symbol": "LTCBTC",
+		"orderId": 1,
+		"clientOrderId": "myOrder1",
+		"transactTime": 1499827319559,
+		"price": "0.0001",
+		"origQty": "12.00",
+		"executedQty": "10.00",
+		"status": "FILLED",
+		"timeInForce": "GTC",
+		"type": "LIMIT",
+		"side": "BUY"
+	}`)
 	s.mockDo(data, nil)
 	defer s.assertDo()
 	symbol := "LTCBTC"
@@ -51,6 +58,13 @@ func (s *orderServiceTestSuite) TestCreateOrder() {
 		OrderID:       1,
 		ClientOrderID: "myOrder1",
 		TransactTime:  1499827319559,
+		Price: "0.0001",
+		OrigQuantity: "12.00",
+		ExecutedQuantity: "10.00",
+		Status: "FILLED",
+		TimeInForce: "GTC",
+		Type: "LIMIT",
+		Side: "BUY",
 	}
 	s.assertCreateOrderResponseEqual(e, res)
 
@@ -66,6 +80,13 @@ func (s *orderServiceTestSuite) assertCreateOrderResponseEqual(e, a *CreateOrder
 	r.Equal(e.OrderID, a.OrderID, "OrderID")
 	r.Equal(e.ClientOrderID, a.ClientOrderID, "ClientOrderID")
 	r.Equal(e.TransactTime, a.TransactTime, "TransactTime")
+	r.Equal(e.Price, a.Price, "Price")
+	r.Equal(e.OrigQuantity, a.OrigQuantity, "OrigQuantity")
+	r.Equal(e.ExecutedQuantity, a.ExecutedQuantity, "ExecutedQuantity")
+	r.Equal(e.Status, a.Status, "Status")
+	r.Equal(e.TimeInForce, a.TimeInForce, "TimeInForce")
+	r.Equal(e.Type, a.Type, "Type")
+	r.Equal(e.Side, a.Side, "Side")
 }
 
 func (s *orderServiceTestSuite) TestListOpenOrders() {

--- a/ticker_service.go
+++ b/ticker_service.go
@@ -7,7 +7,7 @@ import (
 
 // ListBookTickersService list all book tickers
 type ListBookTickersService struct {
-	c      *Client
+	c *Client
 }
 
 // Do send request

--- a/ticker_service.go
+++ b/ticker_service.go
@@ -14,7 +14,7 @@ type ListBookTickersService struct {
 func (s *ListBookTickersService) Do(ctx context.Context, opts ...RequestOption) (res []*BookTicker, err error) {
 	r := &request{
 		method:   "GET",
-		endpoint: "/api/v1/ticker/allBookTickers",
+		endpoint: "/api/v3/ticker/bookTicker",
 	}
 	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {

--- a/ticker_service.go
+++ b/ticker_service.go
@@ -7,7 +7,7 @@ import (
 
 // ListBookTickersService list all book tickers
 type ListBookTickersService struct {
-	c *Client
+	c      *Client
 }
 
 // Do send request
@@ -21,6 +21,36 @@ func (s *ListBookTickersService) Do(ctx context.Context, opts ...RequestOption) 
 		return
 	}
 	res = make([]*BookTicker, 0)
+	err = json.Unmarshal(data, &res)
+	if err != nil {
+		return
+	}
+	return
+}
+
+// BookTickerService list symbol's book ticker
+type BookTickerService struct {
+	c      *Client
+	symbol string
+}
+
+// Symbol set symbol
+func (s *BookTickerService) Symbol(symbol string) *BookTickerService {
+	s.symbol = symbol
+	return s
+}
+
+func (s *BookTickerService) Do(ctx context.Context, opts ...RequestOption) (res *BookTicker, err error) {
+	r := &request{
+		method:   "GET",
+		endpoint: "/api/v3/ticker/bookTicker",
+	}
+	r.setParam("symbol", s.symbol)
+	data, err := s.c.callAPI(ctx, r, opts...)
+	if err != nil {
+		return
+	}
+	res = new(BookTicker)
 	err = json.Unmarshal(data, &res)
 	if err != nil {
 		return

--- a/ticker_service.go
+++ b/ticker_service.go
@@ -40,6 +40,7 @@ func (s *BookTickerService) Symbol(symbol string) *BookTickerService {
 	return s
 }
 
+// Do send request
 func (s *BookTickerService) Do(ctx context.Context, opts ...RequestOption) (res *BookTicker, err error) {
 	r := &request{
 		method:   "GET",

--- a/ticker_service_test.go
+++ b/ticker_service_test.go
@@ -61,6 +61,37 @@ func (s *tickerServiceTestSuite) TestListBookTickers() {
 	s.assertBookTickerEqual(e2, tickers[1])
 }
 
+func (s *tickerServiceTestSuite) TestSingleBookTicker() {
+	data := []byte(`{
+            "symbol": "LTCBTC",
+            "bidPrice": "4.00000000",
+            "bidQty": "431.00000000",
+            "askPrice": "4.00000200",
+            "askQty": "9.00000000"
+        }`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	symbol := "LTCBTC"
+
+	s.assertReq(func(r *request) {
+		e := newRequest().setParam("symbol", symbol)
+		s.assertRequestEqual(e, r)
+	})
+
+	ticker, err := s.client.NewBookTickerService().Symbol("LTCBTC").Do(newContext())
+	r := s.r()
+	r.NoError(err)
+	e := &BookTicker{
+		Symbol:      "LTCBTC",
+		BidPrice:    "4.00000000",
+		BidQuantity: "431.00000000",
+		AskPrice:    "4.00000200",
+		AskQuantity: "9.00000000",
+	}
+	s.assertBookTickerEqual(e, ticker)
+}
+
 func (s *tickerServiceTestSuite) assertBookTickerEqual(e, a *BookTicker) {
 	r := s.r()
 	r.Equal(e.Symbol, a.Symbol, "Symbol")


### PR DESCRIPTION
At first I tried doing a dynamic JSON unmarshaling (something like [this](http://gregtrowbridge.com/golang-json-serialization-with-interfaces/)) for the filters, using the `filterType`, but I don't think it's really possible as the struct returned from the client's method can't be really dynamic.

I have another idea, which is to create a `Filter` struct that will look something like this:

	type Filter struct {
		Price PriceFilter
		LotSize LotSizeFilter
		MinNotinal MinNotionalFilter
	}
	
	type PriceFilter struct {
		MinPrice string
		MaxPrice string
		TickSize string
	}
	
	type LotSizeFilter struct {
		MinQuantity string
		MaxQuantity string
		StepSize string
	}
	
	type MinNotionalFilter struct {
		MinNotional string
	}

and to create them manually by iterating over the filters list.
Tell me if you think it is better.