### PR TITLE
Do not require symbol

### DIFF
--- a/order_service.go
+++ b/order_service.go
@@ -181,7 +181,9 @@ func (s *ListOpenOrdersService) Do(ctx context.Context, opts ...RequestOption) (
 		endpoint: "/api/v3/openOrders",
 		secType:  secTypeSigned,
 	}
-	r.setParam("symbol", s.symbol)
+	if s.symbol != "" {
+		r.setParam("symbol", s.symbol)
+	}
 	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return []*Order{}, err


### PR DESCRIPTION
It has to be possible to load the open orders without any symbol.
[docs](https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#current-open-orders-user_data)