### PR TITLE
Fix typo in header key

### DIFF
--- a/client.go
+++ b/client.go
@@ -111,7 +111,7 @@ func (c *Client) parseRequest(r *request, opts ...RequestOption) (err error) {
 	bodyString := r.form.Encode()
 	header := http.Header{}
 	if bodyString != "" {
-		header.Set("Context-Type", "application/x-www-form-urlencoded")
+		header.Set("Content-Type", "application/x-www-form-urlencoded")
 		body = bytes.NewBufferString(bodyString)
 	}
 	if r.secType == secTypeAPIKey || r.secType == secTypeSigned {


### PR DESCRIPTION
"Context-Type" should be "Content-Type"