### PR TITLE
Future/dualmode

### DIFF
--- a/futures/client.go
+++ b/futures/client.go
@@ -130,7 +130,7 @@ func NewClient(apiKey, secretKey string) *Client {
 	return &Client{
 		APIKey:     apiKey,
 		SecretKey:  secretKey,
-		BaseURL:    "https://fapi.binance.com",
+		BaseURL:    "https://testnet.binancefuture.com",
 		UserAgent:  "Binance/golang",
 		HTTPClient: http.DefaultClient,
 		Logger:     log.New(os.Stderr, "Binance-golang ", log.LstdFlags),
@@ -423,4 +423,9 @@ func (c *Client) NewChangeMarginTypeService() *ChangeMarginTypeService {
 // NewUpdatePositionMarginService init update position margin
 func (c *Client) NewUpdatePositionMarginService() *UpdatePositionMarginService {
 	return &UpdatePositionMarginService{c: c}
+}
+
+// ChangePositionModeService init change position mode service
+func (c *Client) NewChangePositionModeService() *ChangePositionModeService {
+	return &ChangePositionModeService{c: c}
 }

--- a/futures/client.go
+++ b/futures/client.go
@@ -21,6 +21,9 @@ import (
 // SideType define side type of order
 type SideType string
 
+// PositionSideType define position side type of order
+type PositionSideType string
+
 // OrderType define order type
 type OrderType string
 
@@ -55,6 +58,10 @@ type MarginType string
 const (
 	SideTypeBuy  SideType = "BUY"
 	SideTypeSell SideType = "SELL"
+
+	PositionSideBoth  PositionSideType = "BOTH"
+	PositionSideLong  PositionSideType = "LONG"
+	PositionSideShort PositionSideType = "SHORT"
 
 	OrderTypeLimit              OrderType = "LIMIT"
 	OrderTypeMarket             OrderType = "MARKET"
@@ -130,7 +137,7 @@ func NewClient(apiKey, secretKey string) *Client {
 	return &Client{
 		APIKey:     apiKey,
 		SecretKey:  secretKey,
-		BaseURL:    "https://testnet.binancefuture.com",
+		BaseURL:    "https://fapi.binance.com",
 		UserAgent:  "Binance/golang",
 		HTTPClient: http.DefaultClient,
 		Logger:     log.New(os.Stderr, "Binance-golang ", log.LstdFlags),
@@ -428,4 +435,9 @@ func (c *Client) NewUpdatePositionMarginService() *UpdatePositionMarginService {
 // ChangePositionModeService init change position mode service
 func (c *Client) NewChangePositionModeService() *ChangePositionModeService {
 	return &ChangePositionModeService{c: c}
+}
+
+// GetPositionModeService init get position mode service
+func (c *Client) NewGetPositionModeService() *GetPositionModeService {
+	return &GetPositionModeService{c: c}
 }

--- a/futures/order_service.go
+++ b/futures/order_service.go
@@ -10,6 +10,7 @@ type CreateOrderService struct {
 	c                *Client
 	symbol           string
 	side             SideType
+	positionSide     *PositionSideType
 	orderType        OrderType
 	timeInForce      *TimeInForceType
 	quantity         string
@@ -31,6 +32,12 @@ func (s *CreateOrderService) Symbol(symbol string) *CreateOrderService {
 // Side set side
 func (s *CreateOrderService) Side(side SideType) *CreateOrderService {
 	s.side = side
+	return s
+}
+
+// Side set side
+func (s *CreateOrderService) PositionSide(positionSide PositionSideType) *CreateOrderService {
+	s.positionSide = &positionSide
 	return s
 }
 
@@ -105,6 +112,9 @@ func (s *CreateOrderService) createOrder(ctx context.Context, endpoint string, o
 		"side":     s.side,
 		"type":     s.orderType,
 		"quantity": s.quantity,
+	}
+	if s.positionSide != nil {
+		m["positionSide"] = *s.positionSide
 	}
 	if s.timeInForce != nil {
 		m["timeInForce"] = *s.timeInForce

--- a/futures/position_service.go
+++ b/futures/position_service.go
@@ -135,3 +135,36 @@ func (s *UpdatePositionMarginService) Do(ctx context.Context, opts ...RequestOpt
 	}
 	return nil
 }
+
+// ChangePositionModeService change user's position mode
+type ChangePositionModeService struct {
+	c        *Client
+	dualSide string
+}
+
+// Change user's position mode: true - Hedge Mode, false - One-way Mode
+func (s *ChangePositionModeService) DualSide(dualSide bool) *ChangePositionModeService {
+	if dualSide {
+		s.dualSide = "true"
+	} else {
+		s.dualSide = "false"
+	}
+	return s
+}
+
+// Do send request
+func (s *ChangePositionModeService) Do(ctx context.Context, opts ...RequestOption) (err error) {
+	r := &request{
+		method:   "POST",
+		endpoint: " /fapi/v1/positionSide/dual",
+		secType:  secTypeSigned,
+	}
+	r.setFormParams(params{
+		"dualSidePosition": s.dualSide,
+	})
+	_, err = s.c.callAPI(ctx, r, opts...)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/futures/position_service.go
+++ b/futures/position_service.go
@@ -93,15 +93,22 @@ func (s *ChangeMarginTypeService) Do(ctx context.Context, opts ...RequestOption)
 
 // UpdatePositionMarginService update isolated position margin
 type UpdatePositionMarginService struct {
-	c          *Client
-	symbol     string
-	amount     string
-	actionType int
+	c            *Client
+	symbol       string
+	positionSide *PositionSideType
+	amount       string
+	actionType   int
 }
 
 // Symbol set symbol
 func (s *UpdatePositionMarginService) Symbol(symbol string) *UpdatePositionMarginService {
 	s.symbol = symbol
+	return s
+}
+
+// Side set side
+func (s *UpdatePositionMarginService) PositionSide(positionSide PositionSideType) *UpdatePositionMarginService {
+	s.positionSide = &positionSide
 	return s
 }
 
@@ -124,11 +131,16 @@ func (s *UpdatePositionMarginService) Do(ctx context.Context, opts ...RequestOpt
 		endpoint: "/fapi/v1/positionMargin",
 		secType:  secTypeSigned,
 	}
-	r.setFormParams(params{
+	m := params{
 		"symbol": s.symbol,
 		"amount": s.amount,
 		"type":   s.actionType,
-	})
+	}
+	if s.positionSide != nil {
+		m["positionSide"] = *s.positionSide
+	}
+	r.setFormParams(m)
+
 	_, err = s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return err
@@ -156,7 +168,7 @@ func (s *ChangePositionModeService) DualSide(dualSide bool) *ChangePositionModeS
 func (s *ChangePositionModeService) Do(ctx context.Context, opts ...RequestOption) (err error) {
 	r := &request{
 		method:   "POST",
-		endpoint: " /fapi/v1/positionSide/dual",
+		endpoint: "/fapi/v1/positionSide/dual",
 		secType:  secTypeSigned,
 	}
 	r.setFormParams(params{
@@ -167,4 +179,34 @@ func (s *ChangePositionModeService) Do(ctx context.Context, opts ...RequestOptio
 		return err
 	}
 	return nil
+}
+
+// GetPositionModeService get user's position mode
+type GetPositionModeService struct {
+	c *Client
+}
+
+// Response of user's position mode
+type PositionMode struct {
+	DualSidePosition bool `json:"dualSidePosition"`
+}
+
+// Do send request
+func (s *GetPositionModeService) Do(ctx context.Context, opts ...RequestOption) (res *PositionMode, err error) {
+	r := &request{
+		method:   "GET",
+		endpoint: "/fapi/v1/positionSide/dual",
+		secType:  secTypeSigned,
+	}
+	r.setFormParams(params{})
+	data, err := s.c.callAPI(ctx, r, opts...)
+	if err != nil {
+		return nil, err
+	}
+	res = &PositionMode{}
+	err = json.Unmarshal(data, &res)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
 }

--- a/futures/position_service_test.go
+++ b/futures/position_service_test.go
@@ -73,17 +73,52 @@ func (s *positionServiceTestSuite) TestUpdatePositionMargin() {
 	s.mockDo(data, nil)
 	defer s.assertDo()
 	symbol := "BTCUSDT"
+	positionSide := PositionSideLong
+
 	amount := "100.0"
 	actionType := 1
 	s.assertReq(func(r *request) {
 		e := newSignedRequest().setFormParams(params{
-			"symbol": symbol,
-			"amount": amount,
-			"type":   actionType,
+			"symbol":       symbol,
+			"positionSide": positionSide,
+			"amount":       amount,
+			"type":         actionType,
 		})
 		s.assertRequestEqual(e, r)
 	})
 	err := s.client.NewUpdatePositionMarginService().Symbol(symbol).
-		Amount(amount).Type(actionType).Do(newContext())
+		PositionSide(positionSide).Amount(amount).Type(actionType).Do(newContext())
 	s.r().NoError(err)
+}
+
+func (s *positionServiceTestSuite) TestChangePositionMode() {
+	data := []byte(`{
+		"code": 200,
+		"msg": "success"
+	}`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+	s.assertReq(func(r *request) {
+		e := newSignedRequest().setFormParams(params{
+			"dualSidePosition": "true",
+		})
+		s.assertRequestEqual(e, r)
+	})
+	err := s.client.NewChangePositionModeService().DualSide(true).Do(newContext())
+	s.r().NoError(err)
+}
+
+func (s *positionServiceTestSuite) TestGetPositionMode() {
+	data := []byte(`{
+		"dualSidePosition": true
+	}`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+	s.assertReq(func(r *request) {
+		e := newSignedRequest().setFormParams(params{})
+		s.assertRequestEqual(e, r)
+	})
+	res, err := s.client.NewGetPositionModeService().Do(newContext())
+	s.r().NoError(err)
+	s.r().Equal(res.DualSidePosition, true)
 }


### PR DESCRIPTION
 1.New endpoint GET /fapi/v1/positionSide/dual to get current position mode.
 2.New endpoint POST /fapi/v1/positionSide/dual to change position mode: Hedge Mode or One-way Mode.
3.New parameter positionSide in the following endpoints：
      POST /fapi/v1/order
      POST /fapi/v1/positionMargin

