### PR TITLE
Add ClosePosition field to Order struct

### DIFF
--- a/futures/order_service.go
+++ b/futures/order_service.go
@@ -295,6 +295,7 @@ type Order struct {
 	AvgPrice         string           `json:"avgPrice"`
 	OrigType         string           `json:"origType"`
 	PositionSide     PositionSideType `json:"positionSide"`
+	ClosePosition    bool             `json:"closePosition"`
 }
 
 // ListOrdersService all account orders; active, canceled, or filled

--- a/futures/order_service_test.go
+++ b/futures/order_service_test.go
@@ -212,6 +212,7 @@ func (s *baseOrderTestSuite) assertOrderEqual(e, a *Order) {
 	r.Equal(e.ActivatePrice, a.ActivatePrice, "ActivatePrice")
 	r.Equal(e.PriceRate, a.PriceRate, "PriceRate")
 	r.Equal(e.PositionSide, a.PositionSide, "PositionSide")
+	r.Equal(e.ClosePosition, a.ClosePosition, "ClosePosition")
 }
 
 func (s *orderServiceTestSuite) TestGetOrder() {

--- a/futures/order_service_test.go
+++ b/futures/order_service_test.go
@@ -144,7 +144,8 @@ func (s *orderServiceTestSuite) TestListOpenOrders() {
 		  "workingType": "CONTRACT_PRICE",
 		  "activatePrice": "10000",
 		  "priceRate":"0.1",
-		  "positionSide":"BOTH"
+		  "positionSide":"BOTH",
+		  "closePosition": false
 		}
 	]`)
 	s.mockDo(data, nil)
@@ -184,6 +185,7 @@ func (s *orderServiceTestSuite) TestListOpenOrders() {
 		ActivatePrice: "10000",
 		PriceRate:     "0.1",
 		PositionSide:  "BOTH",
+		ClosePosition: false,
 	}
 	s.assertOrderEqual(e, orders[0])
 }
@@ -232,7 +234,8 @@ func (s *orderServiceTestSuite) TestGetOrder() {
 		"workingType": "CONTRACT_PRICE",
 		"activatePrice": "10000",
 		"priceRate":"0.1",
-		"positionSide": "BOTH"
+		"positionSide": "BOTH",
+		"closePosition": false
 	}`)
 	s.mockDo(data, nil)
 	defer s.assertDo()
@@ -272,6 +275,7 @@ func (s *orderServiceTestSuite) TestGetOrder() {
 		ActivatePrice:    "10000",
 		PriceRate:        "0.1",
 		PositionSide:     "BOTH",
+		ClosePosition:    false,
 	}
 	s.assertOrderEqual(e, order)
 }
@@ -296,7 +300,8 @@ func (s *orderServiceTestSuite) TestListOrders() {
 		  "updateTime": 1499827319559,
 		  "workingType": "CONTRACT_PRICE",
 		  "activatePrice": "10000",
-		  "priceRate":"0.1"
+		  "priceRate":"0.1",
+		  "closePosition": false
 		}
 	  ]`)
 	s.mockDo(data, nil)
@@ -342,6 +347,7 @@ func (s *orderServiceTestSuite) TestListOrders() {
 		WorkingType:      WorkingTypeContractPrice,
 		ActivatePrice:    "10000",
 		PriceRate:        "0.1",
+		ClosePosition:    false,
 	}
 	s.assertOrderEqual(e, orders[0])
 }


### PR DESCRIPTION
Adds the `ClosePosition` field to the `Order` struct in the `futures` package. You can see that field in the response examples of the following API endpoints:

https://binance-docs.github.io/apidocs/futures/en/#query-order-user_data
https://binance-docs.github.io/apidocs/futures/en/#query-current-open-order-user_data
https://binance-docs.github.io/apidocs/futures/en/#current-all-open-orders-user_data