### PR TITLE
Fix TranID type on IncomeHistory

### DIFF
--- a/futures/income_history.go
+++ b/futures/income_history.go
@@ -86,6 +86,6 @@ type IncomeHistory struct {
 	Info       string `json:"info"`
 	Symbol     string `json:"symbol"`
 	Time       int64  `json:"time"`
-	TranID     string `json:"tranId"`
+	TranID     int64  `json:"tranId"`
 	TradeID    string `json:"tradeId"`
 }

--- a/futures/income_history_test.go
+++ b/futures/income_history_test.go
@@ -27,7 +27,7 @@ func (s *incomeHistoryServiceTestSuite) TestIncomeHistory() {
 			"asset": "USDT",
 			"info":"",  
 			"time": 1570636800000,
-			"tranId":"9689322392",
+			"tranId":9689322392,
 			"tradeId":"2059192"
 		}
 	]`)
@@ -55,7 +55,7 @@ func (s *incomeHistoryServiceTestSuite) TestIncomeHistory() {
 		Symbol:     "BTCUSDT",
 		Time:       1578047897183,
 		IncomeType: "COMMISSION",
-		TranID:     "9689322392",
+		TranID:     9689322392,
 		TradeID:    "2059192",
 	}
 	s.assertOrderEqual(e, orders[0])

--- a/v2/futures/income_history.go
+++ b/v2/futures/income_history.go
@@ -86,6 +86,6 @@ type IncomeHistory struct {
 	Info       string `json:"info"`
 	Symbol     string `json:"symbol"`
 	Time       int64  `json:"time"`
-	TranID     string `json:"tranId"`
+	TranID     int64  `json:"tranId"`
 	TradeID    string `json:"tradeId"`
 }

--- a/v2/futures/income_history_test.go
+++ b/v2/futures/income_history_test.go
@@ -27,7 +27,7 @@ func (s *incomeHistoryServiceTestSuite) TestIncomeHistory() {
 			"asset": "USDT",
 			"info":"",  
 			"time": 1570636800000,
-			"tranId":"9689322392",
+			"tranId":9689322392,
 			"tradeId":"2059192"
 		}
 	]`)
@@ -55,7 +55,7 @@ func (s *incomeHistoryServiceTestSuite) TestIncomeHistory() {
 		Symbol:     "BTCUSDT",
 		Time:       1578047897183,
 		IncomeType: "COMMISSION",
-		TranID:     "9689322392",
+		TranID:     9689322392,
 		TradeID:    "2059192",
 	}
 	s.assertOrderEqual(e, orders[0])


### PR DESCRIPTION
Fixes the type for TranID. The documentation says that it is a string, but the API returns an int. 

https://binance-docs.github.io/apidocs/futures/en/#get-income-history-user_data