### PR TITLE
'Create' market orders can specify a fuller response

### DIFF
--- a/client.go
+++ b/client.go
@@ -26,6 +26,9 @@ type OrderType string
 // TimeInForce define time in force type of order
 type TimeInForce string
 
+// NewOrderRespType define response JSON verbosity
+type NewOrderRespType string
+
 // Global enums
 const (
 	SideTypeBuy  SideType = "BUY"
@@ -37,6 +40,10 @@ const (
 	TimeInForceGTC TimeInForce = "GTC"
 	TimeInForceIOC TimeInForce = "IOC"
 	TimeInForceFOK TimeInForce = "FOK"
+
+	NewOrderRespTypeACK    NewOrderRespType = "ACK"
+	NewOrderRespTypeRESULT NewOrderRespType = "RESULT"
+	NewOrderRespTypeFULL   NewOrderRespType = "FULL"
 
 	timestampKey  = "timestamp"
 	signatureKey  = "signature"

--- a/order_service.go
+++ b/order_service.go
@@ -12,6 +12,7 @@ type CreateOrderService struct {
 	side             SideType
 	orderType        OrderType
 	timeInForce      *TimeInForce
+	newOrderRespType *NewOrderRespType
 	quantity         string
 	price            *string
 	newClientOrderID *string
@@ -73,6 +74,12 @@ func (s *CreateOrderService) IcebergQuantity(icebergQuantity string) *CreateOrde
 	return s
 }
 
+// NewOrderRespType set icebergQuantity
+func (s *CreateOrderService) NewOrderRespType(newOrderRespType NewOrderRespType) *CreateOrderService {
+	s.newOrderRespType = &newOrderRespType
+	return s
+}
+
 func (s *CreateOrderService) createOrder(ctx context.Context, endpoint string, opts ...RequestOption) (data []byte, err error) {
 	r := &request{
 		method:   "POST",
@@ -99,6 +106,9 @@ func (s *CreateOrderService) createOrder(ctx context.Context, endpoint string, o
 	}
 	if s.icebergQuantity != nil {
 		m["icebergQty"] = *s.icebergQuantity
+	}
+	if s.newOrderRespType != nil {
+		m["newOrderRespType"] = *s.newOrderRespType
 	}
 	r.setFormParams(m)
 	data, err = s.c.callAPI(ctx, r, opts...)
@@ -130,17 +140,26 @@ func (s *CreateOrderService) Test(ctx context.Context, opts ...RequestOption) (e
 
 // CreateOrderResponse define create order response
 type CreateOrderResponse struct {
-	Symbol           string `json:"symbol"`
-	OrderID          int64  `json:"orderId"`
-	ClientOrderID    string `json:"clientOrderId"`
-	TransactTime     int64  `json:"transactTime"`
-	Price            string `json:"price"`
-	OrigQuantity     string `json:"origQty"`
-	ExecutedQuantity string `json:"executedQty"`
-	Status           string `json:"status"`
-	TimeInForce      string `json:"timeInForce"`
-	Type             string `json:"type"`
-	Side             string `json:"side"`
+	Symbol           string  `json:"symbol"`
+	OrderID          int64   `json:"orderId"`
+	ClientOrderID    string  `json:"clientOrderId"`
+	TransactTime     int64   `json:"transactTime"`
+	Price            string  `json:"price"`
+	OrigQuantity     string  `json:"origQty"`
+	ExecutedQuantity string  `json:"executedQty"`
+	Status           string  `json:"status"`
+	TimeInForce      string  `json:"timeInForce"`
+	Type             string  `json:"type"`
+	Side             string  `json:"side"`
+	Fills            []*Fill `json:"fills"`
+}
+
+// Fill may be returned in an array of fills in a CreateOrderResponse.
+type Fill struct {
+	Price           string `json:"price"`
+	Quantity        string `json:"qty"`
+	Commission      string `json:"commission"`
+	CommissionAsset string `json:"commissionAsset"`
 }
 
 // ListOpenOrdersService list opened orders

--- a/order_service_test.go
+++ b/order_service_test.go
@@ -74,6 +74,83 @@ func (s *orderServiceTestSuite) TestCreateOrder() {
 	s.r().NoError(err)
 }
 
+func (s *orderServiceTestSuite) TestCreateOrderFull() {
+	data := []byte(`{
+		"symbol": "LTCBTC",
+		"orderId": 1,
+		"clientOrderId": "myOrder1",
+		"transactTime": 1499827319559,
+		"price": "0.0001",
+		"origQty": "12.00",
+		"executedQty": "10.00",
+		"status": "FILLED",
+		"timeInForce": "GTC",
+		"type": "LIMIT",
+		"side": "BUY",
+		"fills": [
+			{
+				"price":"0.00002991",
+				"qty":"344.00000000",
+				"commission":"0.00332384",
+				"commissionAsset":"BNB",
+				"tradeId":1566397
+			}
+		]
+	}`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+	symbol := "LTCBTC"
+	side := SideTypeBuy
+	orderType := OrderTypeLimit
+	timeInForce := TimeInForceGTC
+	quantity := "12.00"
+	price := "0.0001"
+	newClientOrderID := "myOrder1"
+	s.assertReq(func(r *request) {
+		e := newSignedRequest().setFormParams(params{
+			"symbol":           symbol,
+			"side":             side,
+			"type":             orderType,
+			"timeInForce":      timeInForce,
+			"quantity":         quantity,
+			"price":            price,
+			"newClientOrderId": newClientOrderID,
+		})
+		s.assertRequestEqual(e, r)
+	})
+	res, err := s.client.NewCreateOrderService().Symbol(symbol).Side(side).
+		Type(orderType).TimeInForce(timeInForce).Quantity(quantity).
+		Price(price).NewClientOrderID(newClientOrderID).Do(newContext())
+	s.r().NoError(err)
+	e := &CreateOrderResponse{
+		Symbol:           "LTCBTC",
+		OrderID:          1,
+		ClientOrderID:    "myOrder1",
+		TransactTime:     1499827319559,
+		Price:            "0.0001",
+		OrigQuantity:     "12.00",
+		ExecutedQuantity: "10.00",
+		Status:           "FILLED",
+		TimeInForce:      "GTC",
+		Type:             "LIMIT",
+		Side:             "BUY",
+		Fills: []*Fill{
+			&Fill{
+				Price:           "0.00002991",
+				Quantity:        "344.00000000",
+				Commission:      "0.00332384",
+				CommissionAsset: "BNB",
+			},
+		},
+	}
+	s.assertCreateOrderResponseEqual(e, res)
+
+	err = s.client.NewCreateOrderService().Symbol(symbol).Side(side).
+		Type(orderType).TimeInForce(timeInForce).Quantity(quantity).
+		Price(price).NewClientOrderID(newClientOrderID).Test(newContext())
+	s.r().NoError(err)
+}
+
 func (s *orderServiceTestSuite) assertCreateOrderResponseEqual(e, a *CreateOrderResponse) {
 	r := s.r()
 	r.Equal(e.Symbol, a.Symbol, "Symbol")
@@ -87,6 +164,18 @@ func (s *orderServiceTestSuite) assertCreateOrderResponseEqual(e, a *CreateOrder
 	r.Equal(e.TimeInForce, a.TimeInForce, "TimeInForce")
 	r.Equal(e.Type, a.Type, "Type")
 	r.Equal(e.Side, a.Side, "Side")
+
+	for idx, fill := range e.Fills {
+		s.assertFillEqual(fill, a.Fills[idx])
+	}
+}
+
+func (s *orderServiceTestSuite) assertFillEqual(e, a *Fill) {
+	r := s.r()
+	r.Equal(e.Commission, a.Commission, "Commission")
+	r.Equal(e.CommissionAsset, a.CommissionAsset, "CommissionAsset")
+	r.Equal(e.Price, a.Price, "Price")
+	r.Equal(e.Quantity, a.Quantity, "Quantity")
 }
 
 func (s *orderServiceTestSuite) TestListOpenOrders() {

--- a/order_service_test.go
+++ b/order_service_test.go
@@ -106,6 +106,7 @@ func (s *orderServiceTestSuite) TestCreateOrderFull() {
 	quantity := "12.00"
 	price := "0.0001"
 	newClientOrderID := "myOrder1"
+	newOrderRespType := NewOrderRespTypeFULL
 	s.assertReq(func(r *request) {
 		e := newSignedRequest().setFormParams(params{
 			"symbol":           symbol,
@@ -115,12 +116,14 @@ func (s *orderServiceTestSuite) TestCreateOrderFull() {
 			"quantity":         quantity,
 			"price":            price,
 			"newClientOrderId": newClientOrderID,
+			"newOrderRespType": newOrderRespType,
 		})
 		s.assertRequestEqual(e, r)
 	})
 	res, err := s.client.NewCreateOrderService().Symbol(symbol).Side(side).
 		Type(orderType).TimeInForce(timeInForce).Quantity(quantity).
-		Price(price).NewClientOrderID(newClientOrderID).Do(newContext())
+		Price(price).NewClientOrderID(newClientOrderID).
+		NewOrderRespType(newOrderRespType).Do(newContext())
 	s.r().NoError(err)
 	e := &CreateOrderResponse{
 		Symbol:           "LTCBTC",
@@ -147,7 +150,8 @@ func (s *orderServiceTestSuite) TestCreateOrderFull() {
 
 	err = s.client.NewCreateOrderService().Symbol(symbol).Side(side).
 		Type(orderType).TimeInForce(timeInForce).Quantity(quantity).
-		Price(price).NewClientOrderID(newClientOrderID).Test(newContext())
+		Price(price).NewClientOrderID(newClientOrderID).
+		NewOrderRespType(newOrderRespType).Test(newContext())
 	s.r().NoError(err)
 }
 
@@ -165,6 +169,7 @@ func (s *orderServiceTestSuite) assertCreateOrderResponseEqual(e, a *CreateOrder
 	r.Equal(e.Type, a.Type, "Type")
 	r.Equal(e.Side, a.Side, "Side")
 
+	r.Len(a.Fills, len(e.Fills))
 	for idx, fill := range e.Fills {
 		s.assertFillEqual(fill, a.Fills[idx])
 	}


### PR DESCRIPTION
Hi,

New market orders to /api/v3/order can specify a newOrderRespType parameter, which - if set to FULL - returns some details of the trades created to fill the order.

(This means if I do a market order, I can get all the necessary trade details in the one request instead of having to loop and poll for updates to trades. I'm not convinced market orders are the way I want to trade but I did want to try it out.)

So I updated the CreateOrderService and CreateOrderResponse to handle the newOrderRespType.

I got stuck not knowing which way you wanted to approach testing of it though, so I just copied the existing TestCreateOrder test to TestCreateOrderFull and added fill data and checks to it.