### PR TITLE
Dont use goroutine for every ws frame

### DIFF
--- a/websocket.go
+++ b/websocket.go
@@ -1,8 +1,9 @@
 package binance
 
 import (
-	"github.com/gorilla/websocket"
 	"time"
+
+	"github.com/gorilla/websocket"
 )
 
 // WsHandler handle raw websocket message
@@ -47,10 +48,10 @@ var wsServe = func(cfg *wsConfig, handler WsHandler, errHandler ErrHandler) (don
 			default:
 				_, message, err := c.ReadMessage()
 				if err != nil {
-					go errHandler(err)
+					errHandler(err)
 					return
 				}
-				go handler(message)
+				handler(message)
 			}
 		}
 	}()


### PR DESCRIPTION
Hi,

I looks a bit unnecessary to spawn a new goroutine for every websocket message (price update). If there was a specific reason please let me know. 

Thanks for the lib!