### PR TITLE
Update Deposits and Withdraws endpoints

### DIFF
--- a/client.go
+++ b/client.go
@@ -136,7 +136,12 @@ const (
 )
 
 func currentTimestamp() int64 {
-	return int64(time.Nanosecond) * time.Now().UnixNano() / int64(time.Millisecond)
+	return FormatTimestamp(time.Now())
+}
+
+// FormatTimestamp formats a time into Unix timestamp in milliseconds, as requested by Binance.
+func FormatTimestamp(t time.Time) int64 {
+	return t.UnixNano() / int64(time.Millisecond)
 }
 
 func newJSON(data []byte) (j *simplejson.Json, err error) {

--- a/client_test.go
+++ b/client_test.go
@@ -6,7 +6,10 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -157,4 +160,9 @@ func (s *baseTestSuite) assertTradeV3Equal(e, a *TradeV3) {
 	r.Equal(e.IsBuyer, a.IsBuyer, "IsBuyer")
 	r.Equal(e.IsMaker, a.IsMaker, "IsMaker")
 	r.Equal(e.IsBestMatch, a.IsBestMatch, "IsBestMatch")
+}
+
+func TestFormatTimestamp(t *testing.T) {
+	tm, _ := time.Parse("2006-01-02 15:04:05", "2018-06-01 01:01:01")
+	assert.Equal(t, int64(1527814861000), FormatTimestamp(tm))
 }

--- a/deposit_service.go
+++ b/deposit_service.go
@@ -14,53 +14,53 @@ type ListDepositsService struct {
 	endTime   *int64
 }
 
-// Asset set asset
+// Asset sets the asset parameter.
 func (s *ListDepositsService) Asset(asset string) *ListDepositsService {
 	s.asset = &asset
 	return s
 }
 
-// Status set status
+// Status sets the status parameter.
 func (s *ListDepositsService) Status(status int) *ListDepositsService {
 	s.status = &status
 	return s
 }
 
-// StartTime set startTime
+// StartTime sets the startTime parameter.
+// If present, EndTime MUST be specified. The difference between EndTime - StartTime MUST be between 0-90 days.
 func (s *ListDepositsService) StartTime(startTime int64) *ListDepositsService {
 	s.startTime = &startTime
 	return s
 }
 
-// EndTime set endTime
+// EndTime sets the endTime parameter.
+// If present, StartTime MUST be specified. The difference between EndTime - StartTime MUST be between 0-90 days.
 func (s *ListDepositsService) EndTime(endTime int64) *ListDepositsService {
 	s.endTime = &endTime
 	return s
 }
 
-// Do send request
-func (s *ListDepositsService) Do(ctx context.Context, opts ...RequestOption) (deposits []*Deposit, err error) {
+// Do sends the request.
+func (s *ListDepositsService) Do(ctx context.Context) (deposits []*Deposit, err error) {
 	r := &request{
-		method:   "POST",
-		endpoint: "/wapi/v1/getDepositHistory.html",
+		method:   "GET",
+		endpoint: "/wapi/v3/depositHistory.html",
 		secType:  secTypeSigned,
 	}
-	m := params{}
 	if s.asset != nil {
-		m["asset"] = *s.asset
+		r.setParam("asset", *s.asset)
 	}
 	if s.status != nil {
-		m["status"] = *s.status
+		r.setParam("status", *s.status)
 	}
 	if s.startTime != nil {
-		m["startTime"] = *s.startTime
+		r.setParam("startTime", *s.startTime)
 	}
 	if s.endTime != nil {
-		m["endTime"] = *s.endTime
+		r.setParam("endTime", *s.endTime)
 	}
-	r.setParams(m)
 
-	data, err := s.c.callAPI(ctx, r, opts...)
+	data, err := s.c.callAPI(ctx, r)
 	if err != nil {
 		return
 	}
@@ -72,17 +72,19 @@ func (s *ListDepositsService) Do(ctx context.Context, opts ...RequestOption) (de
 	return res.Deposits, nil
 }
 
-// DepositHistoryResponse define deposit history
+// DepositHistoryResponse represents a response from ListDepositsService.
 type DepositHistoryResponse struct {
 	Success  bool       `json:"success"`
 	Deposits []*Deposit `json:"depositList"`
 }
 
-// Deposit define deposit info
+// Deposit represents a single deposit entry.
 type Deposit struct {
 	InsertTime int64   `json:"insertTime"`
 	Amount     float64 `json:"amount"`
 	Asset      string  `json:"asset"`
-	Status     int     `json:"status"`
+	Address    string  `json:"address"`
+	AddressTag string  `json:"addressTag"`
 	TxID       string  `json:"txId"`
+	Status     int     `json:"status"`
 }

--- a/deposit_service_test.go
+++ b/deposit_service_test.go
@@ -16,18 +16,29 @@ func TestDepositService(t *testing.T) {
 
 func (s *depositServiceTestSuite) TestListDeposits() {
 	data := []byte(`
-    {
-        "depositList": [
-            {
-                "insertTime": 1508198532000,
-                "amount": 0.04670582,
-                "asset": "ETH",
-                "status": 1,
-                "TxID": "b3c6219639c8ae3f9cf010cdc24fw7f7yt8j1e063f9b4bd1a05cb44c4b6e2509"
-            }
-        ],
-        "success": true
-    }`)
+	{
+		"depositList": [
+			{
+				"insertTime": 1508198532000,
+				"amount": 0.04670582,
+				"asset": "ETH",
+				"address": "0x6915f16f8791d0a1cc2bf47c13a6b2a92000504b",
+				"txId": "0xdf33b22bdb2b28b1f75ccd201a4a4m6e7g83jy5fc5d5a9d1340961598cfcb0a1",
+				"status": 1
+			},
+			{
+				"insertTime": 1508298532000,
+				"amount": 1000,
+				"asset": "XMR",
+				"address": "463tWEBn5XZJSxLU34r6g7h8jtxuNcDbjLSjkn3XAXHCbLrTTErJrBWYgHJQyrCwkNgYvyV3z8zctJLPCZy24jvb3NiTcTJ",
+				"addressTag": "342341222",
+				"txId": "b3c6219639c8ae3f9cf010cdc24fw7f7yt8j1e063f9b4bd1a05cb44c4b6e2509",
+				"status": 1
+			}
+		],
+		"success": true
+	}
+	`)
 	s.mockDo(data, nil)
 	defer s.assertDo()
 	s.assertReq(func(r *request) {
@@ -39,20 +50,35 @@ func (s *depositServiceTestSuite) TestListDeposits() {
 		})
 		s.assertRequestEqual(e, r)
 	})
-	deposits, err := s.client.NewListDepositsService().Asset("BTC").
-		Status(1).StartTime(1508198532000).EndTime(1508198532001).
+
+	deposits, err := s.client.NewListDepositsService().
+		Asset("BTC").
+		Status(1).
+		StartTime(1508198532000).
+		EndTime(1508198532001).
 		Do(newContext())
 	r := s.r()
 	r.NoError(err)
-	r.Len(deposits, 1)
-	e := &Deposit{
+
+	r.Len(deposits, 2)
+	s.assertDepositEqual(&Deposit{
 		InsertTime: 1508198532000,
 		Amount:     0.04670582,
 		Asset:      "ETH",
+		Address:    "0x6915f16f8791d0a1cc2bf47c13a6b2a92000504b",
+		AddressTag: "",
+		TxID:       "0xdf33b22bdb2b28b1f75ccd201a4a4m6e7g83jy5fc5d5a9d1340961598cfcb0a1",
 		Status:     1,
+	}, deposits[0])
+	s.assertDepositEqual(&Deposit{
+		InsertTime: 1508298532000,
+		Amount:     1000.0,
+		Asset:      "XMR",
+		Address:    "463tWEBn5XZJSxLU34r6g7h8jtxuNcDbjLSjkn3XAXHCbLrTTErJrBWYgHJQyrCwkNgYvyV3z8zctJLPCZy24jvb3NiTcTJ",
+		AddressTag: "342341222",
 		TxID:       "b3c6219639c8ae3f9cf010cdc24fw7f7yt8j1e063f9b4bd1a05cb44c4b6e2509",
-	}
-	s.assertDepositEqual(e, deposits[0])
+		Status:     1,
+	}, deposits[1])
 }
 
 func (s *depositServiceTestSuite) assertDepositEqual(e, a *Deposit) {

--- a/withdraw_service.go
+++ b/withdraw_service.go
@@ -64,35 +64,37 @@ type ListWithdrawsService struct {
 	endTime   *int64
 }
 
-// Asset set asset
+// Asset sets the asset parameter.
 func (s *ListWithdrawsService) Asset(asset string) *ListWithdrawsService {
 	s.asset = &asset
 	return s
 }
 
-// Status set status
+// Status sets the status parameter.
 func (s *ListWithdrawsService) Status(status int) *ListWithdrawsService {
 	s.status = &status
 	return s
 }
 
-// StartTime set startTime
+// StartTime sets the startTime parameter.
+// If present, EndTime MUST be specified. The difference between EndTime - StartTime MUST be between 0-90 days.
 func (s *ListWithdrawsService) StartTime(startTime int64) *ListWithdrawsService {
 	s.startTime = &startTime
 	return s
 }
 
-// EndTime set endTime
+// EndTime sets the endTime parameter.
+// If present, StartTime MUST be specified. The difference between EndTime - StartTime MUST be between 0-90 days.
 func (s *ListWithdrawsService) EndTime(endTime int64) *ListWithdrawsService {
 	s.endTime = &endTime
 	return s
 }
 
-// Do send request
+// Do sends the request.
 func (s *ListWithdrawsService) Do(ctx context.Context) (withdraws []*Withdraw, err error) {
 	r := &request{
-		method:   "POST",
-		endpoint: "/wapi/v1/getWithdrawHistory.html",
+		method:   "GET",
+		endpoint: "/wapi/v3/withdrawHistory.html",
 		secType:  secTypeSigned,
 	}
 	if s.asset != nil {
@@ -119,20 +121,25 @@ func (s *ListWithdrawsService) Do(ctx context.Context) (withdraws []*Withdraw, e
 	return res.Withdraws, nil
 }
 
-// WithdrawHistoryResponse define withdraw history response
+// DepositHistoryResponse represents a response from ListWithdrawsService.
 type WithdrawHistoryResponse struct {
 	Withdraws []*Withdraw `json:"withdrawList"`
 	Success   bool        `json:"success"`
 }
 
-// Withdraw define withdraw info
+// Withdraw represents a single withdraw entry.
 type Withdraw struct {
-	Amount    float64 `json:"amount"`
-	Address   string  `json:"address"`
-	Asset     string  `json:"asset"`
-	TxID      string  `json:"txId"`
-	ApplyTime int64   `json:"applyTime"`
-	Status    int     `json:"status"`
+	ID              string  `json:"id"`
+	WithdrawOrderID string  `json:"withdrawOrderId"`
+	Amount          float64 `json:"amount"`
+	TransactionFee  float64 `json:"transactionFee"`
+	Address         string  `json:"address"`
+	AddressTag      string  `json:"addressTag"`
+	TxID            string  `json:"txId"`
+	Asset           string  `json:"asset"`
+	ApplyTime       int64   `json:"applyTime"`
+	Network         string  `json:"network"`
+	Status          int     `json:"status"`
 }
 
 // GetWithdrawFeeService get withdraw fee

--- a/withdraw_service_test.go
+++ b/withdraw_service_test.go
@@ -42,26 +42,37 @@ func (s *withdrawServiceTestSuite) TestCreateWithdraw() {
 }
 
 func (s *withdrawServiceTestSuite) TestListWithdraws() {
-	data := []byte(`{
-        "withdrawList": [
-            {
-                "amount": 1,
-                "address": "0x6915f16f8791d0a1cc2bf47c13a6b2a92000504b",
-                "asset": "ETH",
-                "applyTime": 1508198532000,
-                "status": 4
-            },
-            {
-                "amount": 0.005,
-                "address": "0x6915f16f8791d0a1cc2bf47c13a6b2a92000504b",
-                "txId": "0x80aaabed54bdab3f6de5868f89929a2371ad21d666f20f7393d1a3389fad95a1",
-                "asset": "ETH",
-                "applyTime": 1508198532000,
-                "status": 4
-            }
-        ],
-        "success": true
-    }`)
+	data := []byte(`
+	{
+		"withdrawList": [
+			{
+				"id":"7213fea8e94b4a5593d507237e5a555b",
+				"withdrawOrderId": "",    
+				"amount": 0.99,
+				"transactionFee": 0.01,
+				"address": "0x6915f16f8791d0a1cc2bf47c13a6b2a92000504b",
+				"asset": "USDT",
+				"txId": "0xdf33b22bdb2b28b1f75ccd201a4a4m6e7g83jy5fc5d5a9d1340961598cfcb0a1",
+				"applyTime": 1508198532000,
+				"network": "ETH",
+				"status": 4
+			},
+			{
+				"id":"7213fea8e94b4a5534ggsd237e5a555b",
+				"withdrawOrderId": "withdrawtest", 
+				"amount": 999.9999,
+				"transactionFee": 0.0001,
+				"address": "463tWEBn5XZJSxLU34r6g7h8jtxuNcDbjLSjkn3XAXHCbLrTTErJrBWYgHJQyrCwkNgYvyV3z8zctJLPCZy24jvb3NiTcTJ",
+				"addressTag": "342341222",
+				"txId": "b3c6219639c8ae3f9cf010cdc24fw7f7yt8j1e063f9b4bd1a05cb44c4b6e2509",
+				"asset": "XMR",
+				"applyTime": 1508198532000,
+				"status": 4
+			}
+		],
+		"success": true
+	}
+	`)
 	s.mockDo(data, nil)
 	defer s.assertDo()
 
@@ -79,29 +90,41 @@ func (s *withdrawServiceTestSuite) TestListWithdraws() {
 		s.assertRequestEqual(e, r)
 	})
 
-	withdraws, err := s.client.NewListWithdrawsService().Asset(asset).
-		Status(status).StartTime(startTime).EndTime(endTime).
+	withdraws, err := s.client.NewListWithdrawsService().
+		Asset(asset).
+		Status(status).
+		StartTime(startTime).
+		EndTime(endTime).
 		Do(newContext())
 	r := s.r()
 	r.NoError(err)
+
 	s.Len(withdraws, 2)
-	e1 := &Withdraw{
-		Amount:    1,
-		Address:   "0x6915f16f8791d0a1cc2bf47c13a6b2a92000504b",
-		Asset:     "ETH",
-		ApplyTime: 1508198532000,
-		Status:    4,
-	}
-	e2 := &Withdraw{
-		Amount:    0.005,
-		Address:   "0x6915f16f8791d0a1cc2bf47c13a6b2a92000504b",
-		TxID:      "0x80aaabed54bdab3f6de5868f89929a2371ad21d666f20f7393d1a3389fad95a1",
-		Asset:     "ETH",
-		ApplyTime: 1508198532000,
-		Status:    4,
-	}
-	s.assertWithdrawEqual(e1, withdraws[0])
-	s.assertWithdrawEqual(e2, withdraws[1])
+	s.assertWithdrawEqual(&Withdraw{
+		ID:              "7213fea8e94b4a5593d507237e5a555b",
+		WithdrawOrderID: "",
+		Amount:          0.99,
+		TransactionFee:  0.01,
+		Address:         "0x6915f16f8791d0a1cc2bf47c13a6b2a92000504b",
+		AddressTag:      "",
+		Asset:           "USDT",
+		TxID:            "0xdf33b22bdb2b28b1f75ccd201a4a4m6e7g83jy5fc5d5a9d1340961598cfcb0a1",
+		ApplyTime:       1508198532000,
+		Network:         "ETH",
+		Status:          4,
+	}, withdraws[0])
+	s.assertWithdrawEqual(&Withdraw{
+		ID:              "7213fea8e94b4a5534ggsd237e5a555b",
+		WithdrawOrderID: "withdrawOrderId",
+		Amount:          999.9999,
+		TransactionFee:  0.0001,
+		Address:         "463tWEBn5XZJSxLU34r6g7h8jtxuNcDbjLSjkn3XAXHCbLrTTErJrBWYgHJQyrCwkNgYvyV3z8zctJLPCZy24jvb3NiTcTJ",
+		AddressTag:      "342341222",
+		TxID:            "b3c6219639c8ae3f9cf010cdc24fw7f7yt8j1e063f9b4bd1a05cb44c4b6e2509",
+		Asset:           "XMR",
+		ApplyTime:       1508198532000,
+		Status:          4,
+	}, withdraws[1])
 }
 
 func (s *withdrawServiceTestSuite) assertWithdrawEqual(e, a *Withdraw) {


### PR DESCRIPTION
v1 endpoints are deprecates and gone, this PR switches to the v3 endpoints.

It includes spec coverage. I also tested it live, in fact that's how I discovered that the withdraw response also contain a `Network` attribute that is not currently advertised in the Binance docs (I suppose as it's out of date).

Closes https://github.com/adshao/go-binance/pull/69.