### PR TITLE
AccountPosition adding missing 4 fields

### DIFF
--- a/v2/futures/account_service.go
+++ b/v2/futures/account_service.go
@@ -98,16 +98,16 @@ type AccountAsset struct {
 
 // AccountPosition define account position
 type AccountPosition struct {
-	Isolated               bool   `json:"isolated"`
-	Leverage               string `json:"leverage"`
-	InitialMargin          string `json:"initialMargin"`
-	MaintMargin            string `json:"maintMargin"`
-	OpenOrderInitialMargin string `json:"openOrderInitialMargin"`
-	PositionInitialMargin  string `json:"positionInitialMargin"`
-	Symbol                 string `json:"symbol"`
-	UnrealizedProfit       string `json:"unrealizedProfit"`
-	EntryPrice             string `json:"entryPrice"`
-	MaxNotional            string `json:"maxNotional"`
-	PositionSide           string `json:"positionSide"`
-	PositionAmt            string `json:"positionAmt"`
+	Isolated               bool             `json:"isolated"`
+	Leverage               string           `json:"leverage"`
+	InitialMargin          string           `json:"initialMargin"`
+	MaintMargin            string           `json:"maintMargin"`
+	OpenOrderInitialMargin string           `json:"openOrderInitialMargin"`
+	PositionInitialMargin  string           `json:"positionInitialMargin"`
+	Symbol                 string           `json:"symbol"`
+	UnrealizedProfit       string           `json:"unrealizedProfit"`
+	EntryPrice             string           `json:"entryPrice"`
+	MaxNotional            string           `json:"maxNotional"`
+	PositionSide           PositionSideType `json:"positionSide"`
+	PositionAmt            string           `json:"positionAmt"`
 }

--- a/v2/futures/account_service.go
+++ b/v2/futures/account_service.go
@@ -106,4 +106,8 @@ type AccountPosition struct {
 	PositionInitialMargin  string `json:"positionInitialMargin"`
 	Symbol                 string `json:"symbol"`
 	UnrealizedProfit       string `json:"unrealizedProfit"`
+	EntryPrice             string `json:"entryPrice"`
+	MaxNotional            string `json:"maxNotional"`
+	PositionSide           string `json:"positionSide"`
+	PositionAmt            string `json:"positionAmt"`
 }

--- a/v2/futures/account_service_test.go
+++ b/v2/futures/account_service_test.go
@@ -88,7 +88,11 @@ func (s *accountServiceTestSuite) TestGetAccount() {
 				"openOrderInitialMargin": "0.00000",
 				"positionInitialMargin": "0.33683",
 				"symbol": "BTCUSDT",
-				"unrealizedProfit": "-0.44537584"
+				"unrealizedProfit": "-0.44537584",
+				"entryPrice": "8950.5",
+				"maxNotional": "250000",
+				"positionSide": "BOTH",
+				"positionAmt": "0.436"
 			 }
 		 ],
 		 "totalInitialMargin": "0.33683000",
@@ -138,6 +142,10 @@ func (s *accountServiceTestSuite) TestGetAccount() {
 				PositionInitialMargin:  "0.33683",
 				Symbol:                 "BTCUSDT",
 				UnrealizedProfit:       "-0.44537584",
+				EntryPrice:             "8950.5",
+				MaxNotional:            "250000",
+				PositionSide:           "BOTH",
+				PositionAmt:            "0.436",
 			},
 		},
 		TotalInitialMargin:          "0.33683000",
@@ -191,5 +199,9 @@ func (s *accountServiceTestSuite) assertAccountEqual(e, a *Account) {
 		r.Equal(e.Positions[i].PositionInitialMargin, a.Positions[i].PositionInitialMargin, "PositionInitialMargin")
 		r.Equal(e.Positions[i].Symbol, a.Positions[i].Symbol, "Symbol")
 		r.Equal(e.Positions[i].UnrealizedProfit, a.Positions[i].UnrealizedProfit, "UnrealizedProfit")
+		r.Equal(e.Positions[i].EntryPrice, a.Positions[i].EntryPrice, "EntryPrice")
+		r.Equal(e.Positions[i].MaxNotional, a.Positions[i].MaxNotional, "MaxNotional")
+		r.Equal(e.Positions[i].PositionSide, a.Positions[i].PositionSide, "PositionSide")
+		r.Equal(e.Positions[i].PositionAmt, a.Positions[i].PositionAmt, "PositionAmt")
 	}
 }


### PR DESCRIPTION
AccountPosition added 4 fields that were missing. These are rather important to have as they are giving useful information about your futures open positions, something that was missing for a long time from Binance it seems.

https://binance-docs.github.io/apidocs/futures/en/#account-information-v2-user_data