### PR TITLE
Support 100ms streams for depth and partial depth

### DIFF
--- a/websocket_service.go
+++ b/websocket_service.go
@@ -28,9 +28,20 @@ type WsPartialDepthEvent struct {
 // WsPartialDepthHandler handle websocket partial depth event
 type WsPartialDepthHandler func(event *WsPartialDepthEvent)
 
-// WsPartialDepthServe serve websocket partial depth handler with a symbol
+// WsPartialDepthServe serve websocket partial depth handler with a symbol, using 1sec updates
 func WsPartialDepthServe(symbol string, levels string, handler WsPartialDepthHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
 	endpoint := fmt.Sprintf("%s/%s@depth%s", baseURL, strings.ToLower(symbol), levels)
+	return wsPartialDepthServe(endpoint, symbol, handler, errHandler)
+}
+
+// WsPartialDepthServe100Ms serve websocket partial depth handler with a symbol, using 100msec updates
+func WsPartialDepthServe100Ms(symbol string, levels string, handler WsPartialDepthHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	endpoint := fmt.Sprintf("%s/%s@depth%s@100ms", baseURL, strings.ToLower(symbol), levels)
+	return wsPartialDepthServe(endpoint, symbol, handler, errHandler)
+}
+
+// wsPartialDepthServe serve websocket partial depth handler with an arbitrary endpoint address
+func wsPartialDepthServe(endpoint string, symbol string, handler WsPartialDepthHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
 	cfg := newWsConfig(endpoint)
 	wsHandler := func(message []byte) {
 		j, err := newJSON(message)
@@ -64,7 +75,7 @@ func WsPartialDepthServe(symbol string, levels string, handler WsPartialDepthHan
 	return wsServe(cfg, wsHandler, errHandler)
 }
 
-// WsCombinedPartialDepthServe is similar to WsPartialDepthServe, but it for multiple symbols
+// WsCombinedPartialDepthServe is similar to WsPartialDepthServe, but for multiple symbols and 1sec updates only
 func WsCombinedPartialDepthServe(symbolLevels map[string]string, handler WsPartialDepthHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
 	endpoint := combinedBaseURL
 	for s, l := range symbolLevels {
@@ -111,9 +122,20 @@ func WsCombinedPartialDepthServe(symbolLevels map[string]string, handler WsParti
 // WsDepthHandler handle websocket depth event
 type WsDepthHandler func(event *WsDepthEvent)
 
-// WsDepthServe serve websocket depth handler with a symbol
+// WsDepthServe serve websocket depth handler with a symbol, using 1sec updates
 func WsDepthServe(symbol string, handler WsDepthHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
 	endpoint := fmt.Sprintf("%s/%s@depth", baseURL, strings.ToLower(symbol))
+	return wsDepthServe(endpoint, handler, errHandler)
+}
+
+// WsDepthServe100Ms serve websocket depth handler with a symbol, using 100msec updates
+func WsDepthServe100Ms(symbol string, handler WsDepthHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	endpoint := fmt.Sprintf("%s/%s@depth@100ms", baseURL, strings.ToLower(symbol))
+	return wsDepthServe(endpoint, handler, errHandler)
+}
+
+// WsDepthServe serve websocket depth handler with an arbitrary endpoint address
+func wsDepthServe(endpoint string, handler WsDepthHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
 	cfg := newWsConfig(endpoint)
 	wsHandler := func(message []byte) {
 		j, err := newJSON(message)

--- a/websocket_service_test.go
+++ b/websocket_service_test.go
@@ -101,6 +101,56 @@ func (s *websocketServiceTestSuite) TestPartialDepthServe() {
 	<-doneC
 }
 
+func (s *websocketServiceTestSuite) TestPartialDepthServe100Ms() {
+	data := []byte(`{
+	  "lastUpdateId": 160,
+	  "bids": [
+	    [
+	      "0.0024",
+	      "10",
+	      []
+	    ]
+	  ],
+	  "asks": [
+	    [
+	      "0.0026",
+	      "100",
+	      []
+	    ]
+	  ]
+	}`)
+	fakeErrMsg := "fake error"
+	s.mockWsServe(data, errors.New(fakeErrMsg))
+	defer s.assertWsServe()
+
+	doneC, stopC, err := WsPartialDepthServe100Ms("ETHBTC", "5", func(event *WsPartialDepthEvent) {
+		e := &WsPartialDepthEvent{
+			Symbol:       "ETHBTC",
+			LastUpdateID: 160,
+			Bids: []Bid{
+				{
+					Price:    "0.0024",
+					Quantity: "10",
+				},
+			},
+			Asks: []Ask{
+				{
+					Price:    "0.0026",
+					Quantity: "100",
+				},
+			},
+		}
+		s.assertWsPartialDepthEventEqual(e, event)
+	},
+		func(err error) {
+			s.r().EqualError(err, fakeErrMsg)
+		})
+
+	s.r().NoError(err)
+	stopC <- struct{}{}
+	<-doneC
+}
+
 func (s *websocketServiceTestSuite) TestCombinedPartialDepthServe() {
 	data := []byte(`{
       "stream":"ethusdt@depth5",
@@ -171,6 +221,79 @@ func (s *websocketServiceTestSuite) assertWsPartialDepthEventEqual(e, a *WsParti
 }
 
 func (s *websocketServiceTestSuite) TestDepthServe() {
+	data := []byte(`{
+        "e": "depthUpdate",
+        "E": 1499404630606,
+        "s": "ETHBTC",
+        "u": 7913455,
+        "U": 7913452,
+        "b": [
+            [
+                "0.10376590",
+                "59.15767010",
+                []
+            ]
+        ],
+        "a": [
+            [
+                "0.10376586",
+                "159.15767010",
+                []
+            ],
+            [
+                "0.10383109",
+                "345.86845230",
+                []
+            ],
+            [
+                "0.10490700",
+                "0.00000000",
+                []
+            ]
+        ]
+    }`)
+	fakeErrMsg := "fake error"
+	s.mockWsServe(data, errors.New(fakeErrMsg))
+	defer s.assertWsServe()
+
+	doneC, stopC, err := WsDepthServe100Ms("ETHBTC", func(event *WsDepthEvent) {
+		e := &WsDepthEvent{
+			Event:         "depthUpdate",
+			Time:          1499404630606,
+			Symbol:        "ETHBTC",
+			UpdateID:      7913455,
+			FirstUpdateID: 7913452,
+			Bids: []Bid{
+				{
+					Price:    "0.10376590",
+					Quantity: "59.15767010",
+				},
+			},
+			Asks: []Ask{
+				{
+					Price:    "0.10376586",
+					Quantity: "159.15767010",
+				},
+				{
+					Price:    "0.10383109",
+					Quantity: "345.86845230",
+				},
+				{
+					Price:    "0.10490700",
+					Quantity: "0.00000000",
+				},
+			},
+		}
+		s.assertWsDepthEventEqual(e, event)
+	}, func(err error) {
+		s.r().EqualError(err, fakeErrMsg)
+	})
+	s.r().NoError(err)
+	stopC <- struct{}{}
+	<-doneC
+}
+
+func (s *websocketServiceTestSuite) TestDepthServe100Ms() {
 	data := []byte(`{
         "e": "depthUpdate",
         "E": 1499404630606,


### PR DESCRIPTION
These params are available for the depth streams, but were not available through the API:
https://github.com/binance-exchange/binance-official-api-docs/blob/master/web-socket-streams.md#partial-book-depth-streams

This change simply adds support for 100ms to the single-symbol depth and partial depth streams, but not to the WsCombinedPartialDepthServe