### PR TITLE
add NewOrderResponseType to futures order service

### DIFF
--- a/futures/client.go
+++ b/futures/client.go
@@ -78,7 +78,6 @@ const (
 
 	NewOrderRespTypeACK    NewOrderRespType = "ACK"
 	NewOrderRespTypeRESULT NewOrderRespType = "RESULT"
-	NewOrderRespTypeFULL   NewOrderRespType = "FULL"
 
 	OrderStatusTypeNew             OrderStatusType = "NEW"
 	OrderStatusTypePartiallyFilled OrderStatusType = "PARTIALLY_FILLED"

--- a/futures/order_service.go
+++ b/futures/order_service.go
@@ -115,11 +115,11 @@ func (s *CreateOrderService) createOrder(ctx context.Context, endpoint string, o
 		secType:  secTypeSigned,
 	}
 	m := params{
-		"symbol":               s.symbol,
-		"side":                 s.side,
-		"type":                 s.orderType,
-		"quantity":             s.quantity,
-		"newOrderResponseType": s.newOrderRespType,
+		"symbol":           s.symbol,
+		"side":             s.side,
+		"type":             s.orderType,
+		"quantity":         s.quantity,
+		"newOrderRespType": s.newOrderRespType,
 	}
 	if s.positionSide != nil {
 		m["positionSide"] = *s.positionSide

--- a/futures/order_service.go
+++ b/futures/order_service.go
@@ -21,6 +21,7 @@ type CreateOrderService struct {
 	workingType      *WorkingType
 	activationPrice  *string
 	callbackRate     *string
+	newOrderRespType NewOrderRespType
 }
 
 // Symbol set symbol
@@ -101,6 +102,12 @@ func (s *CreateOrderService) CallbackRate(callbackRate string) *CreateOrderServi
 	return s
 }
 
+// NewOrderResponseType set newOrderResponseType
+func (s *CreateOrderService) NewOrderResponseType(newOrderResponseType NewOrderRespType) *CreateOrderService {
+	s.newOrderRespType = newOrderResponseType
+	return s
+}
+
 func (s *CreateOrderService) createOrder(ctx context.Context, endpoint string, opts ...RequestOption) (data []byte, err error) {
 	r := &request{
 		method:   "POST",
@@ -108,10 +115,11 @@ func (s *CreateOrderService) createOrder(ctx context.Context, endpoint string, o
 		secType:  secTypeSigned,
 	}
 	m := params{
-		"symbol":   s.symbol,
-		"side":     s.side,
-		"type":     s.orderType,
-		"quantity": s.quantity,
+		"symbol":               s.symbol,
+		"side":                 s.side,
+		"type":                 s.orderType,
+		"quantity":             s.quantity,
+		"newOrderResponseType": s.newOrderRespType,
 	}
 	if s.positionSide != nil {
 		m["positionSide"] = *s.positionSide

--- a/futures/order_service_test.go
+++ b/futures/order_service_test.go
@@ -54,21 +54,23 @@ func (s *orderServiceTestSuite) TestCreateOrder() {
 	activationPrice := "1000"
 	callbackRate := "0.1"
 	workingType := WorkingTypeContractPrice
+	newOrderResponseType := NewOrderRespTypeRESULT
 	s.assertReq(func(r *request) {
 		e := newSignedRequest().setFormParams(params{
-			"symbol":           symbol,
-			"side":             side,
-			"type":             orderType,
-			"timeInForce":      timeInForce,
-			"positionSide":     positionSide,
-			"quantity":         quantity,
-			"reduceOnly":       reduceOnly,
-			"price":            price,
-			"newClientOrderId": newClientOrderID,
-			"stopPrice":        stopPrice,
-			"workingType":      workingType,
-			"activationPrice":  activationPrice,
-			"callbackRate":     callbackRate,
+			"symbol":               symbol,
+			"side":                 side,
+			"type":                 orderType,
+			"timeInForce":          timeInForce,
+			"positionSide":         positionSide,
+			"quantity":             quantity,
+			"reduceOnly":           reduceOnly,
+			"price":                price,
+			"newClientOrderId":     newClientOrderID,
+			"stopPrice":            stopPrice,
+			"workingType":          workingType,
+			"activationPrice":      activationPrice,
+			"callbackRate":         callbackRate,
+			"newOrderResponseType": NewOrderRespTypeRESULT,
 		})
 		s.assertRequestEqual(e, r)
 	})
@@ -76,7 +78,8 @@ func (s *orderServiceTestSuite) TestCreateOrder() {
 		Type(orderType).TimeInForce(timeInForce).Quantity(quantity).
 		ReduceOnly(reduceOnly).Price(price).NewClientOrderID(newClientOrderID).
 		StopPrice(stopPrice).WorkingType(workingType).ActivationPrice(activationPrice).
-		CallbackRate(callbackRate).PositionSide(positionSide).Do(newContext())
+		CallbackRate(callbackRate).PositionSide(positionSide).NewOrderResponseType(newOrderResponseType).
+		Do(newContext())
 	s.r().NoError(err)
 	e := &CreateOrderResponse{
 		ClientOrderID:    newClientOrderID,

--- a/futures/order_service_test.go
+++ b/futures/order_service_test.go
@@ -70,7 +70,7 @@ func (s *orderServiceTestSuite) TestCreateOrder() {
 			"workingType":          workingType,
 			"activationPrice":      activationPrice,
 			"callbackRate":         callbackRate,
-			"newOrderResponseType": NewOrderRespTypeRESULT,
+			"newOrderResponseType": newOrderResponseType,
 		})
 		s.assertRequestEqual(e, r)
 	})

--- a/futures/order_service_test.go
+++ b/futures/order_service_test.go
@@ -57,20 +57,20 @@ func (s *orderServiceTestSuite) TestCreateOrder() {
 	newOrderResponseType := NewOrderRespTypeRESULT
 	s.assertReq(func(r *request) {
 		e := newSignedRequest().setFormParams(params{
-			"symbol":               symbol,
-			"side":                 side,
-			"type":                 orderType,
-			"timeInForce":          timeInForce,
-			"positionSide":         positionSide,
-			"quantity":             quantity,
-			"reduceOnly":           reduceOnly,
-			"price":                price,
-			"newClientOrderId":     newClientOrderID,
-			"stopPrice":            stopPrice,
-			"workingType":          workingType,
-			"activationPrice":      activationPrice,
-			"callbackRate":         callbackRate,
-			"newOrderResponseType": newOrderResponseType,
+			"symbol":           symbol,
+			"side":             side,
+			"type":             orderType,
+			"timeInForce":      timeInForce,
+			"positionSide":     positionSide,
+			"quantity":         quantity,
+			"reduceOnly":       reduceOnly,
+			"price":            price,
+			"newClientOrderId": newClientOrderID,
+			"stopPrice":        stopPrice,
+			"workingType":      workingType,
+			"activationPrice":  activationPrice,
+			"callbackRate":     callbackRate,
+			"newOrderRespType": newOrderResponseType,
 		})
 		s.assertRequestEqual(e, r)
 	})

--- a/v2/futures/client.go
+++ b/v2/futures/client.go
@@ -78,7 +78,6 @@ const (
 
 	NewOrderRespTypeACK    NewOrderRespType = "ACK"
 	NewOrderRespTypeRESULT NewOrderRespType = "RESULT"
-	NewOrderRespTypeFULL   NewOrderRespType = "FULL"
 
 	OrderStatusTypeNew             OrderStatusType = "NEW"
 	OrderStatusTypePartiallyFilled OrderStatusType = "PARTIALLY_FILLED"

--- a/v2/futures/order_service.go
+++ b/v2/futures/order_service.go
@@ -115,11 +115,11 @@ func (s *CreateOrderService) createOrder(ctx context.Context, endpoint string, o
 		secType:  secTypeSigned,
 	}
 	m := params{
-		"symbol":               s.symbol,
-		"side":                 s.side,
-		"type":                 s.orderType,
-		"quantity":             s.quantity,
-		"newOrderResponseType": s.newOrderRespType,
+		"symbol":           s.symbol,
+		"side":             s.side,
+		"type":             s.orderType,
+		"quantity":         s.quantity,
+		"newOrderRespType": s.newOrderRespType,
 	}
 	if s.positionSide != nil {
 		m["positionSide"] = *s.positionSide

--- a/v2/futures/order_service.go
+++ b/v2/futures/order_service.go
@@ -21,6 +21,7 @@ type CreateOrderService struct {
 	workingType      *WorkingType
 	activationPrice  *string
 	callbackRate     *string
+	newOrderRespType NewOrderRespType
 }
 
 // Symbol set symbol
@@ -101,6 +102,12 @@ func (s *CreateOrderService) CallbackRate(callbackRate string) *CreateOrderServi
 	return s
 }
 
+// NewOrderResponseType set newOrderResponseType
+func (s *CreateOrderService) NewOrderResponseType(newOrderResponseType NewOrderRespType) *CreateOrderService {
+	s.newOrderRespType = newOrderResponseType
+	return s
+}
+
 func (s *CreateOrderService) createOrder(ctx context.Context, endpoint string, opts ...RequestOption) (data []byte, err error) {
 	r := &request{
 		method:   "POST",
@@ -108,10 +115,11 @@ func (s *CreateOrderService) createOrder(ctx context.Context, endpoint string, o
 		secType:  secTypeSigned,
 	}
 	m := params{
-		"symbol":   s.symbol,
-		"side":     s.side,
-		"type":     s.orderType,
-		"quantity": s.quantity,
+		"symbol":               s.symbol,
+		"side":                 s.side,
+		"type":                 s.orderType,
+		"quantity":             s.quantity,
+		"newOrderResponseType": s.newOrderRespType,
 	}
 	if s.positionSide != nil {
 		m["positionSide"] = *s.positionSide

--- a/v2/futures/order_service_test.go
+++ b/v2/futures/order_service_test.go
@@ -54,21 +54,23 @@ func (s *orderServiceTestSuite) TestCreateOrder() {
 	activationPrice := "1000"
 	callbackRate := "0.1"
 	workingType := WorkingTypeContractPrice
+	newOrderResponseType := NewOrderRespTypeRESULT
 	s.assertReq(func(r *request) {
 		e := newSignedRequest().setFormParams(params{
-			"symbol":           symbol,
-			"side":             side,
-			"type":             orderType,
-			"timeInForce":      timeInForce,
-			"positionSide":     positionSide,
-			"quantity":         quantity,
-			"reduceOnly":       reduceOnly,
-			"price":            price,
-			"newClientOrderId": newClientOrderID,
-			"stopPrice":        stopPrice,
-			"workingType":      workingType,
-			"activationPrice":  activationPrice,
-			"callbackRate":     callbackRate,
+			"symbol":               symbol,
+			"side":                 side,
+			"type":                 orderType,
+			"timeInForce":          timeInForce,
+			"positionSide":         positionSide,
+			"quantity":             quantity,
+			"reduceOnly":           reduceOnly,
+			"price":                price,
+			"newClientOrderId":     newClientOrderID,
+			"stopPrice":            stopPrice,
+			"workingType":          workingType,
+			"activationPrice":      activationPrice,
+			"callbackRate":         callbackRate,
+			"newOrderResponseType": NewOrderRespTypeRESULT,
 		})
 		s.assertRequestEqual(e, r)
 	})
@@ -76,7 +78,8 @@ func (s *orderServiceTestSuite) TestCreateOrder() {
 		Type(orderType).TimeInForce(timeInForce).Quantity(quantity).
 		ReduceOnly(reduceOnly).Price(price).NewClientOrderID(newClientOrderID).
 		StopPrice(stopPrice).WorkingType(workingType).ActivationPrice(activationPrice).
-		CallbackRate(callbackRate).PositionSide(positionSide).Do(newContext())
+		CallbackRate(callbackRate).PositionSide(positionSide).NewOrderResponseType(newOrderResponseType).
+		Do(newContext())
 	s.r().NoError(err)
 	e := &CreateOrderResponse{
 		ClientOrderID:    newClientOrderID,

--- a/v2/futures/order_service_test.go
+++ b/v2/futures/order_service_test.go
@@ -70,7 +70,7 @@ func (s *orderServiceTestSuite) TestCreateOrder() {
 			"workingType":          workingType,
 			"activationPrice":      activationPrice,
 			"callbackRate":         callbackRate,
-			"newOrderResponseType": NewOrderRespTypeRESULT,
+			"newOrderResponseType": newOrderResponseType,
 		})
 		s.assertRequestEqual(e, r)
 	})

--- a/v2/futures/order_service_test.go
+++ b/v2/futures/order_service_test.go
@@ -57,20 +57,20 @@ func (s *orderServiceTestSuite) TestCreateOrder() {
 	newOrderResponseType := NewOrderRespTypeRESULT
 	s.assertReq(func(r *request) {
 		e := newSignedRequest().setFormParams(params{
-			"symbol":               symbol,
-			"side":                 side,
-			"type":                 orderType,
-			"timeInForce":          timeInForce,
-			"positionSide":         positionSide,
-			"quantity":             quantity,
-			"reduceOnly":           reduceOnly,
-			"price":                price,
-			"newClientOrderId":     newClientOrderID,
-			"stopPrice":            stopPrice,
-			"workingType":          workingType,
-			"activationPrice":      activationPrice,
-			"callbackRate":         callbackRate,
-			"newOrderResponseType": newOrderResponseType,
+			"symbol":           symbol,
+			"side":             side,
+			"type":             orderType,
+			"timeInForce":      timeInForce,
+			"positionSide":     positionSide,
+			"quantity":         quantity,
+			"reduceOnly":       reduceOnly,
+			"price":            price,
+			"newClientOrderId": newClientOrderID,
+			"stopPrice":        stopPrice,
+			"workingType":      workingType,
+			"activationPrice":  activationPrice,
+			"callbackRate":     callbackRate,
+			"newOrderRespType": newOrderResponseType,
 		})
 		s.assertRequestEqual(e, r)
 	})


### PR DESCRIPTION
Adds a `NewOrderResponseType` method to the futures `CreateOrderService` struct in order to set the `newOrderResponseType` query parameter. Docs for endpoint and option here: https://binance-docs.github.io/apidocs/futures/en/#new-order-trade. Changing the `newOrderResponseType` does not actually change the type of the response so it is compatible with the current `CreateOrderResponse` type. 

The PR also removes the `NewOrderRespTypeFULL` variant of the `NewOrderRespType` enum from the futures package. This variant does not exist within the futures API. 