### PR TITLE
get all margin pairs

### DIFF
--- a/client.go
+++ b/client.go
@@ -453,6 +453,11 @@ func (c *Client) NewGetMarginPairService() *GetMarginPairService {
 	return &GetMarginPairService{c: c}
 }
 
+// NewGetMarginAllPairsService init get margin all pairs service
+func (c *Client) NewGetMarginAllPairsService() *GetMarginAllPairsService {
+	return &GetMarginAllPairsService{c: c}
+}
+
 // NewGetMarginPriceIndexService init get margin price index service
 func (c *Client) NewGetMarginPriceIndexService() *GetMarginPriceIndexService {
 	return &GetMarginPriceIndexService{c: c}

--- a/margin_service.go
+++ b/margin_service.go
@@ -471,6 +471,41 @@ type MarginPair struct {
 	IsSellAllowed bool   `json:"isSellAllowed"`
 }
 
+// GetMarginAllPairsService get margin pair info
+type GetMarginAllPairsService struct {
+	c *Client
+}
+
+// Do send request
+func (s *GetMarginAllPairsService) Do(ctx context.Context, opts ...RequestOption) (res []*MarginAllPair, err error) {
+	r := &request{
+		method:   "GET",
+		endpoint: "/sapi/v1/margin/allPairs",
+		secType:  secTypeAPIKey,
+	}
+	data, err := s.c.callAPI(ctx, r, opts...)
+	if err != nil {
+		return []*MarginAllPair{}, err
+	}
+	res = make([]*MarginAllPair, 0)
+	err = json.Unmarshal(data, &res)
+	if err != nil {
+		return []*MarginAllPair{}, err
+	}
+	return res, nil
+}
+
+// MarginAllPair define margin pair info
+type MarginAllPair struct {
+	ID            int64  `json:"id"`
+	Symbol        string `json:"symbol"`
+	Base          string `json:"base"`
+	Quote         string `json:"quote"`
+	IsMarginTrade bool   `json:"isMarginTrade"`
+	IsBuyAllowed  bool   `json:"isBuyAllowed"`
+	IsSellAllowed bool   `json:"isSellAllowed"`
+}
+
 // GetMarginPriceIndexService get margin price index
 type GetMarginPriceIndexService struct {
 	c      *Client

--- a/margin_service_test.go
+++ b/margin_service_test.go
@@ -439,6 +439,71 @@ func (s *marginTestSuite) assertMarginPairEqual(e, a *MarginPair) {
 	r.Equal(e.IsSellAllowed, a.IsSellAllowed, "IsSellAllowed")
 }
 
+func (s *marginTestSuite) TestGetMarginAllPairs() {
+	data := []byte(`[{
+		"id":323355778339572400,
+		"symbol":"BTCUSDT",
+		"base":"BTC",
+		"quote":"USDT",
+		"isMarginTrade":true,
+		"isBuyAllowed":true,
+		"isSellAllowed":true
+	},{
+		"id":351637150141315861,
+		"symbol":"BNBBTC",
+		"base":"BNB",
+		"quote":"BTC",
+		"isMarginTrade":true,
+		"isBuyAllowed":true,
+		"isSellAllowed":true
+	}]`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	s.assertReq(func(r *request) {
+		e := newRequest()
+		s.assertRequestEqual(e, r)
+	})
+	res, err := s.client.NewGetMarginAllPairsService().
+		Do(newContext())
+	r := s.r()
+	r.NoError(err)
+	r.Len(res, 2)
+	e := []*MarginAllPair{
+		{
+			ID:            323355778339572400,
+			Symbol:        "BTCUSDT",
+			Base:          "BTC",
+			Quote:         "USDT",
+			IsMarginTrade: true,
+			IsBuyAllowed:  true,
+			IsSellAllowed: true,
+		}, {
+			ID:            351637150141315861,
+			Symbol:        "BNBBTC",
+			Base:          "BNB",
+			Quote:         "BTC",
+			IsMarginTrade: true,
+			IsBuyAllowed:  true,
+			IsSellAllowed: true,
+		},
+	}
+	for i := 0; i < len(res); i++ {
+		s.assertMarginAllPairsEqual(e[i], res[i])
+	}
+}
+
+func (s *marginTestSuite) assertMarginAllPairsEqual(e, a *MarginAllPair) {
+	r := s.r()
+	r.Equal(e.ID, a.ID, "ID")
+	r.Equal(e.Symbol, a.Symbol, "Symbol")
+	r.Equal(e.Base, a.Base, "Base")
+	r.Equal(e.Quote, a.Quote, "Quote")
+	r.Equal(e.IsMarginTrade, a.IsMarginTrade, "IsMarginTrade")
+	r.Equal(e.IsBuyAllowed, a.IsBuyAllowed, "IsBuyAllowed")
+	r.Equal(e.IsSellAllowed, a.IsSellAllowed, "IsSellAllowed")
+}
+
 func (s *marginTestSuite) TestGetMarginPriceIndex() {
 	data := []byte(`{
 		"calcTime": 1562046418000,


### PR DESCRIPTION
Missed API function

Get all margin pairs (MARKET_DATA)
Get /sapi/v1/margin/allPairs 