### PR TITLE
Position margin history

### DIFF
--- a/futures/client.go
+++ b/futures/client.go
@@ -348,6 +348,11 @@ func (c *Client) NewGetPositionRiskService() *GetPositionRiskService {
 	return &GetPositionRiskService{c: c}
 }
 
+// NewGetPositionMarginHistoryService init getting position margin history service
+func (c *Client) NewGetPositionMarginHistoryService() *GetPositionMarginHistoryService {
+	return &GetPositionMarginHistoryService{c: c}
+}
+
 // NewHistoricalTradesService init listing trades service
 func (c *Client) NewHistoricalTradesService() *HistoricalTradesService {
 	return &HistoricalTradesService{c: c}

--- a/futures/position_margin_history.go
+++ b/futures/position_margin_history.go
@@ -1,0 +1,88 @@
+package futures
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// GetPositionMarginHistoryService get position margin history service
+type GetPositionMarginHistoryService struct {
+	c         *Client
+	symbol    string
+	_type     *int
+	startTime *int64
+	endTime   *int64
+	limit     *int64
+}
+
+// Symbol set symbol
+func (s *GetPositionMarginHistoryService) Symbol(symbol string) *GetPositionMarginHistoryService {
+	s.symbol = symbol
+	return s
+}
+
+// Type set type
+func (s *GetPositionMarginHistoryService) Type(_type int) *GetPositionMarginHistoryService {
+	s._type = &_type
+	return s
+}
+
+// StartTime set startTime
+func (s *GetPositionMarginHistoryService) StartTime(startTime int64) *GetPositionMarginHistoryService {
+	s.startTime = &startTime
+	return s
+}
+
+// EndTime set endTime
+func (s *GetPositionMarginHistoryService) EndTime(endTime int64) *GetPositionMarginHistoryService {
+	s.endTime = &endTime
+	return s
+}
+
+// Limit set limit
+func (s *GetPositionMarginHistoryService) Limit(limit int64) *GetPositionMarginHistoryService {
+	s.limit = &limit
+	return s
+}
+
+// Do send request
+func (s *GetPositionMarginHistoryService) Do(ctx context.Context, opts ...RequestOption) (res []*PositionMarginHistory, err error) {
+	r := &request{
+		method:   "GET",
+		endpoint: "/fapi/v1/positionMargin/history",
+		secType:  secTypeSigned,
+	}
+	r.setParam("symbol", s.symbol)
+	if s._type != nil {
+		r.setParam("type", *s._type)
+	}
+	if s.startTime != nil {
+		r.setParam("startTime", *s.startTime)
+	}
+	if s.endTime != nil {
+		r.setParam("endTime", *s.endTime)
+	}
+	if s.limit != nil {
+		r.setParam("limit", *s.limit)
+	}
+
+	data, err := s.c.callAPI(ctx, r, opts...)
+	if err != nil {
+		return nil, err
+	}
+	res = make([]*PositionMarginHistory, 0)
+	err = json.Unmarshal(data, &res)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+// PositionMarginHistory define position margin history info
+type PositionMarginHistory struct {
+	Amount string `json:"amount"`
+	Asset  string `json:"asset"`
+	Symbol string `json:"symbol"`
+	Time   int64  `json:"time"`
+	Type   int    `json:"type"`
+}

--- a/futures/position_margin_history_test.go
+++ b/futures/position_margin_history_test.go
@@ -1,0 +1,65 @@
+package futures
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type basePositionMarginHistoryTestSuite struct {
+	baseTestSuite
+}
+
+func TestPositionMarginHistoryTestService(t *testing.T) {
+	suite.Run(t, new(positionMarginHistoryServiceTestSuite))
+}
+
+type positionMarginHistoryServiceTestSuite struct {
+	basePositionMarginHistoryTestSuite
+}
+
+func (s *positionMarginHistoryServiceTestSuite) TestPositionMarginHistory() {
+	data := []byte(`[
+		{
+			"amount": "23.36332311",
+			"asset": "USDT",
+			"symbol": "BTCUSDT",
+			"time": 1578047897183,
+			"type": 1
+		}
+	]`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	symbol := "BTCUSDT"
+	recvWindow := int64(1000)
+	s.assertReq(func(r *request) {
+		e := newSignedRequest().setParams(params{
+			"symbol":     symbol,
+			"recvWindow": recvWindow,
+		})
+		s.assertRequestEqual(e, r)
+	})
+	orders, err := s.client.NewGetPositionMarginHistoryService().Symbol(symbol).
+		Do(newContext(), WithRecvWindow(recvWindow))
+	r := s.r()
+	r.NoError(err)
+	r.Len(orders, 1)
+	e := &PositionMarginHistory{
+		Amount: "23.36332311",
+		Asset:  "USDT",
+		Symbol: "BTCUSDT",
+		Time:   1578047897183,
+		Type:   1,
+	}
+	s.assertOrderEqual(e, orders[0])
+}
+
+func (s *positionMarginHistoryServiceTestSuite) assertOrderEqual(e, a *PositionMarginHistory) {
+	r := s.r()
+	r.Equal(e.Amount, a.Amount, "Amount")
+	r.Equal(e.Asset, a.Asset, "Asset")
+	r.Equal(e.Symbol, a.Symbol, "Symbol")
+	r.Equal(e.Time, e.Time, "Time")
+	r.Equal(e.Type, a.Type, "Type")
+}


### PR DESCRIPTION
Implementing "Get Postion Margin Change History"

I must say that there is currently a bug in the Binance API itself (which I've reported but feel free to report too). The request will fail if the API key has "read only" permission, even though it's a GET request. The permission "Enable Future" must be enabled too...