### PR TITLE
Added new miniticker ws endpoint and unit tests

### DIFF
--- a/websocket_service.go
+++ b/websocket_service.go
@@ -301,7 +301,6 @@ type WsMarketStatEvent struct {
 // WsAllMiniMarketsStatServeHandler handle websocket that push all mini-ticker market statistics for 24hr
 type WsAllMiniMarketsStatServeHandler func(event WsAllMiniMarketsStatEvent)
 
-
 // WsAllMiniMarketsStatServe serve websocket that push mini version of 24hr statistics for all market every second
 func WsAllMiniMarketsStatServe(handler WsAllMiniMarketsStatServeHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
 	endpoint := fmt.Sprintf("%s/!miniTicker@arr", baseURL)
@@ -323,13 +322,13 @@ type WsAllMiniMarketsStatEvent []*WsMiniMarketsStatEvent
 
 // WsMiniMarketsStatEvent define websocket market mini-ticker statistics event
 type WsMiniMarketsStatEvent struct {
-	Event              string `json:"e"`
-	Time               int64  `json:"E"`
-	Symbol             string `json:"s"`
-	LastPrice          string `json:"c"`
-	OpenPrice          string `json:"o"`
-	HighPrice          string `json:"h"`
-	LowPrice           string `json:"l"`
-	BaseVolume         string `json:"v"`
-	QuoteVolume        string `json:"q"`
+	Event       string `json:"e"`
+	Time        int64  `json:"E"`
+	Symbol      string `json:"s"`
+	LastPrice   string `json:"c"`
+	OpenPrice   string `json:"o"`
+	HighPrice   string `json:"h"`
+	LowPrice    string `json:"l"`
+	BaseVolume  string `json:"v"`
+	QuoteVolume string `json:"q"`
 }

--- a/websocket_service.go
+++ b/websocket_service.go
@@ -297,3 +297,39 @@ type WsMarketStatEvent struct {
 	LastID             int64  `json:"L"`
 	Count              int64  `json:"n"`
 }
+
+// WsAllMiniMarketsStatServeHandler handle websocket that push all mini-ticker market statistics for 24hr
+type WsAllMiniMarketsStatServeHandler func(event WsAllMiniMarketsStatEvent)
+
+
+// WsAllMiniMarketsStatServe serve websocket that push mini version of 24hr statistics for all market every second
+func WsAllMiniMarketsStatServe(handler WsAllMiniMarketsStatServeHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	endpoint := fmt.Sprintf("%s/!miniTicker@arr", baseURL)
+	cfg := newWsConfig(endpoint)
+	wsHandler := func(message []byte) {
+		var event WsAllMiniMarketsStatEvent
+		err := json.Unmarshal(message, &event)
+		if err != nil {
+			errHandler(err)
+			return
+		}
+		handler(event)
+	}
+	return wsServe(cfg, wsHandler, errHandler)
+}
+
+// WsAllMiniMarketsStatEvent define array of websocket market mini-ticker statistics events
+type WsAllMiniMarketsStatEvent []*WsMiniMarketsStatEvent
+
+// WsMiniMarketsStatEvent define websocket market mini-ticker statistics event
+type WsMiniMarketsStatEvent struct {
+	Event              string `json:"e"`
+	Time               int64  `json:"E"`
+	Symbol             string `json:"s"`
+	LastPrice          string `json:"c"`
+	OpenPrice          string `json:"o"`
+	HighPrice          string `json:"h"`
+	LowPrice           string `json:"l"`
+	BaseVolume         string `json:"v"`
+	QuoteVolume        string `json:"q"`
+}

--- a/websocket_service_test.go
+++ b/websocket_service_test.go
@@ -665,3 +665,83 @@ func (s *websocketServiceTestSuite) assertWsTradeEventEqual(e, a *WsTradeEvent) 
 	r.Equal(e.TradeTime, a.TradeTime, "TradeTime")
 	r.Equal(e.IsBuyerMaker, a.IsBuyerMaker, "IsBuyerMaker")
 }
+
+
+func (s *websocketServiceTestSuite) TestWsAllMiniMarketsStatServe() {
+	data := []byte(`[{
+  		"e": "24hrMiniTicker",
+    	"E": 1523658017154,
+    	"s": "BNBBTC",
+   	 	"c": "0.00175640",
+    	"o": "0.00161200",
+    	"h": "0.00176000",
+    	"l": "0.00159370",
+    	"v": "3479863.89000000",
+    	"q": "5725.90587704"
+	},{
+  		"e": "24hrMiniTicker",
+    	"E": 1523658017133,
+    	"s": "BNBETH",
+    	"c": "0.02827000",
+    	"o": "0.02628100",
+    	"h": "0.02830300",
+    	"l": "0.02469400",
+    	"v": "456266.78000000",
+    	"q": "11873.11095682"
+	}]`)
+	fakeErrMsg := "fake error"
+	s.mockWsServe(data, errors.New(fakeErrMsg))
+	defer s.assertWsServe()
+
+	doneC, stopC, err := WsAllMiniMarketsStatServe(func(event WsAllMiniMarketsStatEvent) {
+		e := WsAllMiniMarketsStatEvent{
+			&WsMiniMarketsStatEvent{
+				Event:              "24hrMiniTicker",
+				Time:               1523658017154,
+				Symbol:             "BNBBTC",
+				LastPrice:          "0.00175640",
+				OpenPrice:          "0.00161200",
+				HighPrice:          "0.00176000",
+				LowPrice:           "0.00159370",
+				BaseVolume:         "3479863.89000000",
+				QuoteVolume:        "5725.90587704",
+			},
+			&WsMiniMarketsStatEvent{
+				Event:              "24hrMiniTicker",
+				Time:               1523658017133,
+				Symbol:             "BNBETH",
+				LastPrice:          "0.02827000",
+				OpenPrice:          "0.02628100",
+				HighPrice:          "0.02830300",
+				LowPrice:           "0.02469400",
+				BaseVolume:         "456266.78000000",
+				QuoteVolume:        "11873.11095682",
+			},
+		}
+		s.assertWsAllMiniMarketsStatEventEqual(e, event)
+	}, func(err error) {
+		s.r().EqualError(err, fakeErrMsg)
+	})
+	s.r().NoError(err)
+	stopC <- struct{}{}
+	<-doneC
+}
+
+func (s *websocketServiceTestSuite) assertWsAllMiniMarketsStatEventEqual(e, a WsAllMiniMarketsStatEvent) {
+	for i := range e {
+		s.assertWsMiniMarketsStatEventEqual(e[i], a[i])
+	}
+}
+
+func (s *websocketServiceTestSuite) assertWsMiniMarketsStatEventEqual(e, a *WsMiniMarketsStatEvent) {
+	r := s.r()
+	r.Equal(e.Event, a.Event, "Event")
+	r.Equal(e.Time, a.Time, "Time")
+	r.Equal(e.Symbol, a.Symbol, "Symbol")
+	r.Equal(e.LastPrice, a.LastPrice, "LastPrice")
+	r.Equal(e.OpenPrice, a.OpenPrice, "OpenPrice")
+	r.Equal(e.HighPrice, a.HighPrice, "HighPrice")
+	r.Equal(e.LowPrice, a.LowPrice, "LowPrice")
+	r.Equal(e.BaseVolume, a.BaseVolume, "BaseVolume")
+	r.Equal(e.QuoteVolume, a.QuoteVolume, "QuoteVolume")
+}

--- a/websocket_service_test.go
+++ b/websocket_service_test.go
@@ -666,7 +666,6 @@ func (s *websocketServiceTestSuite) assertWsTradeEventEqual(e, a *WsTradeEvent) 
 	r.Equal(e.IsBuyerMaker, a.IsBuyerMaker, "IsBuyerMaker")
 }
 
-
 func (s *websocketServiceTestSuite) TestWsAllMiniMarketsStatServe() {
 	data := []byte(`[{
   		"e": "24hrMiniTicker",
@@ -696,26 +695,26 @@ func (s *websocketServiceTestSuite) TestWsAllMiniMarketsStatServe() {
 	doneC, stopC, err := WsAllMiniMarketsStatServe(func(event WsAllMiniMarketsStatEvent) {
 		e := WsAllMiniMarketsStatEvent{
 			&WsMiniMarketsStatEvent{
-				Event:              "24hrMiniTicker",
-				Time:               1523658017154,
-				Symbol:             "BNBBTC",
-				LastPrice:          "0.00175640",
-				OpenPrice:          "0.00161200",
-				HighPrice:          "0.00176000",
-				LowPrice:           "0.00159370",
-				BaseVolume:         "3479863.89000000",
-				QuoteVolume:        "5725.90587704",
+				Event:       "24hrMiniTicker",
+				Time:        1523658017154,
+				Symbol:      "BNBBTC",
+				LastPrice:   "0.00175640",
+				OpenPrice:   "0.00161200",
+				HighPrice:   "0.00176000",
+				LowPrice:    "0.00159370",
+				BaseVolume:  "3479863.89000000",
+				QuoteVolume: "5725.90587704",
 			},
 			&WsMiniMarketsStatEvent{
-				Event:              "24hrMiniTicker",
-				Time:               1523658017133,
-				Symbol:             "BNBETH",
-				LastPrice:          "0.02827000",
-				OpenPrice:          "0.02628100",
-				HighPrice:          "0.02830300",
-				LowPrice:           "0.02469400",
-				BaseVolume:         "456266.78000000",
-				QuoteVolume:        "11873.11095682",
+				Event:       "24hrMiniTicker",
+				Time:        1523658017133,
+				Symbol:      "BNBETH",
+				LastPrice:   "0.02827000",
+				OpenPrice:   "0.02628100",
+				HighPrice:   "0.02830300",
+				LowPrice:    "0.02469400",
+				BaseVolume:  "456266.78000000",
+				QuoteVolume: "11873.11095682",
 			},
 		}
 		s.assertWsAllMiniMarketsStatEventEqual(e, event)


### PR DESCRIPTION
Lesser known endpoint which Binance hasn't documented.  `/!miniTicker@arr` returns mini version of ticker data.  Library users will be able to take advantage of a reduced payload