### PR TITLE
Add closePosition param to futures order service

### DIFF
--- a/futures/order_service.go
+++ b/futures/order_service.go
@@ -22,6 +22,7 @@ type CreateOrderService struct {
 	activationPrice  *string
 	callbackRate     *string
 	newOrderRespType NewOrderRespType
+	closePosition    *bool
 }
 
 // Symbol set symbol
@@ -108,6 +109,12 @@ func (s *CreateOrderService) NewOrderResponseType(newOrderResponseType NewOrderR
 	return s
 }
 
+// ClosePosition set closePosition
+func (s *CreateOrderService) ClosePosition(closePosition bool) *CreateOrderService {
+	s.closePosition = &closePosition
+	return s
+}
+
 func (s *CreateOrderService) createOrder(ctx context.Context, endpoint string, opts ...RequestOption) (data []byte, err error) {
 	r := &request{
 		method:   "POST",
@@ -147,6 +154,9 @@ func (s *CreateOrderService) createOrder(ctx context.Context, endpoint string, o
 	}
 	if s.callbackRate != nil {
 		m["callbackRate"] = *s.callbackRate
+	}
+	if s.closePosition != nil {
+		m["closePosition"] = *s.closePosition
 	}
 	r.setFormParams(m)
 	data, err = s.c.callAPI(ctx, r, opts...)
@@ -191,6 +201,7 @@ type CreateOrderResponse struct {
 	PriceRate        string           `json:"priceRate"`
 	AvgPrice         string           `json:"avgPrice"`
 	PositionSide     PositionSideType `json:"positionSide"`
+	ClosePosition    bool             `json:"closePosition"`
 }
 
 // ListOpenOrdersService list opened orders

--- a/futures/order_service_test.go
+++ b/futures/order_service_test.go
@@ -37,7 +37,8 @@ func (s *orderServiceTestSuite) TestCreateOrder() {
 		"workingType": "CONTRACT_PRICE",
 		"activatePrice": "1000",
 		"priceRate": "0.1",
-		"positionSide": "BOTH"
+		"positionSide": "BOTH",
+		"closePosition": false
 	}`)
 	s.mockDo(data, nil)
 	defer s.assertDo()
@@ -55,6 +56,7 @@ func (s *orderServiceTestSuite) TestCreateOrder() {
 	callbackRate := "0.1"
 	workingType := WorkingTypeContractPrice
 	newOrderResponseType := NewOrderRespTypeRESULT
+	closePosition := false
 	s.assertReq(func(r *request) {
 		e := newSignedRequest().setFormParams(params{
 			"symbol":           symbol,
@@ -71,11 +73,12 @@ func (s *orderServiceTestSuite) TestCreateOrder() {
 			"activationPrice":  activationPrice,
 			"callbackRate":     callbackRate,
 			"newOrderRespType": newOrderResponseType,
+			"closePosition":    closePosition,
 		})
 		s.assertRequestEqual(e, r)
 	})
 	res, err := s.client.NewCreateOrderService().Symbol(symbol).Side(side).
-		Type(orderType).TimeInForce(timeInForce).Quantity(quantity).
+		Type(orderType).TimeInForce(timeInForce).Quantity(quantity).ClosePosition(closePosition).
 		ReduceOnly(reduceOnly).Price(price).NewClientOrderID(newClientOrderID).
 		StopPrice(stopPrice).WorkingType(workingType).ActivationPrice(activationPrice).
 		CallbackRate(callbackRate).PositionSide(positionSide).NewOrderResponseType(newOrderResponseType).
@@ -100,6 +103,7 @@ func (s *orderServiceTestSuite) TestCreateOrder() {
 		WorkingType:      WorkingTypeContractPrice,
 		ActivatePrice:    activationPrice,
 		PriceRate:        callbackRate,
+		ClosePosition:    false,
 	}
 	s.assertCreateOrderResponseEqual(e, res)
 }
@@ -124,6 +128,7 @@ func (s *baseOrderTestSuite) assertCreateOrderResponseEqual(e, a *CreateOrderRes
 	r.Equal(e.WorkingType, a.WorkingType, "WorkingType")
 	r.Equal(e.ActivatePrice, a.ActivatePrice, "ActivatePrice")
 	r.Equal(e.PriceRate, a.PriceRate, "PriceRate")
+	r.Equal(e.ClosePosition, a.ClosePosition, "ClosePosition")
 }
 
 func (s *orderServiceTestSuite) TestListOpenOrders() {

--- a/v2/futures/order_service.go
+++ b/v2/futures/order_service.go
@@ -22,6 +22,7 @@ type CreateOrderService struct {
 	activationPrice  *string
 	callbackRate     *string
 	newOrderRespType NewOrderRespType
+	closePosition    *bool
 }
 
 // Symbol set symbol
@@ -108,6 +109,12 @@ func (s *CreateOrderService) NewOrderResponseType(newOrderResponseType NewOrderR
 	return s
 }
 
+// ClosePosition set closePosition
+func (s *CreateOrderService) ClosePosition(closePosition bool) *CreateOrderService {
+	s.closePosition = &closePosition
+	return s
+}
+
 func (s *CreateOrderService) createOrder(ctx context.Context, endpoint string, opts ...RequestOption) (data []byte, err error) {
 	r := &request{
 		method:   "POST",
@@ -147,6 +154,9 @@ func (s *CreateOrderService) createOrder(ctx context.Context, endpoint string, o
 	}
 	if s.callbackRate != nil {
 		m["callbackRate"] = *s.callbackRate
+	}
+	if s.closePosition != nil {
+		m["closePosition"] = *s.closePosition
 	}
 	r.setFormParams(m)
 	data, err = s.c.callAPI(ctx, r, opts...)
@@ -191,6 +201,7 @@ type CreateOrderResponse struct {
 	PriceRate        string           `json:"priceRate"`
 	AvgPrice         string           `json:"avgPrice"`
 	PositionSide     PositionSideType `json:"positionSide"`
+	ClosePosition    bool             `json:"closePosition"`
 }
 
 // ListOpenOrdersService list opened orders

--- a/v2/futures/order_service_test.go
+++ b/v2/futures/order_service_test.go
@@ -37,7 +37,8 @@ func (s *orderServiceTestSuite) TestCreateOrder() {
 		"workingType": "CONTRACT_PRICE",
 		"activatePrice": "1000",
 		"priceRate": "0.1",
-		"positionSide": "BOTH"
+		"positionSide": "BOTH",
+		"closePosition": false
 	}`)
 	s.mockDo(data, nil)
 	defer s.assertDo()
@@ -55,6 +56,7 @@ func (s *orderServiceTestSuite) TestCreateOrder() {
 	callbackRate := "0.1"
 	workingType := WorkingTypeContractPrice
 	newOrderResponseType := NewOrderRespTypeRESULT
+	closePosition := false
 	s.assertReq(func(r *request) {
 		e := newSignedRequest().setFormParams(params{
 			"symbol":           symbol,
@@ -71,11 +73,12 @@ func (s *orderServiceTestSuite) TestCreateOrder() {
 			"activationPrice":  activationPrice,
 			"callbackRate":     callbackRate,
 			"newOrderRespType": newOrderResponseType,
+			"closePosition":    closePosition,
 		})
 		s.assertRequestEqual(e, r)
 	})
 	res, err := s.client.NewCreateOrderService().Symbol(symbol).Side(side).
-		Type(orderType).TimeInForce(timeInForce).Quantity(quantity).
+		Type(orderType).TimeInForce(timeInForce).Quantity(quantity).ClosePosition(closePosition).
 		ReduceOnly(reduceOnly).Price(price).NewClientOrderID(newClientOrderID).
 		StopPrice(stopPrice).WorkingType(workingType).ActivationPrice(activationPrice).
 		CallbackRate(callbackRate).PositionSide(positionSide).NewOrderResponseType(newOrderResponseType).
@@ -100,6 +103,7 @@ func (s *orderServiceTestSuite) TestCreateOrder() {
 		WorkingType:      WorkingTypeContractPrice,
 		ActivatePrice:    activationPrice,
 		PriceRate:        callbackRate,
+		ClosePosition:    false,
 	}
 	s.assertCreateOrderResponseEqual(e, res)
 }
@@ -124,6 +128,7 @@ func (s *baseOrderTestSuite) assertCreateOrderResponseEqual(e, a *CreateOrderRes
 	r.Equal(e.WorkingType, a.WorkingType, "WorkingType")
 	r.Equal(e.ActivatePrice, a.ActivatePrice, "ActivatePrice")
 	r.Equal(e.PriceRate, a.PriceRate, "PriceRate")
+	r.Equal(e.ClosePosition, a.ClosePosition, "ClosePosition")
 }
 
 func (s *orderServiceTestSuite) TestListOpenOrders() {


### PR DESCRIPTION
Adds closePosition param to futures order service. Documentation here: https://binance-docs.github.io/apidocs/futures/en/#new-order-trade