### PR TITLE
feature/asset_dividend_service

### DIFF
--- a/asset_dividend_service.go
+++ b/asset_dividend_service.go
@@ -1,0 +1,88 @@
+package binance
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// AssetDividendService fetches the saving purchases
+type AssetDividendService struct {
+	c         *Client
+	asset     *string
+	startTime *int64
+	endTime   *int64
+	limit     *int
+}
+
+// Asset sets the asset parameter.
+func (s *AssetDividendService) Asset(asset string) *AssetDividendService {
+	s.asset = &asset
+	return s
+}
+
+// Limit sets the limit parameter.
+func (s *AssetDividendService) Limit(limit int) *AssetDividendService {
+	s.limit = &limit
+	return s
+}
+
+// StartTime sets the startTime parameter.
+// If present, EndTime MUST be specified. The difference between EndTime - StartTime MUST be between 0-90 days.
+func (s *AssetDividendService) StartTime(startTime int64) *AssetDividendService {
+	s.startTime = &startTime
+	return s
+}
+
+// EndTime sets the endTime parameter.
+// If present, StartTime MUST be specified. The difference between EndTime - StartTime MUST be between 0-90 days.
+func (s *AssetDividendService) EndTime(endTime int64) *AssetDividendService {
+	s.endTime = &endTime
+	return s
+}
+
+// Do sends the request.
+func (s *AssetDividendService) Do(ctx context.Context) (*DividendResponseWrapper, error) {
+	r := &request{
+		method:   "GET",
+		endpoint: "/sapi/v1/asset/assetDividend",
+		secType:  secTypeSigned,
+	}
+	if s.asset != nil {
+		r.setParam("asset", *s.asset)
+	}
+	if s.limit != nil {
+		r.setParam("limit", *s.limit)
+	} else {
+		r.setParam("limit", 20)
+	}
+	if s.startTime != nil {
+		r.setParam("startTime", *s.startTime)
+	}
+	if s.endTime != nil {
+		r.setParam("endTime", *s.endTime)
+	}
+	data, err := s.c.callAPI(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+	res := new(DividendResponseWrapper)
+	err = json.Unmarshal(data, res)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+// DividendResponseWrapper represents a wrapper around a AssetDividendService.
+type DividendResponseWrapper struct {
+	Rows *[]DividendResponse `json:"rows"`
+}
+
+// DividendResponse represents a response from AssetDividendService.
+type DividendResponse struct {
+	Amount string `json:"amount"`
+	Asset  string `json:"asset"`
+	Info   string `json:"enInfo"`
+	Time   int64  `json:"divTime"`
+	TranID int64  `json:"tranId"`
+}

--- a/asset_dividend_service_test.go
+++ b/asset_dividend_service_test.go
@@ -46,7 +46,7 @@ func (s *assetDividendServiceTestSuite) TestListAssetDividend() {
 	s.assertReq(func(r *request) {
 		e := newSignedRequest().setParams(params{
 			`asset`:     asset,
-			`limit`:    2,
+			`limit`:     2,
 			`startTime`: startTime,
 			`endTime`:   endTime,
 		})
@@ -65,18 +65,18 @@ func (s *assetDividendServiceTestSuite) TestListAssetDividend() {
 
 	s.Len(rows, 2)
 	s.assertDividendEqual(&DividendResponse{
-		Amount:          `10.00000000`,
-		Asset:           `BHFT`,
-		Time:            1563189166000,
-		Info:            `BHFT distribution`,
-		TranID:         2968885920,
+		Amount: `10.00000000`,
+		Asset:  `BHFT`,
+		Time:   1563189166000,
+		Info:   `BHFT distribution`,
+		TranID: 2968885920,
 	}, &rows[0])
 	s.assertDividendEqual(&DividendResponse{
-		Amount:          `10.00000000`,
-		Asset:           `BHFT`,
-		Time:            1563189165000,
-		Info:            `BHFT distribution`,
-		TranID:         2968885920,
+		Amount: `10.00000000`,
+		Asset:  `BHFT`,
+		Time:   1563189165000,
+		Info:   `BHFT distribution`,
+		TranID: 2968885920,
 	}, &rows[1])
 }
 

--- a/asset_dividend_service_test.go
+++ b/asset_dividend_service_test.go
@@ -1,0 +1,91 @@
+package binance
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type assetDividendServiceTestSuite struct {
+	baseTestSuite
+}
+
+func TestAssetDividendService(t *testing.T) {
+	suite.Run(t, new(assetDividendServiceTestSuite))
+}
+
+func (s *assetDividendServiceTestSuite) TestListAssetDividend() {
+	data := []byte(`
+	{
+		"rows":[
+			{
+				"amount":"10.00000000",
+				"asset":"BHFT",
+				"divTime":1563189166000,
+				"enInfo":"BHFT distribution",
+				"tranId":2968885920
+			},
+			{
+				"amount":"10.00000000",
+				"asset":"BHFT",
+				"divTime":1563189165000,
+				"enInfo":"BHFT distribution",
+				"tranId":2968885920
+			}
+		],
+		"total":2
+	}
+	`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	asset := `BHFT`
+	startTime := int64(1508198532000)
+	endTime := int64(1508198532001)
+	s.assertReq(func(r *request) {
+		e := newSignedRequest().setParams(params{
+			`asset`:     asset,
+			`limit`:    2,
+			`startTime`: startTime,
+			`endTime`:   endTime,
+		})
+		s.assertRequestEqual(e, r)
+	})
+
+	dividend, err := s.client.NewAssetDividendService().
+		Asset(asset).
+		StartTime(startTime).
+		EndTime(endTime).
+		Limit(2).
+		Do(context.Background())
+	r := s.r()
+	r.NoError(err)
+	rows := *dividend.Rows
+
+	s.Len(rows, 2)
+	s.assertDividendEqual(&DividendResponse{
+		Amount:          `10.00000000`,
+		Asset:           `BHFT`,
+		Time:            1563189166000,
+		Info:            `BHFT distribution`,
+		TranID:         2968885920,
+	}, &rows[0])
+	s.assertDividendEqual(&DividendResponse{
+		Amount:          `10.00000000`,
+		Asset:           `BHFT`,
+		Time:            1563189165000,
+		Info:            `BHFT distribution`,
+		TranID:         2968885920,
+	}, &rows[1])
+}
+
+func (s *assetDividendServiceTestSuite) assertDividendEqual(e, a *DividendResponse) {
+	r := s.r()
+	r.Equal(e.Amount, `10.00000000`, `Amount`)
+	r.Equal(e.Amount, a.Amount, `Amount`)
+	r.Equal(e.Info, a.Info, `Info`)
+	r.Equal(e.Asset, a.Asset, `Asset`)
+	r.Equal(e.Time, a.Time, `Time`)
+	r.Equal(e.TranID, a.TranID, `TranID`)
+}

--- a/client.go
+++ b/client.go
@@ -558,3 +558,8 @@ func (c *Client) NewFuturesTransferService() *FuturesTransferService {
 func (c *Client) NewListFuturesTransferService() *ListFuturesTransferService {
 	return &ListFuturesTransferService{c: c}
 }
+
+// NewAssetDividendService init the asset dividend list service
+func (c *Client) NewAssetDividendService() *AssetDividendService {
+	return &AssetDividendService{c: c}
+}


### PR DESCRIPTION
## What 
This feature adds the [Asset Dividend Record (USER_DATA)](https://binance-docs.github.io/apidocs/spot/en/#asset-dividend-record-user_data) API call.
This matches the following route `Get /sapi/v1/asset/assetDividend (HMAC SHA256)`.

### Parameters 
| Name       | Type   | Mandatory | Description         |
|------------|--------|-----------|---------------------|
| asset      | STRING | NO        |                     |
| startTime  | LONG   | NO        |                     |
| endTime    | LONG   | NO        |                     |
| limit      | INT    | NO        | Default 20, max 500 |
| recvWindow | LONG   | NO        |                     |
| timestamp  | LONG   | YES       |                     |

### Response
```json
{
    "rows":[
        {
            "amount":"10.00000000",
            "asset":"BHFT",
            "divTime":1563189166000,
            "enInfo":"BHFT distribution",
            "tranId":2968885920
        },
        {
            "amount":"10.00000000",
            "asset":"BHFT",
            "divTime":1563189165000,
            "enInfo":"BHFT distribution",
            "tranId":2968885920
        }
    ],
    "total":2
}
```