### PR TITLE
Add AccountTradeListService

### DIFF
--- a/futures/client.go
+++ b/futures/client.go
@@ -376,9 +376,9 @@ func (c *Client) NewHistoricalTradesService() *HistoricalTradesService {
 	return &HistoricalTradesService{c: c}
 }
 
-// NewAccountTradeListService init account trade list service
-func (c *Client) NewAccountTradeListService() *AccountTradeListService {
-	return &AccountTradeListService{c: c}
+// NewListAccountTradeService init account trade list service
+func (c *Client) NewListAccountTradeService() *ListAccountTradeService {
+	return &ListAccountTradeService{c: c}
 }
 
 // NewStartUserStreamService init starting user stream service

--- a/futures/client.go
+++ b/futures/client.go
@@ -376,6 +376,11 @@ func (c *Client) NewHistoricalTradesService() *HistoricalTradesService {
 	return &HistoricalTradesService{c: c}
 }
 
+// NewAccountTradeListService init account trade list service
+func (c *Client) NewAccountTradeListService() *AccountTradeListService {
+	return &AccountTradeListService{c: c}
+}
+
 // NewStartUserStreamService init starting user stream service
 func (c *Client) NewStartUserStreamService() *StartUserStreamService {
 	return &StartUserStreamService{c: c}
@@ -431,12 +436,12 @@ func (c *Client) NewUpdatePositionMarginService() *UpdatePositionMarginService {
 	return &UpdatePositionMarginService{c: c}
 }
 
-// ChangePositionModeService init change position mode service
+// NewChangePositionModeService init change position mode service
 func (c *Client) NewChangePositionModeService() *ChangePositionModeService {
 	return &ChangePositionModeService{c: c}
 }
 
-// GetPositionModeService init get position mode service
+// NewGetPositionModeService init get position mode service
 func (c *Client) NewGetPositionModeService() *GetPositionModeService {
 	return &GetPositionModeService{c: c}
 }

--- a/futures/trade_service.go
+++ b/futures/trade_service.go
@@ -206,3 +206,92 @@ func (s *RecentTradesService) Do(ctx context.Context, opts ...RequestOption) (re
 	}
 	return res, nil
 }
+
+// AccountTradeListService define account trade list service
+type AccountTradeListService struct {
+	c         *Client
+	symbol    string
+	startTime *int64
+	endTime   *int64
+	fromID    *int64
+	limit     *int
+}
+
+// Symbol set symbol
+func (s *AccountTradeListService) Symbol(symbol string) *AccountTradeListService {
+	s.symbol = symbol
+	return s
+}
+
+// StartTime set startTime
+func (s *AccountTradeListService) StartTime(startTime int64) *AccountTradeListService {
+	s.startTime = &startTime
+	return s
+}
+
+// EndTime set endTime
+func (s *AccountTradeListService) EndTime(endTime int64) *AccountTradeListService {
+	s.endTime = &endTime
+	return s
+}
+
+// FromID set fromID
+func (s *AccountTradeListService) FromID(fromID int64) *AccountTradeListService {
+	s.fromID = &fromID
+	return s
+}
+
+// Limit set limit
+func (s *AccountTradeListService) Limit(limit int) *AccountTradeListService {
+	s.limit = &limit
+	return s
+}
+
+// Do send request
+func (s *AccountTradeListService) Do(ctx context.Context, opts ...RequestOption) (res []*AccountTrade, err error) {
+	r := &request{
+		method:   "GET",
+		endpoint: "/fapi/v1/userTrades",
+	}
+	r.setParam("symbol", s.symbol)
+	if s.startTime != nil {
+		r.setParam("startTime", *s.startTime)
+	}
+	if s.endTime != nil {
+		r.setParam("endTime", *s.endTime)
+	}
+	if s.fromID != nil {
+		r.setParam("fromID", *s.fromID)
+	}
+	if s.limit != nil {
+		r.setParam("limit", *s.limit)
+	}
+	data, err := s.c.callAPI(ctx, r, opts...)
+	if err != nil {
+		return []*AccountTrade{}, err
+	}
+	res = make([]*AccountTrade, 0)
+	err = json.Unmarshal(data, &res)
+	if err != nil {
+		return []*AccountTrade{}, err
+	}
+	return res, nil
+}
+
+// AccountTrade define account trade
+type AccountTrade struct {
+	Buyer           bool             `json:"buyer"`
+	Commission      string           `json:"commission"`
+	CommissionAsset string           `json:"commissionAsset"`
+	ID              int64            `json:"id"`
+	Maker           bool             `json:"maker"`
+	OrderID         int64            `json:"orderId"`
+	Price           string           `json:"price"`
+	Quantity        string           `json:"qty"`
+	QuoteQuantity   string           `json:"quoteQty"`
+	RealizedPnl     string           `json:"realizedPnl"`
+	Side            SideType         `json:"side"`
+	PositionSide    PositionSideType `json:"positionSide"`
+	Symbol          string           `json:"symbol"`
+	Time            int64            `json:"time"`
+}

--- a/futures/trade_service.go
+++ b/futures/trade_service.go
@@ -207,8 +207,8 @@ func (s *RecentTradesService) Do(ctx context.Context, opts ...RequestOption) (re
 	return res, nil
 }
 
-// AccountTradeListService define account trade list service
-type AccountTradeListService struct {
+// ListAccountTradeService define account trade list service
+type ListAccountTradeService struct {
 	c         *Client
 	symbol    string
 	startTime *int64
@@ -218,37 +218,37 @@ type AccountTradeListService struct {
 }
 
 // Symbol set symbol
-func (s *AccountTradeListService) Symbol(symbol string) *AccountTradeListService {
+func (s *ListAccountTradeService) Symbol(symbol string) *ListAccountTradeService {
 	s.symbol = symbol
 	return s
 }
 
 // StartTime set startTime
-func (s *AccountTradeListService) StartTime(startTime int64) *AccountTradeListService {
+func (s *ListAccountTradeService) StartTime(startTime int64) *ListAccountTradeService {
 	s.startTime = &startTime
 	return s
 }
 
 // EndTime set endTime
-func (s *AccountTradeListService) EndTime(endTime int64) *AccountTradeListService {
+func (s *ListAccountTradeService) EndTime(endTime int64) *ListAccountTradeService {
 	s.endTime = &endTime
 	return s
 }
 
 // FromID set fromID
-func (s *AccountTradeListService) FromID(fromID int64) *AccountTradeListService {
+func (s *ListAccountTradeService) FromID(fromID int64) *ListAccountTradeService {
 	s.fromID = &fromID
 	return s
 }
 
 // Limit set limit
-func (s *AccountTradeListService) Limit(limit int) *AccountTradeListService {
+func (s *ListAccountTradeService) Limit(limit int) *ListAccountTradeService {
 	s.limit = &limit
 	return s
 }
 
 // Do send request
-func (s *AccountTradeListService) Do(ctx context.Context, opts ...RequestOption) (res []*AccountTrade, err error) {
+func (s *ListAccountTradeService) Do(ctx context.Context, opts ...RequestOption) (res []*AccountTrade, err error) {
 	r := &request{
 		method:   "GET",
 		endpoint: "/fapi/v1/userTrades",

--- a/futures/trade_service.go
+++ b/futures/trade_service.go
@@ -252,6 +252,7 @@ func (s *AccountTradeListService) Do(ctx context.Context, opts ...RequestOption)
 	r := &request{
 		method:   "GET",
 		endpoint: "/fapi/v1/userTrades",
+		secType:  secTypeSigned,
 	}
 	r.setParam("symbol", s.symbol)
 	if s.startTime != nil {

--- a/futures/trade_service_test.go
+++ b/futures/trade_service_test.go
@@ -164,3 +164,83 @@ func (s *tradeServiceTestSuite) assertTradeEqual(e, a *Trade) {
 	r.Equal(e.Time, a.Time, "Time")
 	r.Equal(e.IsBuyerMaker, a.IsBuyerMaker, "IsBuyerMaker")
 }
+
+func (s *tradeServiceTestSuite) TestAccountTradeList() {
+	data := []byte(`[
+		{
+			"buyer": false,
+			"commission": "-0.07819010",
+			"commissionAsset": "USDT",
+			"id": 698759,
+			"maker": false,
+			"orderId": 25851813,
+			"price": "7819.01",
+			"qty": "0.002",
+			"quoteQty": "15.63802",
+			"realizedPnl": "-0.91539999",
+			"side": "SELL",
+			"positionSide": "SHORT",
+			"symbol": "BTCUSDT",
+			"time": 1569514978020
+		}
+	]`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	symbol := "BTCUSDT"
+	startTime := int64(1569514978020)
+	endTime := int64(1569514978021)
+	fromID := int64(698759)
+	limit := 3
+	s.assertReq(func(r *request) {
+		e := newRequest().setParams(params{
+			"symbol":    symbol,
+			"startTime": startTime,
+			"endTime":   endTime,
+			"fromID":    fromID,
+			"limit":     limit,
+		})
+		s.assertRequestEqual(e, r)
+	})
+
+	trades, err := s.client.NewAccountTradeListService().Symbol(symbol).
+		StartTime(startTime).EndTime(endTime).FromID(fromID).Limit(limit).Do(newContext())
+	r := s.r()
+	r.NoError(err)
+	r.Len(trades, 1)
+	e := &AccountTrade{
+		Buyer:           false,
+		Commission:      "-0.07819010",
+		CommissionAsset: "USDT",
+		ID:              698759,
+		Maker:           false,
+		OrderID:         25851813,
+		Price:           "7819.01",
+		Quantity:        "0.002",
+		QuoteQuantity:   "15.63802",
+		RealizedPnl:     "-0.91539999",
+		Side:            SideTypeSell,
+		PositionSide:    PositionSideTypeShort,
+		Symbol:          symbol,
+		Time:            1569514978020,
+	}
+	s.assertAccountTradeEqual(e, trades[0])
+}
+
+func (s *tradeServiceTestSuite) assertAccountTradeEqual(e, a *AccountTrade) {
+	r := s.r()
+	r.Equal(e.ID, a.ID, "ID")
+	r.Equal(e.Buyer, a.Buyer, "Buyer")
+	r.Equal(e.Commission, a.Commission, "Commission")
+	r.Equal(e.CommissionAsset, a.CommissionAsset, "CommissionAsset")
+	r.Equal(e.Maker, a.Maker, "Maker")
+	r.Equal(e.OrderID, a.OrderID, "OrderID")
+	r.Equal(e.Price, a.Price, "Price")
+	r.Equal(e.Quantity, a.Quantity, "Quantity")
+	r.Equal(e.QuoteQuantity, a.QuoteQuantity, "QuoteQuantity")
+	r.Equal(e.RealizedPnl, a.RealizedPnl, "RealizedPnl")
+	r.Equal(e.Side, a.Side, "Side")
+	r.Equal(e.PositionSide, a.PositionSide, "PositionSide")
+	r.Equal(e.Symbol, a.Symbol, "Symbol")
+	r.Equal(e.Time, a.Time, "Time")
+}

--- a/futures/trade_service_test.go
+++ b/futures/trade_service_test.go
@@ -203,7 +203,7 @@ func (s *tradeServiceTestSuite) TestAccountTradeList() {
 		s.assertRequestEqual(e, r)
 	})
 
-	trades, err := s.client.NewAccountTradeListService().Symbol(symbol).
+	trades, err := s.client.NewListAccountTradeService().Symbol(symbol).
 		StartTime(startTime).EndTime(endTime).FromID(fromID).Limit(limit).Do(newContext())
 	r := s.r()
 	r.NoError(err)

--- a/futures/trade_service_test.go
+++ b/futures/trade_service_test.go
@@ -193,7 +193,7 @@ func (s *tradeServiceTestSuite) TestAccountTradeList() {
 	fromID := int64(698759)
 	limit := 3
 	s.assertReq(func(r *request) {
-		e := newRequest().setParams(params{
+		e := newSignedRequest().setParams(params{
 			"symbol":    symbol,
 			"startTime": startTime,
 			"endTime":   endTime,

--- a/v2/futures/client.go
+++ b/v2/futures/client.go
@@ -376,9 +376,9 @@ func (c *Client) NewHistoricalTradesService() *HistoricalTradesService {
 	return &HistoricalTradesService{c: c}
 }
 
-// NewAccountTradeListService init account trade list service
-func (c *Client) NewAccountTradeListService() *AccountTradeListService {
-	return &AccountTradeListService{c: c}
+// NewListAccountTradeService init account trade list service
+func (c *Client) NewListAccountTradeService() *ListAccountTradeService {
+	return &ListAccountTradeService{c: c}
 }
 
 // NewStartUserStreamService init starting user stream service

--- a/v2/futures/client.go
+++ b/v2/futures/client.go
@@ -376,6 +376,11 @@ func (c *Client) NewHistoricalTradesService() *HistoricalTradesService {
 	return &HistoricalTradesService{c: c}
 }
 
+// NewAccountTradeListService init account trade list service
+func (c *Client) NewAccountTradeListService() *AccountTradeListService {
+	return &AccountTradeListService{c: c}
+}
+
 // NewStartUserStreamService init starting user stream service
 func (c *Client) NewStartUserStreamService() *StartUserStreamService {
 	return &StartUserStreamService{c: c}
@@ -431,12 +436,12 @@ func (c *Client) NewUpdatePositionMarginService() *UpdatePositionMarginService {
 	return &UpdatePositionMarginService{c: c}
 }
 
-// ChangePositionModeService init change position mode service
+// NewChangePositionModeService init change position mode service
 func (c *Client) NewChangePositionModeService() *ChangePositionModeService {
 	return &ChangePositionModeService{c: c}
 }
 
-// GetPositionModeService init get position mode service
+// NewGetPositionModeService init get position mode service
 func (c *Client) NewGetPositionModeService() *GetPositionModeService {
 	return &GetPositionModeService{c: c}
 }

--- a/v2/futures/trade_service.go
+++ b/v2/futures/trade_service.go
@@ -206,3 +206,92 @@ func (s *RecentTradesService) Do(ctx context.Context, opts ...RequestOption) (re
 	}
 	return res, nil
 }
+
+// AccountTradeListService define account trade list service
+type AccountTradeListService struct {
+	c         *Client
+	symbol    string
+	startTime *int64
+	endTime   *int64
+	fromID    *int64
+	limit     *int
+}
+
+// Symbol set symbol
+func (s *AccountTradeListService) Symbol(symbol string) *AccountTradeListService {
+	s.symbol = symbol
+	return s
+}
+
+// StartTime set startTime
+func (s *AccountTradeListService) StartTime(startTime int64) *AccountTradeListService {
+	s.startTime = &startTime
+	return s
+}
+
+// EndTime set endTime
+func (s *AccountTradeListService) EndTime(endTime int64) *AccountTradeListService {
+	s.endTime = &endTime
+	return s
+}
+
+// FromID set fromID
+func (s *AccountTradeListService) FromID(fromID int64) *AccountTradeListService {
+	s.fromID = &fromID
+	return s
+}
+
+// Limit set limit
+func (s *AccountTradeListService) Limit(limit int) *AccountTradeListService {
+	s.limit = &limit
+	return s
+}
+
+// Do send request
+func (s *AccountTradeListService) Do(ctx context.Context, opts ...RequestOption) (res []*AccountTrade, err error) {
+	r := &request{
+		method:   "GET",
+		endpoint: "/fapi/v1/userTrades",
+	}
+	r.setParam("symbol", s.symbol)
+	if s.startTime != nil {
+		r.setParam("startTime", *s.startTime)
+	}
+	if s.endTime != nil {
+		r.setParam("endTime", *s.endTime)
+	}
+	if s.fromID != nil {
+		r.setParam("fromID", *s.fromID)
+	}
+	if s.limit != nil {
+		r.setParam("limit", *s.limit)
+	}
+	data, err := s.c.callAPI(ctx, r, opts...)
+	if err != nil {
+		return []*AccountTrade{}, err
+	}
+	res = make([]*AccountTrade, 0)
+	err = json.Unmarshal(data, &res)
+	if err != nil {
+		return []*AccountTrade{}, err
+	}
+	return res, nil
+}
+
+// AccountTrade define account trade
+type AccountTrade struct {
+	Buyer           bool             `json:"buyer"`
+	Commission      string           `json:"commission"`
+	CommissionAsset string           `json:"commissionAsset"`
+	ID              int64            `json:"id"`
+	Maker           bool             `json:"maker"`
+	OrderID         int64            `json:"orderId"`
+	Price           string           `json:"price"`
+	Quantity        string           `json:"qty"`
+	QuoteQuantity   string           `json:"quoteQty"`
+	RealizedPnl     string           `json:"realizedPnl"`
+	Side            SideType         `json:"side"`
+	PositionSide    PositionSideType `json:"positionSide"`
+	Symbol          string           `json:"symbol"`
+	Time            int64            `json:"time"`
+}

--- a/v2/futures/trade_service.go
+++ b/v2/futures/trade_service.go
@@ -207,8 +207,8 @@ func (s *RecentTradesService) Do(ctx context.Context, opts ...RequestOption) (re
 	return res, nil
 }
 
-// AccountTradeListService define account trade list service
-type AccountTradeListService struct {
+// ListAccountTradeService define account trade list service
+type ListAccountTradeService struct {
 	c         *Client
 	symbol    string
 	startTime *int64
@@ -218,37 +218,37 @@ type AccountTradeListService struct {
 }
 
 // Symbol set symbol
-func (s *AccountTradeListService) Symbol(symbol string) *AccountTradeListService {
+func (s *ListAccountTradeService) Symbol(symbol string) *ListAccountTradeService {
 	s.symbol = symbol
 	return s
 }
 
 // StartTime set startTime
-func (s *AccountTradeListService) StartTime(startTime int64) *AccountTradeListService {
+func (s *ListAccountTradeService) StartTime(startTime int64) *ListAccountTradeService {
 	s.startTime = &startTime
 	return s
 }
 
 // EndTime set endTime
-func (s *AccountTradeListService) EndTime(endTime int64) *AccountTradeListService {
+func (s *ListAccountTradeService) EndTime(endTime int64) *ListAccountTradeService {
 	s.endTime = &endTime
 	return s
 }
 
 // FromID set fromID
-func (s *AccountTradeListService) FromID(fromID int64) *AccountTradeListService {
+func (s *ListAccountTradeService) FromID(fromID int64) *ListAccountTradeService {
 	s.fromID = &fromID
 	return s
 }
 
 // Limit set limit
-func (s *AccountTradeListService) Limit(limit int) *AccountTradeListService {
+func (s *ListAccountTradeService) Limit(limit int) *ListAccountTradeService {
 	s.limit = &limit
 	return s
 }
 
 // Do send request
-func (s *AccountTradeListService) Do(ctx context.Context, opts ...RequestOption) (res []*AccountTrade, err error) {
+func (s *ListAccountTradeService) Do(ctx context.Context, opts ...RequestOption) (res []*AccountTrade, err error) {
 	r := &request{
 		method:   "GET",
 		endpoint: "/fapi/v1/userTrades",

--- a/v2/futures/trade_service.go
+++ b/v2/futures/trade_service.go
@@ -252,6 +252,7 @@ func (s *AccountTradeListService) Do(ctx context.Context, opts ...RequestOption)
 	r := &request{
 		method:   "GET",
 		endpoint: "/fapi/v1/userTrades",
+		secType:  secTypeSigned,
 	}
 	r.setParam("symbol", s.symbol)
 	if s.startTime != nil {

--- a/v2/futures/trade_service_test.go
+++ b/v2/futures/trade_service_test.go
@@ -164,3 +164,83 @@ func (s *tradeServiceTestSuite) assertTradeEqual(e, a *Trade) {
 	r.Equal(e.Time, a.Time, "Time")
 	r.Equal(e.IsBuyerMaker, a.IsBuyerMaker, "IsBuyerMaker")
 }
+
+func (s *tradeServiceTestSuite) TestAccountTradeList() {
+	data := []byte(`[
+		{
+			"buyer": false,
+			"commission": "-0.07819010",
+			"commissionAsset": "USDT",
+			"id": 698759,
+			"maker": false,
+			"orderId": 25851813,
+			"price": "7819.01",
+			"qty": "0.002",
+			"quoteQty": "15.63802",
+			"realizedPnl": "-0.91539999",
+			"side": "SELL",
+			"positionSide": "SHORT",
+			"symbol": "BTCUSDT",
+			"time": 1569514978020
+		}
+	]`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	symbol := "BTCUSDT"
+	startTime := int64(1569514978020)
+	endTime := int64(1569514978021)
+	fromID := int64(698759)
+	limit := 3
+	s.assertReq(func(r *request) {
+		e := newRequest().setParams(params{
+			"symbol":    symbol,
+			"startTime": startTime,
+			"endTime":   endTime,
+			"fromID":    fromID,
+			"limit":     limit,
+		})
+		s.assertRequestEqual(e, r)
+	})
+
+	trades, err := s.client.NewAccountTradeListService().Symbol(symbol).
+		StartTime(startTime).EndTime(endTime).FromID(fromID).Limit(limit).Do(newContext())
+	r := s.r()
+	r.NoError(err)
+	r.Len(trades, 1)
+	e := &AccountTrade{
+		Buyer:           false,
+		Commission:      "-0.07819010",
+		CommissionAsset: "USDT",
+		ID:              698759,
+		Maker:           false,
+		OrderID:         25851813,
+		Price:           "7819.01",
+		Quantity:        "0.002",
+		QuoteQuantity:   "15.63802",
+		RealizedPnl:     "-0.91539999",
+		Side:            SideTypeSell,
+		PositionSide:    PositionSideTypeShort,
+		Symbol:          symbol,
+		Time:            1569514978020,
+	}
+	s.assertAccountTradeEqual(e, trades[0])
+}
+
+func (s *tradeServiceTestSuite) assertAccountTradeEqual(e, a *AccountTrade) {
+	r := s.r()
+	r.Equal(e.ID, a.ID, "ID")
+	r.Equal(e.Buyer, a.Buyer, "Buyer")
+	r.Equal(e.Commission, a.Commission, "Commission")
+	r.Equal(e.CommissionAsset, a.CommissionAsset, "CommissionAsset")
+	r.Equal(e.Maker, a.Maker, "Maker")
+	r.Equal(e.OrderID, a.OrderID, "OrderID")
+	r.Equal(e.Price, a.Price, "Price")
+	r.Equal(e.Quantity, a.Quantity, "Quantity")
+	r.Equal(e.QuoteQuantity, a.QuoteQuantity, "QuoteQuantity")
+	r.Equal(e.RealizedPnl, a.RealizedPnl, "RealizedPnl")
+	r.Equal(e.Side, a.Side, "Side")
+	r.Equal(e.PositionSide, a.PositionSide, "PositionSide")
+	r.Equal(e.Symbol, a.Symbol, "Symbol")
+	r.Equal(e.Time, a.Time, "Time")
+}

--- a/v2/futures/trade_service_test.go
+++ b/v2/futures/trade_service_test.go
@@ -203,7 +203,7 @@ func (s *tradeServiceTestSuite) TestAccountTradeList() {
 		s.assertRequestEqual(e, r)
 	})
 
-	trades, err := s.client.NewAccountTradeListService().Symbol(symbol).
+	trades, err := s.client.NewListAccountTradeService().Symbol(symbol).
 		StartTime(startTime).EndTime(endTime).FromID(fromID).Limit(limit).Do(newContext())
 	r := s.r()
 	r.NoError(err)

--- a/v2/futures/trade_service_test.go
+++ b/v2/futures/trade_service_test.go
@@ -193,7 +193,7 @@ func (s *tradeServiceTestSuite) TestAccountTradeList() {
 	fromID := int64(698759)
 	limit := 3
 	s.assertReq(func(r *request) {
-		e := newRequest().setParams(params{
+		e := newSignedRequest().setParams(params{
 			"symbol":    symbol,
 			"startTime": startTime,
 			"endTime":   endTime,


### PR DESCRIPTION
Adds service `ListAccountTradeService` for the futures account trade list endpoint: https://binance-docs.github.io/apidocs/futures/en/#account-trade-list-user_data