### PR TITLE
Withdraw: Add missing options

### DIFF
--- a/withdraw_service.go
+++ b/withdraw_service.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 )
 
-// CreateWithdrawService create withdraw
+// CreateWithdrawService submits a withdraw request.
+//
+// See https://binance-docs.github.io/apidocs/spot/en/#withdraw
 type CreateWithdrawService struct {
 	c       *Client
 	asset   string
@@ -14,32 +16,32 @@ type CreateWithdrawService struct {
 	name    *string
 }
 
-// Asset set asset
+// Asset sets asset parameter (MANDATORY).
 func (s *CreateWithdrawService) Asset(asset string) *CreateWithdrawService {
 	s.asset = asset
 	return s
 }
 
-// Address set address
+// Address sets the address parameter (MANDATORY).
 func (s *CreateWithdrawService) Address(address string) *CreateWithdrawService {
 	s.address = address
 	return s
 }
 
-// Amount set amount
+// Amount sets the amount parameter (MANDATORY).
 func (s *CreateWithdrawService) Amount(amount string) *CreateWithdrawService {
 	s.amount = amount
 	return s
 }
 
-// Name set name
+// Name sets the name parameter.
 func (s *CreateWithdrawService) Name(name string) *CreateWithdrawService {
 	s.name = &name
 	return s
 }
 
-// Do send request
-func (s *CreateWithdrawService) Do(ctx context.Context) (err error) {
+// Do sends the request.
+func (s *CreateWithdrawService) Do(ctx context.Context) (*CreateWithdrawResponse, error) {
 	r := &request{
 		method:   "POST",
 		endpoint: "/wapi/v3/withdraw.html",
@@ -51,11 +53,30 @@ func (s *CreateWithdrawService) Do(ctx context.Context) (err error) {
 	if s.name != nil {
 		r.setParam("name", *s.name)
 	}
-	_, err = s.c.callAPI(ctx, r)
-	return err
+
+	data, err := s.c.callAPI(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+
+	res := &CreateWithdrawResponse{}
+	if err := json.Unmarshal(data, res); err != nil {
+		return nil, err
+	}
+
+	return res, nil
 }
 
-// ListWithdrawsService list withdraws
+// CreateWithdrawResponse represents a response from CreateWithdrawService.
+type CreateWithdrawResponse struct {
+	ID      string `json:"id"`
+	Msg     string `json:"msg"`
+	Success bool   `json:"success"`
+}
+
+// ListWithdrawsService fetches withdraw history.
+//
+// See https://binance-docs.github.io/apidocs/spot/en/#withdraw-history-supporting-network-user_data
 type ListWithdrawsService struct {
 	c         *Client
 	asset     *string

--- a/withdraw_service.go
+++ b/withdraw_service.go
@@ -9,16 +9,32 @@ import (
 //
 // See https://binance-docs.github.io/apidocs/spot/en/#withdraw
 type CreateWithdrawService struct {
-	c       *Client
-	asset   string
-	address string
-	amount  string
-	name    *string
+	c                  *Client
+	asset              string
+	withdrawOrderID    *string
+	network            *string
+	address            string
+	addressTag         *string
+	amount             string
+	transactionFeeFlag *bool
+	name               *string
 }
 
-// Asset sets asset parameter (MANDATORY).
-func (s *CreateWithdrawService) Asset(asset string) *CreateWithdrawService {
-	s.asset = asset
+// Asset sets the asset parameter (MANDATORY).
+func (s *CreateWithdrawService) Asset(v string) *CreateWithdrawService {
+	s.asset = v
+	return s
+}
+
+// WithdrawOrderID sets the withdrawOrderID parameter.
+func (s *CreateWithdrawService) WithdrawOrderID(v string) *CreateWithdrawService {
+	s.withdrawOrderID = &v
+	return s
+}
+
+// Network sets the network parameter.
+func (s *CreateWithdrawService) Network(v string) *CreateWithdrawService {
+	s.network = &v
 	return s
 }
 
@@ -28,15 +44,27 @@ func (s *CreateWithdrawService) Address(address string) *CreateWithdrawService {
 	return s
 }
 
+// AddressTag sets the addressTag parameter.
+func (s *CreateWithdrawService) AddressTag(v string) *CreateWithdrawService {
+	s.addressTag = &v
+	return s
+}
+
 // Amount sets the amount parameter (MANDATORY).
-func (s *CreateWithdrawService) Amount(amount string) *CreateWithdrawService {
-	s.amount = amount
+func (s *CreateWithdrawService) Amount(v string) *CreateWithdrawService {
+	s.amount = v
+	return s
+}
+
+// TransactionFeeFlag sets the transactionFeeFlag parameter.
+func (s *CreateWithdrawService) TransactionFeeFlag(v bool) *CreateWithdrawService {
+	s.transactionFeeFlag = &v
 	return s
 }
 
 // Name sets the name parameter.
-func (s *CreateWithdrawService) Name(name string) *CreateWithdrawService {
-	s.name = &name
+func (s *CreateWithdrawService) Name(v string) *CreateWithdrawService {
+	s.name = &v
 	return s
 }
 
@@ -50,8 +78,20 @@ func (s *CreateWithdrawService) Do(ctx context.Context) (*CreateWithdrawResponse
 	r.setParam("asset", s.asset)
 	r.setParam("address", s.address)
 	r.setParam("amount", s.amount)
-	if s.name != nil {
-		r.setParam("name", *s.name)
+	if v := s.withdrawOrderID; v != nil {
+		r.setParam("withdrawOrderId", *v)
+	}
+	if v := s.network; v != nil {
+		r.setParam("network", *v)
+	}
+	if v := s.addressTag; v != nil {
+		r.setParam("addressTag", *v)
+	}
+	if v := s.transactionFeeFlag; v != nil {
+		r.setParam("transactionFeeFlag", *v)
+	}
+	if v := s.name; v != nil {
+		r.setParam("name", *v)
 	}
 
 	data, err := s.c.callAPI(ctx, r)
@@ -151,7 +191,7 @@ type WithdrawHistoryResponse struct {
 // Withdraw represents a single withdraw entry.
 type Withdraw struct {
 	ID              string  `json:"id"`
-	WithdrawOrderID string  `json:"withdrawOrderId"`
+	WithdrawOrderID string  `json:"withdrawOrderID"`
 	Amount          float64 `json:"amount"`
 	TransactionFee  float64 `json:"transactionFee"`
 	Address         string  `json:"address"`

--- a/withdraw_service_test.go
+++ b/withdraw_service_test.go
@@ -25,24 +25,36 @@ func (s *withdrawServiceTestSuite) TestCreateWithdraw() {
 	s.mockDo(data, nil)
 	defer s.assertDo()
 
-	asset := "ETH"
+	asset := "USDT"
+	withdrawOrderID := "testID"
+	network := "ETH"
 	address := "myaddress"
+	addressTag := "xyz"
 	amount := "0.01"
+	transactionFeeFlag := true
 	name := "eth"
 	s.assertReq(func(r *request) {
 		e := newSignedRequest().setParams(params{
-			"asset":   asset,
-			"address": address,
-			"amount":  amount,
-			"name":    name,
+			"asset":              asset,
+			"withdrawOrderId":    withdrawOrderID,
+			"network":            network,
+			"address":            address,
+			"addressTag":         addressTag,
+			"amount":             amount,
+			"transactionFeeFlag": transactionFeeFlag,
+			"name":               name,
 		})
 		s.assertRequestEqual(e, r)
 	})
 
 	res, err := s.client.NewCreateWithdrawService().
 		Asset(asset).
+		WithdrawOrderID(withdrawOrderID).
+		Network(network).
 		Address(address).
+		AddressTag(addressTag).
 		Amount(amount).
+		TransactionFeeFlag(transactionFeeFlag).
 		Name(name).
 		Do(newContext())
 
@@ -59,7 +71,7 @@ func (s *withdrawServiceTestSuite) TestListWithdraws() {
 		"withdrawList": [
 			{
 				"id":"7213fea8e94b4a5593d507237e5a555b",
-				"withdrawOrderId": "",    
+				"withdrawOrderID": "",    
 				"amount": 0.99,
 				"transactionFee": 0.01,
 				"address": "0x6915f16f8791d0a1cc2bf47c13a6b2a92000504b",
@@ -71,7 +83,7 @@ func (s *withdrawServiceTestSuite) TestListWithdraws() {
 			},
 			{
 				"id":"7213fea8e94b4a5534ggsd237e5a555b",
-				"withdrawOrderId": "withdrawtest", 
+				"withdrawOrderID": "withdrawtest", 
 				"amount": 999.9999,
 				"transactionFee": 0.0001,
 				"address": "463tWEBn5XZJSxLU34r6g7h8jtxuNcDbjLSjkn3XAXHCbLrTTErJrBWYgHJQyrCwkNgYvyV3z8zctJLPCZy24jvb3NiTcTJ",
@@ -127,7 +139,7 @@ func (s *withdrawServiceTestSuite) TestListWithdraws() {
 	}, withdraws[0])
 	s.assertWithdrawEqual(&Withdraw{
 		ID:              "7213fea8e94b4a5534ggsd237e5a555b",
-		WithdrawOrderID: "withdrawOrderId",
+		WithdrawOrderID: "withdrawOrderID",
 		Amount:          999.9999,
 		TransactionFee:  0.0001,
 		Address:         "463tWEBn5XZJSxLU34r6g7h8jtxuNcDbjLSjkn3XAXHCbLrTTErJrBWYgHJQyrCwkNgYvyV3z8zctJLPCZy24jvb3NiTcTJ",

--- a/withdraw_service_test.go
+++ b/withdraw_service_test.go
@@ -15,10 +15,13 @@ func TestWithdrawService(t *testing.T) {
 }
 
 func (s *withdrawServiceTestSuite) TestCreateWithdraw() {
-	data := []byte(`{
-        "msg": "success",
-        "success": true
-    }`)
+	data := []byte(`
+	{
+		"msg": "success",
+		"success": true,
+		"id":"7213fea8e94b4a5593d507237e5a555b"
+	}
+	`)
 	s.mockDo(data, nil)
 	defer s.assertDo()
 
@@ -36,9 +39,18 @@ func (s *withdrawServiceTestSuite) TestCreateWithdraw() {
 		s.assertRequestEqual(e, r)
 	})
 
-	err := s.client.NewCreateWithdrawService().Asset(asset).
-		Address(address).Amount(amount).Name(name).Do(newContext())
-	s.r().NoError(err)
+	res, err := s.client.NewCreateWithdrawService().
+		Asset(asset).
+		Address(address).
+		Amount(amount).
+		Name(name).
+		Do(newContext())
+
+	r := s.r()
+	r.NoError(err)
+	r.Equal("7213fea8e94b4a5593d507237e5a555b", res.ID)
+	r.Equal("success", res.Msg)
+	r.True(res.Success)
 }
 
 func (s *withdrawServiceTestSuite) TestListWithdraws() {


### PR DESCRIPTION
This PR updates the `Withdraw` implementation with all the [missing options](https://binance-docs.github.io/apidocs/spot/en/#withdraw), including `addressTag` and transaction info.

It also changes the signature a bit as Withdraw does return a response, and that was currently not supported. I decided to stick with returning the response container as it actually enables to expose all attributes and potentially further data in the future (like headers).

I found that `ListWithdrawsService` and `ListDepositsService`, for instance, return the inner set of entries rather than a response. I think returning the response would be appropriate as well even in those scenarios, but I'm not going to make changes in this PR outside the scope. `Withdraw` response doesn't have this problem anyways, as it's not a container.

Closes https://github.com/adshao/go-binance/pull/85

PS. As a curiosity, have you ever considered to migrate the design from using methods as individual setter, to a struct input payload, which can be serialized via JSON (example https://github.com/fastly/go-fastly/blob/8c5f5b72363930ec9ba4de2ae53a5f7751a8b68a/fastly/pool.go#L99-L130). I'm asking because as I was working on this PR, I realized there's a lot of boilerplate with a significant risk of copy/paste error when writing setters and setting params in the request.