### PR TITLE
Added OrderID to TradeV3 to allow trades to be tied to particular orders

### DIFF
--- a/trade_service.go
+++ b/trade_service.go
@@ -123,6 +123,7 @@ type Trade struct {
 // TradeV3 define v3 trade info
 type TradeV3 struct {
 	ID              int64  `json:"id"`
+	OrderID         int64  `json:"orderId"`
 	Price           string `json:"price"`
 	Quantity        string `json:"qty"`
 	Commission      string `json:"commission"`

--- a/trade_service_test.go
+++ b/trade_service_test.go
@@ -18,6 +18,7 @@ func (s *tradeServiceTestSuite) TestListTrades() {
 	data := []byte(`[
         {
             "id": 28457,
+            "orderId": 12345,
             "price": "4.00000100",
             "qty": "12.00000000",
             "commission": "10.10000000",
@@ -50,6 +51,7 @@ func (s *tradeServiceTestSuite) TestListTrades() {
 	r.Len(trades, 1)
 	e := &TradeV3{
 		ID:              28457,
+		OrderID:         12345,
 		Price:           "4.00000100",
 		Quantity:        "12.00000000",
 		Commission:      "10.10000000",
@@ -65,6 +67,7 @@ func (s *tradeServiceTestSuite) TestListTrades() {
 func (s *tradeServiceTestSuite) assertTradeV3Equal(e, a *TradeV3) {
 	r := s.r()
 	r.Equal(e.ID, a.ID, "ID")
+	r.Equal(e.OrderID, a.OrderID, "OrderID")
 	r.Equal(e.Price, a.Price, "Price")
 	r.Equal(e.Quantity, a.Quantity, "Quantity")
 	r.Equal(e.Commission, a.Commission, "Commission")


### PR DESCRIPTION
My program's idea of my current balance was drifting away from Binance's, and it turns out it's because the price returned for the Order is the limit price, not necessarily the actual price that was achieved.

I found this out on the Binance API Telegram channel, where I was told:
> to get the complete info you need to get both orders and trades from the API and map them to one another
> orders can contain one or multiple trades

And:
> Your sell order was executed at a higher price. The API retrieves your limit price.

OK, so I need to take the order and get all the trades associated with it.

But I can't. The REST API returns the orderId for the trade, but there's no matching property in the TradeV3 struct.

Without this, there's no way to match a given trade to a given order (unless I maybe try matching vague timestamps).

So, for this pull request I've added the OrderID property to the TradeV3 struct and updated the test to take this into account. And hopefully I haven't broken anything else!