### PR TITLE
Fix unmarshalling issue with NewExchangeInfoService()

### DIFF
--- a/exchange_info_service.go
+++ b/exchange_info_service.go
@@ -37,13 +37,13 @@ type ExchangeInfo struct {
 
 // Symbol market symbol
 type Symbol struct {
-	Symbol             string              `json:"symbol"`
-	Status             string              `json:"status"`
-	BaseAsset          string              `json:"baseAsset"`
-	BaseAssetPrecision int                 `json:"baseAssetPrecision"`
-	QuoteAsset         string              `json:"quoteAsset"`
-	QuotePrecision     int                 `json:"quotePrecision"`
-	OrderTypes         []string            `json:"orderTypes"`
-	IcebergAllowed     bool                `json:"icebergAllowed"`
-	Filters            []map[string]string `json:"filters"`
+	Symbol             string                   `json:"symbol"`
+	Status             string                   `json:"status"`
+	BaseAsset          string                   `json:"baseAsset"`
+	BaseAssetPrecision int                      `json:"baseAssetPrecision"`
+	QuoteAsset         string                   `json:"quoteAsset"`
+	QuotePrecision     int                      `json:"quotePrecision"`
+	OrderTypes         []string                 `json:"orderTypes"`
+	IcebergAllowed     bool                     `json:"icebergAllowed"`
+	Filters            []map[string]interface{} `json:"filters"`
 }

--- a/exchange_info_service_test.go
+++ b/exchange_info_service_test.go
@@ -49,7 +49,7 @@ func (s *exchangeInfoServiceTestSuite) TestExchangeInfo() {
 				QuotePrecision:     8,
 				OrderTypes:         []string{"LIMIT", "LIMIT_MAKER", "MARKET", "STOP_LOSS_LIMIT", "TAKE_PROFIT_LIMIT"},
 				IcebergAllowed:     true,
-				Filters: []map[string]string{
+				Filters: []map[string]interface{}{
 					{"filterType": "PRICE_FILTER", "minPrice": "0.00000100", "maxPrice": "100000.00000000", "tickSize": "0.00000100"},
 					{"filterType": "LOT_SIZE", "minQty": "0.00100000", "maxQty": "100000.00000000", "stepSize": "0.00100000"},
 					{"filterType": "MIN_NOTIONAL", "minNotional": "0.00100000"},


### PR DESCRIPTION
When calling NewExchangeInfoService(), this error is returned:

`API error: json: cannot unmarshal number into Go value of type string`

 Thus, the json data is handled incorrectly. 

I've corrected the `Symbol` structure below with the correct `Filters` slice.
