### PR TITLE
Add depositAddress API

### DIFF
--- a/client.go
+++ b/client.go
@@ -399,6 +399,11 @@ func (c *Client) NewListDepositsService() *ListDepositsService {
 	return &ListDepositsService{c: c}
 }
 
+// NewGetDepositAddressService init getting deposit address service
+func (c *Client) NewGetDepositAddressService() *GetDepositsAddressService {
+	return &GetDepositsAddressService{c: c}
+}
+
 // NewCreateWithdrawService init creating withdraw service
 func (c *Client) NewCreateWithdrawService() *CreateWithdrawService {
 	return &CreateWithdrawService{c: c}

--- a/deposit_service.go
+++ b/deposit_service.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 )
 
-// ListDepositsService list deposits
+// ListDepositsService fetches deposit history.
+//
+// See https://binance-docs.github.io/apidocs/spot/en/#deposit-history-user_data
 type ListDepositsService struct {
 	c         *Client
 	asset     *string
@@ -87,4 +89,59 @@ type Deposit struct {
 	AddressTag string  `json:"addressTag"`
 	TxID       string  `json:"txId"`
 	Status     int     `json:"status"`
+}
+
+// GetDepositsAddressService retrieves the details of a deposit address.
+//
+// See https://binance-docs.github.io/apidocs/spot/en/#deposit-address-supporting-network-user_data
+type GetDepositsAddressService struct {
+	c      *Client
+	asset  string
+	status *bool
+}
+
+// Asset sets the asset parameter (MANDATORY).
+func (s *GetDepositsAddressService) Asset(v string) *GetDepositsAddressService {
+	s.asset = v
+	return s
+}
+
+// Status sets the status parameter.
+func (s *GetDepositsAddressService) Status(v bool) *GetDepositsAddressService {
+	s.status = &v
+	return s
+}
+
+// Do sends the request.
+func (s *GetDepositsAddressService) Do(ctx context.Context) (*GetDepositAddressResponse, error) {
+	r := &request{
+		method:   "GET",
+		endpoint: "/wapi/v3/depositAddress.html",
+		secType:  secTypeSigned,
+	}
+	r.setParam("asset", s.asset)
+	if v := s.status; v != nil {
+		r.setParam("status", *v)
+	}
+
+	data, err := s.c.callAPI(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+
+	res := &GetDepositAddressResponse{}
+	if err := json.Unmarshal(data, res); err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+// GetDepositAddressResponse represents a response from GetDepositsAddressService.
+type GetDepositAddressResponse struct {
+	Success    bool   `json:"success"`
+	Address    string `json:"address"`
+	AddressTag string `json:"addressTag"`
+	Asset      string `json:"asset"`
+	URL        string `json:"url"`
 }

--- a/deposit_service_test.go
+++ b/deposit_service_test.go
@@ -89,3 +89,40 @@ func (s *depositServiceTestSuite) assertDepositEqual(e, a *Deposit) {
 	r.Equal(e.Status, a.Status, "Status")
 	r.Equal(e.TxID, a.TxID, "TxID")
 }
+
+func (s *depositServiceTestSuite) TestGetDepositAddress() {
+	data := []byte(`
+	{
+		"address": "0xbf1f86b3c8ff4f8cbfc195e9713b6f0000000000",
+		"success": true,
+		"addressTag": "1231212",
+		"asset": "ETH",
+		"url": "https://etherscan.io/address/0xbf1f86b3c8ff4f8cbfc195e9713b6f0000000000"
+	}
+	`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	asset := "ETH"
+	status := true
+	s.assertReq(func(r *request) {
+		e := newSignedRequest().setParams(params{
+			"asset":  asset,
+			"status": status,
+		})
+		s.assertRequestEqual(e, r)
+	})
+
+	res, err := s.client.NewGetDepositAddressService().
+		Asset(asset).
+		Status(status).
+		Do(newContext())
+
+	r := s.r()
+	r.NoError(err)
+	r.True(res.Success)
+	r.Equal("0xbf1f86b3c8ff4f8cbfc195e9713b6f0000000000", res.Address)
+	r.Equal("1231212", res.AddressTag)
+	r.Equal("ETH", res.Asset)
+	r.Equal("https://etherscan.io/address/0xbf1f86b3c8ff4f8cbfc195e9713b6f0000000000", res.URL)
+}

--- a/withdraw_service.go
+++ b/withdraw_service.go
@@ -39,8 +39,8 @@ func (s *CreateWithdrawService) Network(v string) *CreateWithdrawService {
 }
 
 // Address sets the address parameter (MANDATORY).
-func (s *CreateWithdrawService) Address(address string) *CreateWithdrawService {
-	s.address = address
+func (s *CreateWithdrawService) Address(v string) *CreateWithdrawService {
+	s.address = v
 	return s
 }
 


### PR DESCRIPTION
Tests are passing. I also tested it live, and that's how I discovered the undocumented `url` response field.

Closes https://github.com/adshao/go-binance/issues/67