### PR TITLE
Add TranId and TradeID to IncomeHistory

### DIFF
--- a/futures/income_history.go
+++ b/futures/income_history.go
@@ -86,4 +86,6 @@ type IncomeHistory struct {
 	Info       string `json:"info"`
 	Symbol     string `json:"symbol"`
 	Time       int64  `json:"time"`
+	TranID     string `json:"tranId"`
+	TradeID    string `json:"tradeId"`
 }

--- a/futures/income_history_test.go
+++ b/futures/income_history_test.go
@@ -26,7 +26,9 @@ func (s *incomeHistoryServiceTestSuite) TestIncomeHistory() {
 			"income": "-0.01000000",
 			"asset": "USDT",
 			"info":"",  
-			"time": 1570636800000
+			"time": 1570636800000,
+			"tranId":"9689322392",
+			"tradeId":"2059192"
 		}
 	]`)
 	s.mockDo(data, nil)
@@ -53,6 +55,8 @@ func (s *incomeHistoryServiceTestSuite) TestIncomeHistory() {
 		Symbol:     "BTCUSDT",
 		Time:       1578047897183,
 		IncomeType: "COMMISSION",
+		TranID:     "9689322392",
+		TradeID:    "2059192",
 	}
 	s.assertOrderEqual(e, orders[0])
 }
@@ -65,4 +69,6 @@ func (s *incomeHistoryServiceTestSuite) assertOrderEqual(e, a *IncomeHistory) {
 	r.Equal(e.Symbol, a.Symbol, "Symbol")
 	r.Equal(e.Time, e.Time, "Time")
 	r.Equal(e.IncomeType, a.IncomeType, "IncomeType")
+	r.Equal(e.TranID, a.TranID, "TranID")
+	r.Equal(e.TradeID, a.TradeID, "TradeID")
 }

--- a/v2/futures/income_history.go
+++ b/v2/futures/income_history.go
@@ -86,4 +86,6 @@ type IncomeHistory struct {
 	Info       string `json:"info"`
 	Symbol     string `json:"symbol"`
 	Time       int64  `json:"time"`
+	TranID     string `json:"tranId"`
+	TradeID    string `json:"tradeId"`
 }

--- a/v2/futures/income_history_test.go
+++ b/v2/futures/income_history_test.go
@@ -26,7 +26,9 @@ func (s *incomeHistoryServiceTestSuite) TestIncomeHistory() {
 			"income": "-0.01000000",
 			"asset": "USDT",
 			"info":"",  
-			"time": 1570636800000
+			"time": 1570636800000,
+			"tranId":"9689322392",
+			"tradeId":"2059192"
 		}
 	]`)
 	s.mockDo(data, nil)
@@ -53,6 +55,8 @@ func (s *incomeHistoryServiceTestSuite) TestIncomeHistory() {
 		Symbol:     "BTCUSDT",
 		Time:       1578047897183,
 		IncomeType: "COMMISSION",
+		TranID:     "9689322392",
+		TradeID:    "2059192",
 	}
 	s.assertOrderEqual(e, orders[0])
 }
@@ -65,4 +69,6 @@ func (s *incomeHistoryServiceTestSuite) assertOrderEqual(e, a *IncomeHistory) {
 	r.Equal(e.Symbol, a.Symbol, "Symbol")
 	r.Equal(e.Time, e.Time, "Time")
 	r.Equal(e.IncomeType, a.IncomeType, "IncomeType")
+	r.Equal(e.TranID, a.TranID, "TranID")
+	r.Equal(e.TradeID, a.TradeID, "TradeID")
 }


### PR DESCRIPTION
Adds fields TranID and TradeID to the futures IncomeHistory type. Relevant JSON schema definition here: https://binance-docs.github.io/apidocs/futures/en/#get-income-history-user_data