### PR TITLE
Delivery API (Coin-M) - All WebSocket Services

### DIFF
--- a/delivery/client.go
+++ b/delivery/client.go
@@ -266,6 +266,21 @@ func (c *Client) callAPI(ctx context.Context, r *request, opts ...RequestOption)
 	return data, nil
 }
 
+// NewStartUserStreamService init starting user stream service
+func (c *Client) NewStartUserStreamService() *StartUserStreamService {
+	return &StartUserStreamService{c: c}
+}
+
+// NewKeepaliveUserStreamService init keep alive user stream service
+func (c *Client) NewKeepaliveUserStreamService() *KeepaliveUserStreamService {
+	return &KeepaliveUserStreamService{c: c}
+}
+
+// NewCloseUserStreamService init closing user stream service
+func (c *Client) NewCloseUserStreamService() *CloseUserStreamService {
+	return &CloseUserStreamService{c: c}
+}
+
 // NewExchangeInfoService init exchange info service
 func (c *Client) NewExchangeInfoService() *ExchangeInfoService {
 	return &ExchangeInfoService{c: c}

--- a/delivery/depth_service.go
+++ b/delivery/depth_service.go
@@ -1,0 +1,13 @@
+package delivery
+
+// Bid define bid info with price and quantity
+type Bid struct {
+	Price    string
+	Quantity string
+}
+
+// Ask define ask info with price and quantity
+type Ask struct {
+	Price    string
+	Quantity string
+}

--- a/delivery/user_stream_service.go
+++ b/delivery/user_stream_service.go
@@ -1,0 +1,77 @@
+package delivery
+
+import (
+	"context"
+)
+
+// StartUserStreamService create listen key for user stream service
+type StartUserStreamService struct {
+	c *Client
+}
+
+// Do send request
+func (s *StartUserStreamService) Do(ctx context.Context, opts ...RequestOption) (listenKey string, err error) {
+	r := &request{
+		method:   "POST",
+		endpoint: "/dapi/v1/listenKey",
+		secType:  secTypeSigned,
+	}
+	data, err := s.c.callAPI(ctx, r, opts...)
+	if err != nil {
+		return "", err
+	}
+	j, err := newJSON(data)
+	if err != nil {
+		return "", err
+	}
+	listenKey = j.Get("listenKey").MustString()
+	return listenKey, nil
+}
+
+// KeepaliveUserStreamService update listen key
+type KeepaliveUserStreamService struct {
+	c         *Client
+	listenKey string
+}
+
+// ListenKey set listen key
+func (s *KeepaliveUserStreamService) ListenKey(listenKey string) *KeepaliveUserStreamService {
+	s.listenKey = listenKey
+	return s
+}
+
+// Do send request
+func (s *KeepaliveUserStreamService) Do(ctx context.Context, opts ...RequestOption) (err error) {
+	r := &request{
+		method:   "PUT",
+		endpoint: "/dapi/v1/listenKey",
+		secType:  secTypeSigned,
+	}
+	r.setFormParam("listenKey", s.listenKey)
+	_, err = s.c.callAPI(ctx, r, opts...)
+	return err
+}
+
+// CloseUserStreamService delete listen key
+type CloseUserStreamService struct {
+	c         *Client
+	listenKey string
+}
+
+// ListenKey set listen key
+func (s *CloseUserStreamService) ListenKey(listenKey string) *CloseUserStreamService {
+	s.listenKey = listenKey
+	return s
+}
+
+// Do send request
+func (s *CloseUserStreamService) Do(ctx context.Context, opts ...RequestOption) (err error) {
+	r := &request{
+		method:   "DELETE",
+		endpoint: "/dapi/v1/listenKey",
+		secType:  secTypeSigned,
+	}
+	r.setFormParam("listenKey", s.listenKey)
+	_, err = s.c.callAPI(ctx, r, opts...)
+	return err
+}

--- a/delivery/user_stream_service_test.go
+++ b/delivery/user_stream_service_test.go
@@ -1,0 +1,59 @@
+package delivery
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type userStreamServiceTestSuite struct {
+	baseTestSuite
+}
+
+func TestUserStreamService(t *testing.T) {
+	suite.Run(t, new(userStreamServiceTestSuite))
+}
+
+func (s *userStreamServiceTestSuite) TestStartUserStream() {
+	data := []byte(`{
+        "listenKey": "pqia91ma19a5s61cv6a81va65sdf19v8a65a1a5s61cv6a81va65sdf19v8a65a1"
+    }`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	s.assertReq(func(r *request) {
+		s.assertRequestEqual(newSignedRequest(), r)
+	})
+
+	listenKey, err := s.client.NewStartUserStreamService().Do(newContext())
+	s.r().NoError(err)
+	s.r().Equal("pqia91ma19a5s61cv6a81va65sdf19v8a65a1a5s61cv6a81va65sdf19v8a65a1", listenKey)
+}
+
+func (s *userStreamServiceTestSuite) TestKeepaliveUserStream() {
+	data := []byte(`{}`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	listenKey := "dummykey"
+	s.assertReq(func(r *request) {
+		s.assertRequestEqual(newSignedRequest().setFormParam("listenKey", listenKey), r)
+	})
+
+	err := s.client.NewKeepaliveUserStreamService().ListenKey(listenKey).Do(newContext())
+	s.r().NoError(err)
+}
+
+func (s *userStreamServiceTestSuite) TestCloseUserStream() {
+	data := []byte(`{}`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	listenKey := "dummykey"
+	s.assertReq(func(r *request) {
+		s.assertRequestEqual(newSignedRequest().setFormParam("listenKey", listenKey), r)
+	})
+
+	err := s.client.NewCloseUserStreamService().ListenKey(listenKey).Do(newContext())
+	s.r().NoError(err)
+}

--- a/delivery/websocket.go
+++ b/delivery/websocket.go
@@ -1,0 +1,91 @@
+package delivery
+
+import (
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// WsHandler handle raw websocket message
+type WsHandler func(message []byte)
+
+// ErrHandler handles errors
+type ErrHandler func(err error)
+
+// WsConfig webservice configuration
+type WsConfig struct {
+	Endpoint string
+}
+
+func newWsConfig(endpoint string) *WsConfig {
+	return &WsConfig{
+		Endpoint: endpoint,
+	}
+}
+
+var wsServe = func(cfg *WsConfig, handler WsHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	c, _, err := websocket.DefaultDialer.Dial(cfg.Endpoint, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	doneC = make(chan struct{})
+	stopC = make(chan struct{})
+	go func() {
+		// This function will exit either on error from
+		// websocket.Conn.ReadMessage or when the stopC channel is
+		// closed by the client.
+		defer close(doneC)
+		if WebsocketKeepalive {
+			keepAlive(c, WebsocketTimeout)
+		}
+		// Wait for the stopC channel to be closed.  We do that in a
+		// separate goroutine because ReadMessage is a blocking
+		// operation.
+		silent := false
+		go func() {
+			select {
+			case <-stopC:
+				silent = true
+			case <-doneC:
+			}
+			c.Close()
+		}()
+		for {
+			_, message, err := c.ReadMessage()
+			if err != nil {
+				if !silent {
+					errHandler(err)
+				}
+				return
+			}
+			handler(message)
+		}
+	}()
+	return
+}
+
+func keepAlive(c *websocket.Conn, timeout time.Duration) {
+	ticker := time.NewTicker(timeout)
+
+	lastResponse := time.Now()
+	c.SetPongHandler(func(msg string) error {
+		lastResponse = time.Now()
+		return nil
+	})
+
+	go func() {
+		defer ticker.Stop()
+		for {
+			deadline := time.Now().Add(10 * time.Second)
+			err := c.WriteControl(websocket.PingMessage, []byte{}, deadline)
+			if err != nil {
+				return
+			}
+			<-ticker.C
+			if time.Since(lastResponse) > timeout {
+				c.Close()
+				return
+			}
+		}
+	}()
+}

--- a/delivery/websocket_service.go
+++ b/delivery/websocket_service.go
@@ -1,0 +1,605 @@
+package delivery
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	baseURL = "wss://dstream.binance.com/ws"
+)
+
+var (
+
+	// WebsocketTimeout is an interval for sending ping/pong messages if WebsocketKeepalive is enabled
+	WebsocketTimeout = time.Second * 60
+	// WebsocketKeepalive enables sending ping/pong messages to check the connection stability
+	WebsocketKeepalive = false
+)
+
+// WsAggTradeEvent define websocket aggTrde event.
+type WsAggTradeEvent struct {
+	Event            string `json:"e"`
+	Time             int64  `json:"E"`
+	AggregateTradeID int64  `json:"a"`
+	Symbol           string `json:"s"`
+	Price            string `json:"p"`
+	Quantity         string `json:"q"`
+	FirstTradeID     int64  `json:"f"`
+	LastTradeID      int64  `json:"l"`
+	TradeTime        int64  `json:"T"`
+	Maker            bool   `json:"m"`
+}
+
+// WsAggTradeHandler handle websocket that push trade information that is aggregated for a single taker order.
+type WsAggTradeHandler func(event *WsAggTradeEvent)
+
+// WsAggTradeServe serve websocket that push trade information that is aggregated for a single taker order.
+func WsAggTradeServe(symbol string, handler WsAggTradeHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	endpoint := fmt.Sprintf("%s/%s@aggTrade", baseURL, strings.ToLower(symbol))
+	cfg := newWsConfig(endpoint)
+	wsHandler := func(message []byte) {
+		event := new(WsAggTradeEvent)
+		err := json.Unmarshal(message, &event)
+		if err != nil {
+			errHandler(err)
+			return
+		}
+		handler(event)
+	}
+	return wsServe(cfg, wsHandler, errHandler)
+}
+
+// WsIndexPriceEvent define websocket indexPriceUpdate event.
+type WsIndexPriceEvent struct {
+	Event      string `json:"e"`
+	Time       int64  `json:"E"`
+	Pair       string `json:"i"`
+	IndexPrice string `json:"p"`
+}
+
+// WsIndexPriceHandler handle websocket that push index price for a pair.
+type WsIndexPriceHandler func(event *WsIndexPriceEvent)
+
+// WsIndexPriceServe serve websocket that pushes index price for a pair.
+func WsIndexPriceServe(symbol string, handler WsIndexPriceHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	endpoint := fmt.Sprintf("%s/%s@indexPrice", baseURL, strings.ToLower(symbol))
+	cfg := newWsConfig(endpoint)
+	wsHandler := func(message []byte) {
+		event := new(WsIndexPriceEvent)
+		err := json.Unmarshal(message, &event)
+		if err != nil {
+			errHandler(err)
+			return
+		}
+		handler(event)
+	}
+	return wsServe(cfg, wsHandler, errHandler)
+}
+
+// WsMarkPriceEvent define websocket markPriceUpdate event.
+type WsMarkPriceEvent struct {
+	Event                string `json:"e"`
+	Time                 int64  `json:"E"`
+	Symbol               string `json:"s"`
+	MarkPrice            string `json:"p"`
+	EstimatedSettlePrice string `json:"P"`
+	FundingRate          string `json:"r"`
+	NextFundingTime      int64  `json:"T"`
+}
+
+// WsMarkPriceHandler handle websocket that pushes price and funding rate for a single symbol.
+type WsMarkPriceHandler func(event *WsMarkPriceEvent)
+
+// WsMarkPriceServe serve websocket that pushes price and funding rate for a single symbol.
+func WsMarkPriceServe(symbol string, handler WsMarkPriceHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	endpoint := fmt.Sprintf("%s/%s@markPrice", baseURL, strings.ToLower(symbol))
+	cfg := newWsConfig(endpoint)
+	wsHandler := func(message []byte) {
+		event := new(WsMarkPriceEvent)
+		err := json.Unmarshal(message, &event)
+		if err != nil {
+			errHandler(err)
+			return
+		}
+		handler(event)
+	}
+	return wsServe(cfg, wsHandler, errHandler)
+}
+
+// WsPairMarkPriceEvent defines an array of websocket markPriceUpdate events.
+type WsPairMarkPriceEvent []*WsMarkPriceEvent
+
+// WsPairMarkPriceHandler handle websocket that pushes price and funding rate for all symbol.
+type WsPairMarkPriceHandler func(event WsPairMarkPriceEvent)
+
+// WsPairMarkPriceServe serve websocket that pushes price and funding rate for all symbol.
+func WsPairMarkPriceServe(handler WsPairMarkPriceHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	endpoint := fmt.Sprintf("%s/markPrice@arr", baseURL)
+	cfg := newWsConfig(endpoint)
+	wsHandler := func(message []byte) {
+		var event WsPairMarkPriceEvent
+		err := json.Unmarshal(message, &event)
+		if err != nil {
+			errHandler(err)
+			return
+		}
+		handler(event)
+	}
+	return wsServe(cfg, wsHandler, errHandler)
+}
+
+// WsKlineEvent define websocket kline event
+type WsKlineEvent struct {
+	Event  string  `json:"e"`
+	Time   int64   `json:"E"`
+	Symbol string  `json:"s"`
+	Kline  WsKline `json:"k"`
+}
+
+// WsKline define websocket kline
+type WsKline struct {
+	StartTime            int64  `json:"t"`
+	EndTime              int64  `json:"T"`
+	Symbol               string `json:"s"`
+	Interval             string `json:"i"`
+	FirstTradeID         int64  `json:"f"`
+	LastTradeID          int64  `json:"L"`
+	Open                 string `json:"o"`
+	Close                string `json:"c"`
+	High                 string `json:"h"`
+	Low                  string `json:"l"`
+	Volume               string `json:"v"`
+	TradeNum             int64  `json:"n"`
+	IsFinal              bool   `json:"x"`
+	QuoteVolume          string `json:"q"`
+	ActiveBuyVolume      string `json:"V"`
+	ActiveBuyQuoteVolume string `json:"Q"`
+}
+
+// WsKlineHandler handle websocket kline event
+type WsKlineHandler func(event *WsKlineEvent)
+
+// WsKlineServe serve websocket kline handler with a symbol and interval like 15m, 30s
+func WsKlineServe(symbol string, interval string, handler WsKlineHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	endpoint := fmt.Sprintf("%s/%s@kline_%s", baseURL, strings.ToLower(symbol), interval)
+	cfg := newWsConfig(endpoint)
+	wsHandler := func(message []byte) {
+		event := new(WsKlineEvent)
+		err := json.Unmarshal(message, event)
+		if err != nil {
+			errHandler(err)
+			return
+		}
+		handler(event)
+	}
+	return wsServe(cfg, wsHandler, errHandler)
+}
+
+// WsContinuousKlineEvent define websocket continuous kline event
+type WsContinuousKlineEvent struct {
+	Event        string            `json:"e"`
+	Time         int64             `json:"E"`
+	Pair         string            `json:"ps"`
+	ContractType string            `json:"ct"`
+	Kline        WsContinuousKline `json:"k"`
+}
+
+// WsContinuousKline define websocket continuous kline
+type WsContinuousKline struct {
+	StartTime            int64  `json:"t"`
+	EndTime              int64  `json:"T"`
+	Interval             string `json:"i"`
+	FirstTradeID         int64  `json:"f"`
+	LastTradeID          int64  `json:"L"`
+	Open                 string `json:"o"`
+	Close                string `json:"c"`
+	High                 string `json:"h"`
+	Low                  string `json:"l"`
+	Volume               string `json:"v"`
+	TradeNum             int64  `json:"n"`
+	IsFinal              bool   `json:"x"`
+	QuoteVolume          string `json:"q"`
+	ActiveBuyVolume      string `json:"V"`
+	ActiveBuyQuoteVolume string `json:"Q"`
+}
+
+// WsContinuousKlineHandler handle websocket continuous kline event
+type WsContinuousKlineHandler func(event *WsContinuousKlineEvent)
+
+// WsContinuousKlineServe serve websocket kline handler with a pair, a contract type and interval like 15m, 30s
+func WsContinuousKlineServe(pair string, contractType string, interval string, handler WsContinuousKlineHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	endpoint := fmt.Sprintf("%s/%s_%s@continuousKline_%s", baseURL, strings.ToLower(pair), strings.ToLower(contractType), interval)
+	cfg := newWsConfig(endpoint)
+	wsHandler := func(message []byte) {
+		event := new(WsContinuousKlineEvent)
+		err := json.Unmarshal(message, event)
+		if err != nil {
+			errHandler(err)
+			return
+		}
+		handler(event)
+	}
+	return wsServe(cfg, wsHandler, errHandler)
+}
+
+// WsIndexPriceKlineEvent define websocket index price kline event
+type WsIndexPriceKlineEvent struct {
+	Event string            `json:"e"`
+	Time  int64             `json:"E"`
+	Pair  string            `json:"ps"`
+	Kline WsIndexPriceKline `json:"k"`
+}
+
+// WsIndexPriceKline define websocket index price kline
+type WsIndexPriceKline struct {
+	StartTime   int64  `json:"t"`
+	EndTime     int64  `json:"T"`
+	Interval    string `json:"i"`
+	LastTradeId int64  `json:"L"` // LastTradeId Ignore
+	Open        string `json:"o"`
+	Close       string `json:"c"`
+	High        string `json:"h"`
+	Low         string `json:"l"`
+	TradeNum    int64  `json:"n"`
+	IsFinal     bool   `json:"x"`
+}
+
+// WsIndexPriceKlineHandler handle websocket index kline event
+type WsIndexPriceKlineHandler func(event *WsIndexPriceKlineEvent)
+
+// WsIndexPriceKlineServe serve websocket kline handler with a pair and interval like 15m, 30s
+func WsIndexPriceKlineServe(pair string, interval string, handler WsIndexPriceKlineHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	endpoint := fmt.Sprintf("%s/%s@indexPriceKline_%s", baseURL, strings.ToLower(pair), interval)
+	cfg := newWsConfig(endpoint)
+	wsHandler := func(message []byte) {
+		event := new(WsIndexPriceKlineEvent)
+		err := json.Unmarshal(message, event)
+		if err != nil {
+			errHandler(err)
+			return
+		}
+		handler(event)
+	}
+	return wsServe(cfg, wsHandler, errHandler)
+}
+
+// WsMarkPriceKlineEvent define websocket market price kline event
+type WsMarkPriceKlineEvent struct {
+	Event string           `json:"e"`
+	Time  int64            `json:"E"`
+	Pair  string           `json:"ps"`
+	Kline WsMarkPriceKline `json:"k"`
+}
+
+// WsMarkPriceKline define websocket market price kline
+type WsMarkPriceKline struct {
+	StartTime   int64  `json:"t"`
+	EndTime     int64  `json:"T"`
+	Symbol      string `json:"s"`
+	Interval    string `json:"i"`
+	LastTradeID int64  `json:"L"` // LastTradeID Ignore
+	Open        string `json:"o"`
+	Close       string `json:"c"`
+	High        string `json:"h"`
+	Low         string `json:"l"`
+	TradeNum    int64  `json:"n"`
+	IsFinal     bool   `json:"x"`
+}
+
+// WsMarkPriceKlineHandler handle websocket market price kline event
+type WsMarkPriceKlineHandler func(event *WsMarkPriceKlineEvent)
+
+// WsMarkPriceKlineServe serve websocket kline handler with a symbol and interval like 15m, 30s
+func WsMarkPriceKlineServe(symbol string, interval string, handler WsMarkPriceKlineHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	endpoint := fmt.Sprintf("%s/%s@markPriceKline_%s", baseURL, strings.ToLower(symbol), interval)
+	cfg := newWsConfig(endpoint)
+	wsHandler := func(message []byte) {
+		event := new(WsMarkPriceKlineEvent)
+		err := json.Unmarshal(message, event)
+		if err != nil {
+			errHandler(err)
+			return
+		}
+		handler(event)
+	}
+	return wsServe(cfg, wsHandler, errHandler)
+}
+
+// WsMiniMarketTickerEvent define websocket mini market ticker event.
+type WsMiniMarketTickerEvent struct {
+	Event       string `json:"e"`
+	Time        int64  `json:"E"`
+	Symbol      string `json:"s"`
+	Pair        string `json:"ps"`
+	ClosePrice  string `json:"c"`
+	OpenPrice   string `json:"o"`
+	HighPrice   string `json:"h"`
+	LowPrice    string `json:"l"`
+	Volume      string `json:"v"`
+	QuoteVolume string `json:"q"`
+}
+
+// WsMiniMarketTickerHandler handle websocket that pushes 24hr rolling window mini-ticker statistics for a single symbol.
+type WsMiniMarketTickerHandler func(event *WsMiniMarketTickerEvent)
+
+// WsMiniMarketTickerServe serve websocket that pushes 24hr rolling window mini-ticker statistics for a single symbol.
+func WsMiniMarketTickerServe(symbol string, handler WsMiniMarketTickerHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	endpoint := fmt.Sprintf("%s/%s@miniTicker", baseURL, strings.ToLower(symbol))
+	cfg := newWsConfig(endpoint)
+	wsHandler := func(message []byte) {
+		event := new(WsMiniMarketTickerEvent)
+		err := json.Unmarshal(message, &event)
+		if err != nil {
+			errHandler(err)
+			return
+		}
+		handler(event)
+	}
+	return wsServe(cfg, wsHandler, errHandler)
+}
+
+// WsAllMiniMarketTickerEvent define an array of websocket mini market ticker events.
+type WsAllMiniMarketTickerEvent []*WsMiniMarketTickerEvent
+
+// WsAllMiniMarketTickerHandler handle websocket that pushes price and funding rate for all markets.
+type WsAllMiniMarketTickerHandler func(event WsAllMiniMarketTickerEvent)
+
+// WsAllMiniMarketTickerServe serve websocket that pushes price and funding rate for all markets.
+func WsAllMiniMarketTickerServe(handler WsAllMiniMarketTickerHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	endpoint := fmt.Sprintf("%s/!miniTicker@arr", baseURL)
+	cfg := newWsConfig(endpoint)
+	wsHandler := func(message []byte) {
+		var event WsAllMiniMarketTickerEvent
+		err := json.Unmarshal(message, &event)
+		if err != nil {
+			errHandler(err)
+			return
+		}
+		handler(event)
+	}
+	return wsServe(cfg, wsHandler, errHandler)
+}
+
+// WsMarketTickerEvent define websocket market ticker event.
+type WsMarketTickerEvent struct {
+	Event              string `json:"e"`
+	Time               int64  `json:"E"`
+	Symbol             string `json:"s"`
+	Pair               string `json:"ps"`
+	PriceChange        string `json:"p"`
+	PriceChangePercent string `json:"P"`
+	WeightedAvgPrice   string `json:"w"`
+	ClosePrice         string `json:"c"`
+	CloseQty           string `json:"Q"`
+	OpenPrice          string `json:"o"`
+	HighPrice          string `json:"h"`
+	LowPrice           string `json:"l"`
+	BaseVolume         string `json:"v"`
+	QuoteVolume        string `json:"q"`
+	OpenTime           int64  `json:"O"`
+	CloseTime          int64  `json:"C"`
+	FirstID            int64  `json:"F"`
+	LastID             int64  `json:"L"`
+	TradeCount         int64  `json:"n"`
+}
+
+// WsMarketTickerHandler handle websocket that pushes 24hr rolling window mini-ticker statistics for a single symbol.
+type WsMarketTickerHandler func(event *WsMarketTickerEvent)
+
+// WsMarketTickerServe serve websocket that pushes 24hr rolling window mini-ticker statistics for a single symbol.
+func WsMarketTickerServe(symbol string, handler WsMarketTickerHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	endpoint := fmt.Sprintf("%s/%s@ticker", baseURL, strings.ToLower(symbol))
+	cfg := newWsConfig(endpoint)
+	wsHandler := func(message []byte) {
+		event := new(WsMarketTickerEvent)
+		err := json.Unmarshal(message, &event)
+		if err != nil {
+			errHandler(err)
+			return
+		}
+		handler(event)
+	}
+	return wsServe(cfg, wsHandler, errHandler)
+}
+
+// WsAllMarketTickerEvent define an array of websocket mini ticker events.
+type WsAllMarketTickerEvent []*WsMarketTickerEvent
+
+// WsAllMarketTickerHandler handle websocket that pushes price and funding rate for all markets.
+type WsAllMarketTickerHandler func(event WsAllMarketTickerEvent)
+
+// WsAllMarketTickerServe serve websocket that pushes price and funding rate for all markets.
+func WsAllMarketTickerServe(handler WsAllMarketTickerHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	endpoint := fmt.Sprintf("%s/!ticker@arr", baseURL)
+	cfg := newWsConfig(endpoint)
+	wsHandler := func(message []byte) {
+		var event WsAllMarketTickerEvent
+		err := json.Unmarshal(message, &event)
+		if err != nil {
+			errHandler(err)
+			return
+		}
+		handler(event)
+	}
+	return wsServe(cfg, wsHandler, errHandler)
+}
+
+// WsBookTickerEvent define websocket best book ticker event.
+type WsBookTickerEvent struct {
+	Event           string `json:"e"`
+	UpdateID        int64  `json:"u"`
+	Symbol          string `json:"s"`
+	Pair            string `json:"ps"`
+	BestBidPrice    string `json:"b"`
+	BestBidQty      string `json:"B"`
+	BestAskPrice    string `json:"a"`
+	BestAskQty      string `json:"A"`
+	TransactionTime int64  `json:"T"`
+	Time            int64  `json:"E"`
+}
+
+// WsBookTickerHandler handle websocket that pushes updates to the best bid or ask price or quantity in real-time for a specified symbol.
+type WsBookTickerHandler func(event *WsBookTickerEvent)
+
+// WsBookTickerServe serve websocket that pushes updates to the best bid or ask price or quantity in real-time for a specified symbol.
+func WsBookTickerServe(symbol string, handler WsBookTickerHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	endpoint := fmt.Sprintf("%s/%s@bookTicker", baseURL, strings.ToLower(symbol))
+	cfg := newWsConfig(endpoint)
+	wsHandler := func(message []byte) {
+		event := new(WsBookTickerEvent)
+		err := json.Unmarshal(message, &event)
+		if err != nil {
+			errHandler(err)
+			return
+		}
+		handler(event)
+	}
+	return wsServe(cfg, wsHandler, errHandler)
+}
+
+// WsAllBookTickerServe serve websocket that pushes updates to the best bid or ask price or quantity in real-time for all symbols.
+func WsAllBookTickerServe(handler WsBookTickerHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	endpoint := fmt.Sprintf("%s/!bookTicker", baseURL)
+	cfg := newWsConfig(endpoint)
+	wsHandler := func(message []byte) {
+		event := new(WsBookTickerEvent)
+		err := json.Unmarshal(message, &event)
+		if err != nil {
+			errHandler(err)
+			return
+		}
+		handler(event)
+	}
+	return wsServe(cfg, wsHandler, errHandler)
+}
+
+// WsLiquidationOrderEvent define websocket liquidation order event.
+type WsLiquidationOrderEvent struct {
+	Event            string             `json:"e"`
+	Time             int64              `json:"E"`
+	LiquidationOrder WsLiquidationOrder `json:"o"`
+}
+
+// WsLiquidationOrder define websocket liquidation order.
+type WsLiquidationOrder struct {
+	Symbol               string          `json:"s"`
+	Pair                 string          `json:"ps"`
+	Side                 SideType        `json:"S"`
+	OrderType            OrderType       `json:"o"`
+	TimeInForce          TimeInForceType `json:"f"`
+	OrigQuantity         string          `json:"q"`
+	Price                string          `json:"p"`
+	AvgPrice             string          `json:"ap"`
+	OrderStatus          OrderStatusType `json:"X"`
+	LastFilledQty        string          `json:"l"`
+	AccumulatedFilledQty string          `json:"z"`
+	TradeTime            int64           `json:"T"`
+}
+
+// WsLiquidationOrderHandler handle websocket that pushes force liquidation order information for specific symbol.
+type WsLiquidationOrderHandler func(event *WsLiquidationOrderEvent)
+
+// WsLiquidationOrderServe serve websocket that pushes force liquidation order information for specific symbol.
+func WsLiquidationOrderServe(symbol string, handler WsLiquidationOrderHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	endpoint := fmt.Sprintf("%s/%s@forceOrder", baseURL, strings.ToLower(symbol))
+	cfg := newWsConfig(endpoint)
+	wsHandler := func(message []byte) {
+		event := new(WsLiquidationOrderEvent)
+		err := json.Unmarshal(message, &event)
+		if err != nil {
+			errHandler(err)
+			return
+		}
+		handler(event)
+	}
+	return wsServe(cfg, wsHandler, errHandler)
+}
+
+// WsAllLiquidationOrderServe serve websocket that pushes force liquidation order information for all symbols.
+func WsAllLiquidationOrderServe(handler WsLiquidationOrderHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	endpoint := fmt.Sprintf("%s/!forceOrder@arr", baseURL)
+	cfg := newWsConfig(endpoint)
+	wsHandler := func(message []byte) {
+		event := new(WsLiquidationOrderEvent)
+		err := json.Unmarshal(message, &event)
+		if err != nil {
+			errHandler(err)
+			return
+		}
+		handler(event)
+	}
+	return wsServe(cfg, wsHandler, errHandler)
+}
+
+// WsDepthEvent define websocket depth book event
+type WsDepthEvent struct {
+	Event            string `json:"e"`
+	Time             int64  `json:"E"`
+	TransactionTime  int64  `json:"T"`
+	Symbol           string `json:"s"`
+	Pair             string `json:"ps"`
+	FirstUpdateID    int64  `json:"U"`
+	LastUpdateID     int64  `json:"u"`
+	PrevLastUpdateID int64  `json:"pu"`
+	Bids             []Bid  `json:"b"`
+	Asks             []Ask  `json:"a"`
+}
+
+// WsDepthHandler handle websocket depth event
+type WsDepthHandler func(event *WsDepthEvent)
+
+// WsPartialDepthServe serve websocket partial depth handler.
+func WsPartialDepthServe(symbol string, levels int, handler WsDepthHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	endpoint := fmt.Sprintf("%s/%s@depth%d", baseURL, strings.ToLower(symbol), levels)
+	cfg := newWsConfig(endpoint)
+	return wsDepthServe(cfg, handler, errHandler)
+}
+
+// WsDiffDepthServe serve websocket diff. depth handler.
+func WsDiffDepthServe(symbol string, handler WsDepthHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	endpoint := fmt.Sprintf("%s/%s@depth", baseURL, strings.ToLower(symbol))
+	cfg := newWsConfig(endpoint)
+	return wsDepthServe(cfg, handler, errHandler)
+}
+
+func wsDepthServe(cfg *WsConfig, handler WsDepthHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	wsHandler := func(message []byte) {
+		j, err := newJSON(message)
+		if err != nil {
+			errHandler(err)
+			return
+		}
+		event := new(WsDepthEvent)
+		event.Event = j.Get("e").MustString()
+		event.Time = j.Get("E").MustInt64()
+		event.TransactionTime = j.Get("T").MustInt64()
+		event.Symbol = j.Get("s").MustString()
+		event.Pair = j.Get("ps").MustString()
+		event.FirstUpdateID = j.Get("U").MustInt64()
+		event.LastUpdateID = j.Get("u").MustInt64()
+		event.PrevLastUpdateID = j.Get("pu").MustInt64()
+		bidsLen := len(j.Get("b").MustArray())
+		event.Bids = make([]Bid, bidsLen)
+		for i := 0; i < bidsLen; i++ {
+			item := j.Get("b").GetIndex(i)
+			event.Bids[i] = Bid{
+				Price:    item.GetIndex(0).MustString(),
+				Quantity: item.GetIndex(1).MustString(),
+			}
+		}
+		asksLen := len(j.Get("a").MustArray())
+		event.Asks = make([]Ask, asksLen)
+		for i := 0; i < asksLen; i++ {
+			item := j.Get("a").GetIndex(i)
+			event.Asks[i] = Ask{
+				Price:    item.GetIndex(0).MustString(),
+				Quantity: item.GetIndex(1).MustString(),
+			}
+		}
+		handler(event)
+	}
+	return wsServe(cfg, wsHandler, errHandler)
+}

--- a/delivery/websocket_service.go
+++ b/delivery/websocket_service.go
@@ -12,12 +12,18 @@ const (
 )
 
 var (
-
 	// WebsocketTimeout is an interval for sending ping/pong messages if WebsocketKeepalive is enabled
 	WebsocketTimeout = time.Second * 60
 	// WebsocketKeepalive enables sending ping/pong messages to check the connection stability
 	WebsocketKeepalive = false
 )
+
+// WsUserDataServe serve user data handler with listen key
+func WsUserDataServe(listenKey string, handler WsHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	endpoint := fmt.Sprintf("%s/%s", baseURL, listenKey)
+	cfg := newWsConfig(endpoint)
+	return wsServe(cfg, handler, errHandler)
+}
 
 // WsAggTradeEvent define websocket aggTrde event.
 type WsAggTradeEvent struct {

--- a/delivery/websocket_service_test.go
+++ b/delivery/websocket_service_test.go
@@ -1,0 +1,1168 @@
+package delivery
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type websocketServiceTestSuite struct {
+	baseTestSuite
+	origWsServe func(*WsConfig, WsHandler, ErrHandler) (chan struct{}, chan struct{}, error)
+	serveCount  int
+}
+
+func TestWebsocketService(t *testing.T) {
+	suite.Run(t, new(websocketServiceTestSuite))
+}
+
+func (s *websocketServiceTestSuite) SetupTest() {
+	s.origWsServe = wsServe
+}
+
+func (s *websocketServiceTestSuite) TearDownTest() {
+	wsServe = s.origWsServe
+	s.serveCount = 0
+}
+
+func (s *websocketServiceTestSuite) mockWsServe(data []byte, err error) {
+	wsServe = func(cfg *WsConfig, handler WsHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, innerErr error) {
+		s.serveCount++
+		doneC = make(chan struct{})
+		stopC = make(chan struct{})
+		go func() {
+			<-stopC
+			close(doneC)
+		}()
+		handler(data)
+		if err != nil {
+			errHandler(err)
+		}
+		return doneC, stopC, nil
+	}
+}
+
+func (s *websocketServiceTestSuite) assertWsServe(count ...int) {
+	e := 1
+	if len(count) > 0 {
+		e = count[0]
+	}
+	s.r().Equal(e, s.serveCount)
+}
+
+// https://binance-docs.github.io/apidocs/delivery/en/#aggregate-trade-streams
+func (s *websocketServiceTestSuite) TestAggTradeServe() {
+	data := []byte(`{
+		  "e":"aggTrade",
+		  "E":1591261134288,
+		  "a":424951,
+		  "s":"BTCUSD_200626",
+		  "p":"9643.5",
+		  "q":"2",
+		  "f":606073,
+		  "l":606073,
+		  "T":1591261134199,
+		  "m":false
+	  }`)
+	fakeErrMsg := "fake error"
+	s.mockWsServe(data, errors.New(fakeErrMsg))
+	defer s.assertWsServe()
+
+	doneC, stopC, err := WsAggTradeServe("BTCUSD_200626", func(event *WsAggTradeEvent) {
+		e := &WsAggTradeEvent{
+			Event:            "aggTrade",
+			Time:             1591261134288,
+			AggregateTradeID: 424951,
+			Symbol:           "BTCUSD_200626",
+			Price:            "9643.5",
+			Quantity:         "2",
+			FirstTradeID:     606073,
+			LastTradeID:      606073,
+			TradeTime:        1591261134199,
+			Maker:            false,
+		}
+		s.assertWsAggTradeEvent(e, event)
+	},
+		func(err error) {
+			s.r().EqualError(err, fakeErrMsg)
+		})
+
+	s.r().NoError(err)
+	stopC <- struct{}{}
+	<-doneC
+}
+
+func (s *websocketServiceTestSuite) assertWsAggTradeEvent(e, a *WsAggTradeEvent) {
+	r := s.r()
+	r.Equal(e.Event, a.Event, "Event")
+	r.Equal(e.Time, a.Time, "Time")
+	r.Equal(e.Symbol, a.Symbol, "Symbol")
+	r.Equal(e.AggregateTradeID, a.AggregateTradeID, "AggregateTradeID")
+	r.Equal(e.Price, a.Price, "Price")
+	r.Equal(e.Quantity, a.Quantity, "Quantity")
+	r.Equal(e.FirstTradeID, a.FirstTradeID, "FirstTradeID")
+	r.Equal(e.LastTradeID, a.LastTradeID, "LastTradeID")
+	r.Equal(e.TradeTime, a.TradeTime, "TradeTime")
+	r.Equal(e.Maker, a.Maker, "Maker")
+}
+
+// https://binance-docs.github.io/apidocs/delivery/en/#index-price-stream
+func (s *websocketServiceTestSuite) TestIndexPriceServe() {
+	data := []byte(`{
+		"e": "indexPriceUpdate",
+		"E": 1591261236000,
+		"i": "BTCUSD",
+		"p": "9636.57860000"
+	  }`)
+	fakeErrMsg := "fake error"
+	s.mockWsServe(data, errors.New(fakeErrMsg))
+	defer s.assertWsServe()
+
+	doneC, stopC, err := WsIndexPriceServe("BTCUSD", func(event *WsIndexPriceEvent) {
+		e := &WsIndexPriceEvent{
+			Event:      "indexPriceUpdate",
+			Time:       1591261236000,
+			Pair:       "BTCUSD",
+			IndexPrice: "9636.57860000",
+		}
+		s.assertWsIndexPriceEvent(e, event)
+	},
+		func(err error) {
+			s.r().EqualError(err, fakeErrMsg)
+		})
+
+	s.r().NoError(err)
+	stopC <- struct{}{}
+	<-doneC
+}
+
+func (s *websocketServiceTestSuite) assertWsIndexPriceEvent(e, a *WsIndexPriceEvent) {
+	r := s.r()
+	r.Equal(e.Event, a.Event, "Event")
+	r.Equal(e.Time, a.Time, "Time")
+	r.Equal(e.Pair, a.Pair, "Pair")
+	r.Equal(e.IndexPrice, a.IndexPrice, "IndexPrice")
+}
+
+// https://binance-docs.github.io/apidocs/delivery/en/#mark-price-stream
+func (s *websocketServiceTestSuite) TestMarkPriceServe() {
+	data := []byte(`{
+    	"e":"markPriceUpdate",
+    	"E":1596095725000,
+    	"s":"BTCUSD_201225",
+    	"p":"10934.62615417",
+    	"P":"10962.17178236",
+    	"r":"",
+    	"T":0
+	  }`)
+	fakeErrMsg := "fake error"
+	s.mockWsServe(data, errors.New(fakeErrMsg))
+	defer s.assertWsServe()
+
+	doneC, stopC, err := WsMarkPriceServe("BTCUSD_201225", func(event *WsMarkPriceEvent) {
+		e := &WsMarkPriceEvent{
+			Event:                "markPriceUpdate",
+			Time:                 1596095725000,
+			Symbol:               "BTCUSD_201225",
+			MarkPrice:            "10934.62615417",
+			EstimatedSettlePrice: "10962.17178236",
+			FundingRate:          "",
+			NextFundingTime:      0,
+		}
+		s.assertWsMarkPriceEvent(e, event)
+	},
+		func(err error) {
+			s.r().EqualError(err, fakeErrMsg)
+		})
+
+	s.r().NoError(err)
+	stopC <- struct{}{}
+	<-doneC
+}
+
+// https://binance-docs.github.io/apidocs/delivery/en/#mark-price-of-all-symbols-of-a-pair
+func (s *websocketServiceTestSuite) TestPairMarkPriceServe() {
+	data := []byte(`[
+	  {
+		"e":"markPriceUpdate",
+		"E":1596095725000,
+		"s":"BTCUSD_201225",
+		"p":"10934.62615417",
+		"P":"10962.17178236",
+		"r":"",
+		"T":0
+	  },
+	  {
+		"e":"markPriceUpdate",
+		"E":1596095725000,
+		"s":"BTCUSD_PERP",
+		"p":"11012.31359011",
+		"P":"10962.17178236",
+		"r":"0.00000000",
+		"T":1596096000000
+  }]`)
+	fakeErrMsg := "fake error"
+	s.mockWsServe(data, errors.New(fakeErrMsg))
+	defer s.assertWsServe()
+
+	doneC, stopC, err := WsPairMarkPriceServe(func(event WsPairMarkPriceEvent) {
+		e := WsPairMarkPriceEvent{{
+			Event:                "markPriceUpdate",
+			Time:                 1596095725000,
+			Symbol:               "BTCUSD_201225",
+			MarkPrice:            "10934.62615417",
+			EstimatedSettlePrice: "10962.17178236",
+			FundingRate:          "",
+			NextFundingTime:      0,
+		}, {
+			Event:                "markPriceUpdate",
+			Time:                 1596095725000,
+			Symbol:               "BTCUSD_PERP",
+			MarkPrice:            "11012.31359011",
+			EstimatedSettlePrice: "10962.17178236",
+			FundingRate:          "0.00000000",
+			NextFundingTime:      1596096000000,
+		}}
+		s.assertWsMarkPriceEvent(e[0], event[0])
+		s.assertWsMarkPriceEvent(e[1], event[1])
+	},
+		func(err error) {
+			s.r().EqualError(err, fakeErrMsg)
+		})
+
+	s.r().NoError(err)
+	stopC <- struct{}{}
+	<-doneC
+}
+
+func (s *websocketServiceTestSuite) assertWsMarkPriceEvent(e, a *WsMarkPriceEvent) {
+	r := s.r()
+	r.Equal(e.Event, a.Event, "Event")
+	r.Equal(e.Time, a.Time, "Time")
+	r.Equal(e.Symbol, a.Symbol, "Symbol")
+	r.Equal(e.MarkPrice, a.MarkPrice, "MarkPrice")
+	r.Equal(e.EstimatedSettlePrice, a.EstimatedSettlePrice, "EstimatedSettlePrice")
+	r.Equal(e.FundingRate, a.FundingRate, "FundingRate")
+	r.Equal(e.NextFundingTime, a.NextFundingTime, "NextFundingTime")
+}
+
+// https://binance-docs.github.io/apidocs/delivery/en/#kline-candlestick-streams
+func (s *websocketServiceTestSuite) TestKlineServe() {
+	data := []byte(`{
+	  "e":"kline",
+	  "E":1591261542539,
+	  "s":"BTCUSD_200626",
+	  "k":{
+		"t":1591261500000,
+		"T":1591261559999,
+		"s":"BTCUSD_200626",
+		"i":"1m",
+		"f":606400,
+		"L":606430,
+		"o":"9638.9",
+		"c":"9639.8",
+		"h":"9639.8",
+		"l":"9638.6",
+		"v":"156",
+		"n":31,
+		"x":false,
+		"q":"1.61836886",
+		"V":"73",
+		"Q":"0.75731156",
+		"B":"0"
+      }
+	}`)
+	fakeErrMsg := "fake error"
+	s.mockWsServe(data, errors.New(fakeErrMsg))
+	defer s.assertWsServe()
+
+	doneC, stopC, err := WsKlineServe("BTCUSD_200626", "1m", func(event *WsKlineEvent) {
+		e := &WsKlineEvent{
+			Event:  "kline",
+			Time:   1591261542539,
+			Symbol: "BTCUSD_200626",
+			Kline: WsKline{
+				StartTime:            1591261500000,
+				EndTime:              1591261559999,
+				Symbol:               "BTCUSD_200626",
+				Interval:             "1m",
+				FirstTradeID:         606400,
+				LastTradeID:          606430,
+				Open:                 "9638.9",
+				Close:                "9639.8",
+				High:                 "9639.8",
+				Low:                  "9638.6",
+				Volume:               "156",
+				TradeNum:             31,
+				IsFinal:              false,
+				QuoteVolume:          "1.61836886",
+				ActiveBuyVolume:      "73",
+				ActiveBuyQuoteVolume: "0.75731156",
+			},
+		}
+		s.assertWsKlineEventEqual(e, event)
+	}, func(err error) {
+		s.r().EqualError(err, fakeErrMsg)
+	})
+	s.r().NoError(err)
+	stopC <- struct{}{}
+	<-doneC
+}
+
+func (s *websocketServiceTestSuite) assertWsKlineEventEqual(e, a *WsKlineEvent) {
+	r := s.r()
+	r.Equal(e.Event, a.Event, "Event")
+	r.Equal(e.Time, a.Time, "Time")
+	r.Equal(e.Symbol, a.Symbol, "Symbol")
+	ek, ak := e.Kline, a.Kline
+	r.Equal(ek.StartTime, ak.StartTime, "StartTime")
+	r.Equal(ek.EndTime, ak.EndTime, "EndTime")
+	r.Equal(ek.Symbol, ak.Symbol, "Symbol")
+	r.Equal(ek.Interval, ak.Interval, "Interval")
+	r.Equal(ek.FirstTradeID, ak.FirstTradeID, "FirstTradeID")
+	r.Equal(ek.LastTradeID, ak.LastTradeID, "LastTradeID")
+	r.Equal(ek.Open, ak.Open, "Open")
+	r.Equal(ek.Close, ak.Close, "Close")
+	r.Equal(ek.High, ak.High, "High")
+	r.Equal(ek.Low, ak.Low, "Low")
+	r.Equal(ek.Volume, ak.Volume, "Volume")
+	r.Equal(ek.TradeNum, ak.TradeNum, "TradeNum")
+	r.Equal(ek.IsFinal, ak.IsFinal, "IsFinal")
+	r.Equal(ek.QuoteVolume, ak.QuoteVolume, "QuoteVolume")
+	r.Equal(ek.ActiveBuyVolume, ak.ActiveBuyVolume, "ActiveBuyVolume")
+	r.Equal(ek.ActiveBuyQuoteVolume, ak.ActiveBuyQuoteVolume, "ActiveBuyQuoteVolume")
+}
+
+// https://binance-docs.github.io/apidocs/delivery/en/#continues-contract-kline-candlestick-streams
+func (s *websocketServiceTestSuite) TestContinuousKlineServe() {
+	data := []byte(`{
+	  "e":"continuous_kline",
+	  "E":1591261542539,
+	  "ps":"BTCUSD",
+      "ct":"NEXT_QUARTER",
+	  "k":{
+		"t":1591261500000,
+		"T":1591261559999,
+		"i":"1m",
+		"f":606400,
+		"L":606430,
+		"o":"9638.9",
+		"c":"9639.8",
+		"h":"9639.8",
+		"l":"9638.6",
+		"v":"156",
+		"n":31,
+		"x":false,
+		"q":"1.61836886",
+		"V":"73",
+		"Q":"0.75731156",
+		"B":"0"
+      }
+	}`)
+	fakeErrMsg := "fake error"
+	s.mockWsServe(data, errors.New(fakeErrMsg))
+	defer s.assertWsServe()
+
+	doneC, stopC, err := WsContinuousKlineServe("BTCUSD", "NEXT_QUARTER", "1m", func(event *WsContinuousKlineEvent) {
+		e := &WsContinuousKlineEvent{
+			Event:        "continuous_kline",
+			Time:         1591261542539,
+			Pair:         "BTCUSD",
+			ContractType: "NEXT_QUARTER",
+			Kline: WsContinuousKline{
+				StartTime:            1591261500000,
+				EndTime:              1591261559999,
+				Interval:             "1m",
+				FirstTradeID:         606400,
+				LastTradeID:          606430,
+				Open:                 "9638.9",
+				Close:                "9639.8",
+				High:                 "9639.8",
+				Low:                  "9638.6",
+				Volume:               "156",
+				TradeNum:             31,
+				IsFinal:              false,
+				QuoteVolume:          "1.61836886",
+				ActiveBuyVolume:      "73",
+				ActiveBuyQuoteVolume: "0.75731156",
+			},
+		}
+		s.assertWsContinuousKlineEventEqual(e, event)
+	}, func(err error) {
+		s.r().EqualError(err, fakeErrMsg)
+	})
+	s.r().NoError(err)
+	stopC <- struct{}{}
+	<-doneC
+}
+
+func (s *websocketServiceTestSuite) assertWsContinuousKlineEventEqual(e, a *WsContinuousKlineEvent) {
+	r := s.r()
+	r.Equal(e.Event, a.Event, "Event")
+	r.Equal(e.Time, a.Time, "Time")
+	r.Equal(e.Pair, a.Pair, "Pair")
+	r.Equal(e.ContractType, a.ContractType, "ContractType")
+	ek, ak := e.Kline, a.Kline
+	r.Equal(ek.StartTime, ak.StartTime, "StartTime")
+	r.Equal(ek.EndTime, ak.EndTime, "EndTime")
+	r.Equal(ek.Interval, ak.Interval, "Interval")
+	r.Equal(ek.FirstTradeID, ak.FirstTradeID, "FirstTradeID")
+	r.Equal(ek.LastTradeID, ak.LastTradeID, "LastTradeID")
+	r.Equal(ek.Open, ak.Open, "Open")
+	r.Equal(ek.Close, ak.Close, "Close")
+	r.Equal(ek.High, ak.High, "High")
+	r.Equal(ek.Low, ak.Low, "Low")
+	r.Equal(ek.Volume, ak.Volume, "Volume")
+	r.Equal(ek.TradeNum, ak.TradeNum, "TradeNum")
+	r.Equal(ek.IsFinal, ak.IsFinal, "IsFinal")
+	r.Equal(ek.QuoteVolume, ak.QuoteVolume, "QuoteVolume")
+	r.Equal(ek.ActiveBuyVolume, ak.ActiveBuyVolume, "ActiveBuyVolume")
+	r.Equal(ek.ActiveBuyQuoteVolume, ak.ActiveBuyQuoteVolume, "ActiveBuyQuoteVolume")
+}
+
+// https://binance-docs.github.io/apidocs/delivery/en/#index-kline-candlestick-streams
+func (s *websocketServiceTestSuite) TestIndexKlineServe() {
+	data := []byte(`{
+	  "e":"indexPrice_kline",
+	  "E":1591267070033,
+	  "ps":"BTCUSD",
+	  "k":{
+		"t":1591267020000,
+		"T":1591267079999,
+		"s":"0",
+		"i":"1m",
+		"f":1591267020000,
+		"L":1591267070000,
+		"o":"9542.21900000",
+		"c":"9542.50440000",
+		"h":"9542.71640000",
+		"l":"9542.21040000",
+		"v":"0",
+		"n":51,
+		"x":false,
+		"q":"0",
+		"V":"0",
+		"Q":"0",
+		"B":"0"
+	  }
+	}`)
+	fakeErrMsg := "fake error"
+	s.mockWsServe(data, errors.New(fakeErrMsg))
+	defer s.assertWsServe()
+
+	doneC, stopC, err := WsIndexPriceKlineServe("BTCUSD", "1m", func(event *WsIndexPriceKlineEvent) {
+		e := &WsIndexPriceKlineEvent{
+			Event: "indexPrice_kline",
+			Time:  1591267070033,
+			Pair:  "BTCUSD",
+			Kline: WsIndexPriceKline{
+				StartTime: 1591267020000,
+				EndTime:   1591267079999,
+				Interval:  "1m",
+				Open:      "9542.21900000",
+				Close:     "9542.50440000",
+				High:      "9542.71640000",
+				Low:       "9542.21040000",
+				TradeNum:  51,
+				IsFinal:   false,
+			},
+		}
+		s.assertWsIndexKlineEventEqual(e, event)
+	}, func(err error) {
+		s.r().EqualError(err, fakeErrMsg)
+	})
+	s.r().NoError(err)
+	stopC <- struct{}{}
+	<-doneC
+}
+
+func (s *websocketServiceTestSuite) assertWsIndexKlineEventEqual(e, a *WsIndexPriceKlineEvent) {
+	r := s.r()
+	r.Equal(e.Event, a.Event, "Event")
+	r.Equal(e.Time, a.Time, "Time")
+	r.Equal(e.Pair, a.Pair, "Pair")
+	ek, ak := e.Kline, a.Kline
+	r.Equal(ek.StartTime, ak.StartTime, "StartTime")
+	r.Equal(ek.EndTime, ak.EndTime, "EndTime")
+	r.Equal(ek.Interval, ak.Interval, "Interval")
+	r.Equal(ek.Open, ak.Open, "Open")
+	r.Equal(ek.Close, ak.Close, "Close")
+	r.Equal(ek.High, ak.High, "High")
+	r.Equal(ek.Low, ak.Low, "Low")
+	r.Equal(ek.TradeNum, ak.TradeNum, "TradeNum")
+	r.Equal(ek.IsFinal, ak.IsFinal, "IsFinal")
+}
+
+// https://binance-docs.github.io/apidocs/delivery/en/#mark-price-kline-candlestick-streams
+func (s *websocketServiceTestSuite) TestMarkPriceKlineServe() {
+	data := []byte(`{
+	  "e":"markPrice_kline",
+	  "E":1591267398004,
+	  "ps":"BTCUSD",
+	  "k":{
+		"t":1591267380000,
+		"T":1591267439999,
+		"s":"BTCUSD_200626",
+		"i":"1m",
+		"f":1591267380000,
+		"L":1591267398000,
+		"o":"9539.67161333",
+		"c":"9540.82761333",
+		"h":"9540.82761333",
+		"l":"9539.66961333",
+		"v":"0",
+		"n":19,
+		"x":false,
+		"q":"0",
+		"V":"0",
+		"Q":"0",
+		"B":"0"
+	  }
+	}`)
+	fakeErrMsg := "fake error"
+	s.mockWsServe(data, errors.New(fakeErrMsg))
+	defer s.assertWsServe()
+
+	doneC, stopC, err := WsMarkPriceKlineServe("BTCUSD_200626", "1m", func(event *WsMarkPriceKlineEvent) {
+		e := &WsMarkPriceKlineEvent{
+			Event: "markPrice_kline",
+			Time:  1591267398004,
+			Pair:  "BTCUSD",
+			Kline: WsMarkPriceKline{
+				StartTime: 1591267380000,
+				EndTime:   1591267439999,
+				Symbol:    "BTCUSD_200626",
+				Interval:  "1m",
+				Open:      "9539.67161333",
+				Close:     "9540.82761333",
+				High:      "9540.82761333",
+				Low:       "9539.66961333",
+				TradeNum:  19,
+				IsFinal:   false,
+			},
+		}
+		s.assertWsMarkPriceKlineEventEqual(e, event)
+	}, func(err error) {
+		s.r().EqualError(err, fakeErrMsg)
+	})
+	s.r().NoError(err)
+	stopC <- struct{}{}
+	<-doneC
+}
+
+func (s *websocketServiceTestSuite) assertWsMarkPriceKlineEventEqual(e, a *WsMarkPriceKlineEvent) {
+	r := s.r()
+	r.Equal(e.Event, a.Event, "Event")
+	r.Equal(e.Time, a.Time, "Time")
+	r.Equal(e.Pair, a.Pair, "Pair")
+	ek, ak := e.Kline, a.Kline
+	r.Equal(ek.StartTime, ak.StartTime, "StartTime")
+	r.Equal(ek.EndTime, ak.EndTime, "EndTime")
+	r.Equal(ek.Interval, ak.Interval, "Interval")
+	r.Equal(ek.Symbol, ak.Symbol, "Symbol")
+	r.Equal(ek.Open, ak.Open, "Open")
+	r.Equal(ek.Close, ak.Close, "Close")
+	r.Equal(ek.High, ak.High, "High")
+	r.Equal(ek.Low, ak.Low, "Low")
+	r.Equal(ek.TradeNum, ak.TradeNum, "TradeNum")
+	r.Equal(ek.IsFinal, ak.IsFinal, "IsFinal")
+}
+
+// https://binance-docs.github.io/apidocs/delivery/en/#individual-symbol-mini-ticker-stream
+func (s *websocketServiceTestSuite) TestMiniMarketTickerServe() {
+	data := []byte(`{
+	    "e":"24hrMiniTicker",
+	    "E":1591267704450,
+	    "s":"BTCUSD_200626",
+	    "ps":"BTCUSD",
+	    "c":"9561.7",
+	    "o":"9580.9",
+	    "h":"10000.0",
+	    "l":"7000.0",
+	    "v":"487476",
+	    "q":"33264343847.22378500"
+	  }`)
+	fakeErrMsg := "fake error"
+	s.mockWsServe(data, errors.New(fakeErrMsg))
+	defer s.assertWsServe()
+
+	doneC, stopC, err := WsMiniMarketTickerServe("BTCUSD_200626", func(event *WsMiniMarketTickerEvent) {
+		e := &WsMiniMarketTickerEvent{
+			Event:       "24hrMiniTicker",
+			Time:        1591267704450,
+			Symbol:      "BTCUSD_200626",
+			Pair:        "BTCUSD",
+			ClosePrice:  "9561.7",
+			OpenPrice:   "9580.9",
+			HighPrice:   "10000.0",
+			LowPrice:    "7000.0",
+			Volume:      "487476",
+			QuoteVolume: "33264343847.22378500",
+		}
+		s.assertWsMinMarketTickerEvent(e, event)
+	},
+		func(err error) {
+			s.r().EqualError(err, fakeErrMsg)
+		})
+
+	s.r().NoError(err)
+	stopC <- struct{}{}
+	<-doneC
+}
+
+// https://binance-docs.github.io/apidocs/delivery/en/#all-market-mini-tickers-stream
+func (s *websocketServiceTestSuite) TestAllMiniMarketTickerServe() {
+	data := []byte(`[{
+		"e":"24hrMiniTicker",
+		"E":1591267704450,
+		"s":"BTCUSD_200626",
+		"ps":"BTCUSD",
+		"c":"9561.7",
+		"o":"9580.9",
+		"h":"10000.0",
+		"l":"7000.0",
+		"v":"487476",
+		"q":"33264343847.22378500"
+	  }]`)
+	fakeErrMsg := "fake error"
+	s.mockWsServe(data, errors.New(fakeErrMsg))
+	defer s.assertWsServe()
+
+	doneC, stopC, err := WsAllMiniMarketTickerServe(func(event WsAllMiniMarketTickerEvent) {
+		e := []*WsMiniMarketTickerEvent{{
+			Event:       "24hrMiniTicker",
+			Time:        1591267704450,
+			Symbol:      "BTCUSD_200626",
+			Pair:        "BTCUSD",
+			ClosePrice:  "9561.7",
+			OpenPrice:   "9580.9",
+			HighPrice:   "10000.0",
+			LowPrice:    "7000.0",
+			Volume:      "487476",
+			QuoteVolume: "33264343847.22378500",
+		}}
+		s.assertWsMinMarketTickerEvent(e[0], event[0])
+	},
+		func(err error) {
+			s.r().EqualError(err, fakeErrMsg)
+		})
+
+	s.r().NoError(err)
+	stopC <- struct{}{}
+	<-doneC
+}
+
+func (s *websocketServiceTestSuite) assertWsMinMarketTickerEvent(e, a *WsMiniMarketTickerEvent) {
+	r := s.r()
+	r.Equal(e.Event, a.Event, "Event")
+	r.Equal(e.Time, a.Time, "Time")
+	r.Equal(e.Symbol, a.Symbol, "Symbol")
+	r.Equal(e.Pair, a.Pair, "Pair")
+	r.Equal(e.ClosePrice, a.ClosePrice, "ClosePrice")
+	r.Equal(e.OpenPrice, a.OpenPrice, "OpenPrice")
+	r.Equal(e.HighPrice, a.HighPrice, "HighPrice")
+	r.Equal(e.LowPrice, a.LowPrice, "LowPrice")
+	r.Equal(e.Volume, a.Volume, "Volume")
+	r.Equal(e.QuoteVolume, a.QuoteVolume, "QuoteVolume")
+}
+
+// https://binance-docs.github.io/apidocs/delivery/en/#individual-symbol-ticker-streams
+func (s *websocketServiceTestSuite) TestMarketTickerServe() {
+	data := []byte(`{
+		"e":"24hrTicker",
+		"E":1591268262453,
+		"s":"BTCUSD_200626",
+		"ps":"BTCUSD",
+		"p":"-43.4",
+		"P":"-0.452",
+		"w":"0.00147974",
+		"c":"9548.5",
+		"Q":"2",
+		"o":"9591.9",
+		"h":"10000.0",
+		"l":"7000.0",
+		"v":"487850",
+		"q":"32968676323.46222700",
+		"O":1591181820000,
+		"C":1591268262442,
+		"F":512014,
+		"L":615289,
+		"n":103272
+	  }`)
+	fakeErrMsg := "fake error"
+	s.mockWsServe(data, errors.New(fakeErrMsg))
+	defer s.assertWsServe()
+
+	doneC, stopC, err := WsMarketTickerServe("BTCUSDT", func(event *WsMarketTickerEvent) {
+		e := &WsMarketTickerEvent{
+			Event:              "24hrTicker",
+			Time:               1591268262453,
+			Symbol:             "BTCUSD_200626",
+			Pair:               "BTCUSD",
+			PriceChange:        "-43.4",
+			PriceChangePercent: "-0.452",
+			WeightedAvgPrice:   "0.00147974",
+			ClosePrice:         "9548.5",
+			CloseQty:           "2",
+			OpenPrice:          "9591.9",
+			HighPrice:          "10000.0",
+			LowPrice:           "7000.0",
+			BaseVolume:         "487850",
+			QuoteVolume:        "32968676323.46222700",
+			OpenTime:           1591181820000,
+			CloseTime:          1591268262442,
+			FirstID:            512014,
+			LastID:             615289,
+			TradeCount:         103272,
+		}
+		s.assertWsMarketTickerEvent(e, event)
+	},
+		func(err error) {
+			s.r().EqualError(err, fakeErrMsg)
+		})
+
+	s.r().NoError(err)
+	stopC <- struct{}{}
+	<-doneC
+}
+
+// https://binance-docs.github.io/apidocs/delivery/en/#all-market-tickers-streams
+func (s *websocketServiceTestSuite) TestAllMarketTickerServe() {
+	data := []byte(`[{
+		"e":"24hrTicker",
+		"E":1591268262453,
+		"s":"BTCUSD_200626",
+		"ps":"BTCUSD",
+		"p":"-43.4",
+		"P":"-0.452",
+		"w":"0.00147974",
+		"c":"9548.5",
+		"Q":"2",
+		"o":"9591.9",
+		"h":"10000.0",
+		"l":"7000.0",
+		"v":"487850",
+		"q":"32968676323.46222700",
+		"O":1591181820000,
+		"C":1591268262442,
+		"F":512014,
+		"L":615289,
+		"n":103272
+	  }]`)
+	fakeErrMsg := "fake error"
+	s.mockWsServe(data, errors.New(fakeErrMsg))
+	defer s.assertWsServe()
+
+	doneC, stopC, err := WsAllMarketTickerServe(func(event WsAllMarketTickerEvent) {
+		e := WsAllMarketTickerEvent{{
+			Event:              "24hrTicker",
+			Time:               1591268262453,
+			Symbol:             "BTCUSD_200626",
+			Pair:               "BTCUSD",
+			PriceChange:        "-43.4",
+			PriceChangePercent: "-0.452",
+			WeightedAvgPrice:   "0.00147974",
+			ClosePrice:         "9548.5",
+			CloseQty:           "2",
+			OpenPrice:          "9591.9",
+			HighPrice:          "10000.0",
+			LowPrice:           "7000.0",
+			BaseVolume:         "487850",
+			QuoteVolume:        "32968676323.46222700",
+			OpenTime:           1591181820000,
+			CloseTime:          1591268262442,
+			FirstID:            512014,
+			LastID:             615289,
+			TradeCount:         103272,
+		}}
+		s.assertWsMarketTickerEvent(e[0], event[0])
+	},
+		func(err error) {
+			s.r().EqualError(err, fakeErrMsg)
+		})
+
+	s.r().NoError(err)
+	stopC <- struct{}{}
+	<-doneC
+}
+
+func (s *websocketServiceTestSuite) assertWsMarketTickerEvent(e, a *WsMarketTickerEvent) {
+	r := s.r()
+	r.Equal(e.Event, a.Event, "Event")
+	r.Equal(e.Time, a.Time, "Time")
+	r.Equal(e.Symbol, a.Symbol, "Symbol")
+	r.Equal(e.Pair, a.Pair, "Pair")
+	r.Equal(e.PriceChange, a.PriceChange, "PriceChange")
+	r.Equal(e.PriceChangePercent, a.PriceChangePercent, "PriceChangePercent")
+	r.Equal(e.WeightedAvgPrice, a.WeightedAvgPrice, "WeightedAvgPrice")
+	r.Equal(e.ClosePrice, a.ClosePrice, "ClosePrice")
+	r.Equal(e.CloseQty, a.CloseQty, "CloseQty")
+	r.Equal(e.OpenPrice, a.OpenPrice, "OpenPrice")
+	r.Equal(e.HighPrice, a.HighPrice, "HighPrice")
+	r.Equal(e.LowPrice, a.LowPrice, "LowPrice")
+	r.Equal(e.BaseVolume, a.BaseVolume, "BaseVolume")
+	r.Equal(e.QuoteVolume, a.QuoteVolume, "QuoteVolume")
+	r.Equal(e.OpenTime, a.OpenTime, "OpenTime")
+	r.Equal(e.CloseTime, a.CloseTime, "CloseTime")
+	r.Equal(e.FirstID, a.FirstID, "FirstID")
+	r.Equal(e.LastID, a.LastID, "LastID")
+	r.Equal(e.TradeCount, a.TradeCount, "TradeCount")
+}
+
+// https://binance-docs.github.io/apidocs/delivery/en/#individual-symbol-book-ticker-streams
+func (s *websocketServiceTestSuite) TestBookTickerServe() {
+	data := []byte(`{
+  		"e":"bookTicker",
+  		"u":17242169,
+  		"s":"BTCUSD_200626",
+  		"ps":"BTCUSD",
+  		"b":"9548.1",
+  		"B":"52",
+  		"a":"9548.5",
+  		"A":"11",
+  		"T":1591268628155,
+  		"E":1591268628166
+	  }`)
+	fakeErrMsg := "fake error"
+	s.mockWsServe(data, errors.New(fakeErrMsg))
+	defer s.assertWsServe()
+
+	doneC, stopC, err := WsBookTickerServe("BTCUSD_200626", func(event *WsBookTickerEvent) {
+		e := &WsBookTickerEvent{
+			Event:           "bookTicker",
+			UpdateID:        17242169,
+			Symbol:          "BTCUSD_200626",
+			Pair:            "BTCUSD",
+			BestBidPrice:    "9548.1",
+			BestBidQty:      "52",
+			BestAskPrice:    "9548.5",
+			BestAskQty:      "11",
+			TransactionTime: 1591268628155,
+			Time:            1591268628166,
+		}
+		s.assertWsBookTickerEvent(e, event)
+	},
+		func(err error) {
+			s.r().EqualError(err, fakeErrMsg)
+		})
+
+	s.r().NoError(err)
+	stopC <- struct{}{}
+	<-doneC
+}
+
+// https://binance-docs.github.io/apidocs/delivery/en/#all-book-tickers-stream
+func (s *websocketServiceTestSuite) TestAllBookTickerServe() {
+	data := []byte(`{
+  		"e":"bookTicker",
+  		"u":17242169,
+  		"s":"BTCUSD_200626",
+  		"ps":"BTCUSD",
+  		"b":"9548.1",
+  		"B":"52",
+  		"a":"9548.5",
+  		"A":"11",
+  		"T":1591268628155,
+  		"E":1591268628166
+	  }`)
+	fakeErrMsg := "fake error"
+	s.mockWsServe(data, errors.New(fakeErrMsg))
+	defer s.assertWsServe()
+
+	doneC, stopC, err := WsAllBookTickerServe(func(event *WsBookTickerEvent) {
+		e := &WsBookTickerEvent{
+			Event:           "bookTicker",
+			UpdateID:        17242169,
+			Symbol:          "BTCUSD_200626",
+			Pair:            "BTCUSD",
+			BestBidPrice:    "9548.1",
+			BestBidQty:      "52",
+			BestAskPrice:    "9548.5",
+			BestAskQty:      "11",
+			TransactionTime: 1591268628155,
+			Time:            1591268628166,
+		}
+		s.assertWsBookTickerEvent(e, event)
+	},
+		func(err error) {
+			s.r().EqualError(err, fakeErrMsg)
+		})
+
+	s.r().NoError(err)
+	stopC <- struct{}{}
+	<-doneC
+}
+
+func (s *websocketServiceTestSuite) assertWsBookTickerEvent(e, a *WsBookTickerEvent) {
+	r := s.r()
+	r.Equal(e.Event, a.Event, "Event")
+	r.Equal(e.UpdateID, a.UpdateID, "UpdateID")
+	r.Equal(e.Time, a.Time, "Time")
+	r.Equal(e.TransactionTime, a.TransactionTime, "TransactionTime")
+	r.Equal(e.Symbol, a.Symbol, "Symbol")
+	r.Equal(e.Pair, a.Pair, "Pair")
+	r.Equal(e.BestBidPrice, a.BestBidPrice, "BestBidPrice")
+	r.Equal(e.BestBidQty, a.BestBidQty, "BestBidQty")
+	r.Equal(e.BestAskPrice, a.BestAskPrice, "BestAskPrice")
+	r.Equal(e.BestAskQty, a.BestAskQty, "BestAskQty")
+}
+
+// https://binance-docs.github.io/apidocs/delivery/en/#liquidation-order-streams
+func (s *websocketServiceTestSuite) TestLiquidationOrderServe() {
+	data := []byte(`{
+	  "e":"forceOrder",
+	  "E": 1591154240950,
+	  "o":{
+	    "s":"BTCUSD_200925",
+	    "ps": "BTCUSD",
+	    "S":"SELL",
+	    "o":"LIMIT",
+	    "f":"IOC",
+	    "q":"1",
+	    "p":"9425.5",
+	    "ap":"9496.5",
+	    "X":"FILLED",
+	    "l":"1",
+	    "z":"1",
+	    "T": 1591154240949
+	  }
+	}`)
+	fakeErrMsg := "fake error"
+	s.mockWsServe(data, errors.New(fakeErrMsg))
+	defer s.assertWsServe()
+
+	doneC, stopC, err := WsLiquidationOrderServe("BTCUSD_200925", func(event *WsLiquidationOrderEvent) {
+		e := &WsLiquidationOrderEvent{
+			Event: "forceOrder",
+			Time:  1591154240950,
+			LiquidationOrder: WsLiquidationOrder{
+				Symbol:               "BTCUSD_200925",
+				Pair:                 "BTCUSD",
+				Side:                 SideTypeSell,
+				OrderType:            OrderTypeLimit,
+				TimeInForce:          TimeInForceTypeIOC,
+				OrigQuantity:         "1",
+				Price:                "9425.5",
+				AvgPrice:             "9496.5",
+				OrderStatus:          OrderStatusTypeFilled,
+				LastFilledQty:        "1",
+				AccumulatedFilledQty: "1",
+				TradeTime:            1591154240949,
+			},
+		}
+		s.assertLiquidationOrderEvent(e, event)
+	},
+		func(err error) {
+			s.r().EqualError(err, fakeErrMsg)
+		})
+
+	s.r().NoError(err)
+	stopC <- struct{}{}
+	<-doneC
+}
+
+// https://binance-docs.github.io/apidocs/delivery/en/#all-market-liquidation-order-streams
+func (s *websocketServiceTestSuite) TestAllLiquidationOrderServe() {
+	data := []byte(`{
+	  "e":"forceOrder",
+	  "E": 1591154240950,
+	  "o":{
+		"s":"BTCUSD_200925",
+		"ps": "BTCUSD",
+		"S":"SELL",
+		"o":"LIMIT",
+		"f":"IOC",
+		"q":"1",
+		"p":"9425.5",
+		"ap":"9496.5",
+		"X":"FILLED",
+		"l":"1",
+		"z":"1",
+		"T": 1591154240949
+	  }
+	}`)
+	fakeErrMsg := "fake error"
+	s.mockWsServe(data, errors.New(fakeErrMsg))
+	defer s.assertWsServe()
+
+	doneC, stopC, err := WsAllLiquidationOrderServe(func(event *WsLiquidationOrderEvent) {
+		e := &WsLiquidationOrderEvent{
+			Event: "forceOrder",
+			Time:  1591154240950,
+			LiquidationOrder: WsLiquidationOrder{
+				Symbol:               "BTCUSD_200925",
+				Pair:                 "BTCUSD",
+				Side:                 SideTypeSell,
+				OrderType:            OrderTypeLimit,
+				TimeInForce:          TimeInForceTypeIOC,
+				OrigQuantity:         "1",
+				Price:                "9425.5",
+				AvgPrice:             "9496.5",
+				OrderStatus:          OrderStatusTypeFilled,
+				LastFilledQty:        "1",
+				AccumulatedFilledQty: "1",
+				TradeTime:            1591154240949,
+			},
+		}
+		s.assertLiquidationOrderEvent(e, event)
+	},
+		func(err error) {
+			s.r().EqualError(err, fakeErrMsg)
+		})
+
+	s.r().NoError(err)
+	stopC <- struct{}{}
+	<-doneC
+}
+
+func (s *websocketServiceTestSuite) assertLiquidationOrderEvent(e, a *WsLiquidationOrderEvent) {
+	r := s.r()
+	r.Equal(e.Event, a.Event, "Event")
+	r.Equal(e.Time, a.Time, "Time")
+	elo, alo := e.LiquidationOrder, a.LiquidationOrder
+	r.Equal(elo.Symbol, alo.Symbol, "Symbol")
+	r.Equal(elo.Pair, alo.Pair, "Pair")
+	r.Equal(elo.Side, alo.Side, "Side")
+	r.Equal(elo.OrderType, alo.OrderType, "OrderType")
+	r.Equal(elo.TimeInForce, alo.TimeInForce, "TimeInForce")
+	r.Equal(elo.OrigQuantity, alo.OrigQuantity, "OrigQuantity")
+	r.Equal(elo.Price, alo.Price, "Price")
+	r.Equal(elo.AvgPrice, alo.AvgPrice, "AvgPrice")
+	r.Equal(elo.OrderStatus, alo.OrderStatus, "OrderStatus")
+	r.Equal(elo.LastFilledQty, alo.LastFilledQty, "LastFilledQty")
+	r.Equal(elo.AccumulatedFilledQty, alo.AccumulatedFilledQty, "AccumulatedFilledQty")
+	r.Equal(elo.TradeTime, alo.TradeTime, "TradeTime")
+}
+
+// https://binance-docs.github.io/apidocs/delivery/en/#partial-book-depth-streams
+func (s *websocketServiceTestSuite) TestPartialDepthServe() {
+	data := []byte(`{
+	  "e":"depthUpdate",     
+	  "E":1591269996801,     
+	  "T":1591269996646,     
+	  "s":"BTCUSD_200626",   
+	  "ps":"BTCUSD",         
+	  "U":17276694,
+	  "u":17276701,
+	  "pu":17276678,
+	  "b":[                  
+		["9523.0","5"],
+		["9522.8","8"],
+		["9522.6","2"],
+		["9522.4","1"],
+		["9522.0","5"]
+	  ],
+	  "a":[
+		["9524.6","2"],
+		["9524.7","3"],
+		["9524.9","16"],
+		["9525.1","10"],
+		["9525.3","6"]
+	  ]
+	}`)
+	fakeErrMsg := "fake error"
+	s.mockWsServe(data, errors.New(fakeErrMsg))
+	defer s.assertWsServe()
+
+	doneC, stopC, err := WsPartialDepthServe("BTCUSD_200626", 5, func(event *WsDepthEvent) {
+		e := &WsDepthEvent{
+			Event:            "depthUpdate",
+			Time:             1591269996801,
+			TransactionTime:  1591269996646,
+			Symbol:           "BTCUSD_200626",
+			Pair:             "BTCUSD",
+			FirstUpdateID:    17276694,
+			LastUpdateID:     17276701,
+			PrevLastUpdateID: 17276678,
+			Bids: []Bid{
+				{Price: "9523.0", Quantity: "5"},
+				{Price: "9522.8", Quantity: "8"},
+				{Price: "9522.6", Quantity: "2"},
+				{Price: "9522.4", Quantity: "1"},
+				{Price: "9522.0", Quantity: "5"},
+			},
+			Asks: []Ask{
+				{Price: "9524.6", Quantity: "2"},
+				{Price: "9524.7", Quantity: "3"},
+				{Price: "9524.9", Quantity: "16"},
+				{Price: "9525.1", Quantity: "10"},
+				{Price: "9525.3", Quantity: "6"},
+			},
+		}
+		s.assertDepthEvent(e, event)
+	},
+		func(err error) {
+			s.r().EqualError(err, fakeErrMsg)
+		})
+
+	s.r().NoError(err)
+	stopC <- struct{}{}
+	<-doneC
+}
+
+// https://binance-docs.github.io/apidocs/delivery/en/#diff-book-depth-streams
+func (s *websocketServiceTestSuite) TestDiffDepthServe() {
+	data := []byte(`{
+	  "e": "depthUpdate",
+	  "E": 1591270260907,
+	  "T": 1591270260891,
+	  "s": "BTCUSD_200626",
+	  "ps": "BTCUSD",
+	  "U": 17285681,
+	  "u": 17285702,
+	  "pu": 17285675,
+	  "b": [
+		["9517.6","10"]
+	  ],
+	  "a": [
+		["9518.5","45"]
+	  ]
+	}`)
+	fakeErrMsg := "fake error"
+	s.mockWsServe(data, errors.New(fakeErrMsg))
+	defer s.assertWsServe()
+
+	doneC, stopC, err := WsDiffDepthServe("BTCUSD_200626", func(event *WsDepthEvent) {
+		e := &WsDepthEvent{
+			Event:            "depthUpdate",
+			Time:             1591270260907,
+			TransactionTime:  1591270260891,
+			Symbol:           "BTCUSD_200626",
+			Pair:             "BTCUSD",
+			FirstUpdateID:    17285681,
+			LastUpdateID:     17285702,
+			PrevLastUpdateID: 17285675,
+			Bids:             []Bid{{Price: "9517.6", Quantity: "10"}},
+			Asks:             []Ask{{Price: "9518.5", Quantity: "45"}},
+		}
+		s.assertDepthEvent(e, event)
+	},
+		func(err error) {
+			s.r().EqualError(err, fakeErrMsg)
+		})
+
+	s.r().NoError(err)
+	stopC <- struct{}{}
+	<-doneC
+}
+
+func (s *websocketServiceTestSuite) assertDepthEvent(e, a *WsDepthEvent) {
+	r := s.r()
+	r.Equal(e.Event, a.Event, "Event")
+	r.Equal(e.Time, a.Time, "Time")
+	r.Equal(e.TransactionTime, a.TransactionTime, "TransactionTime")
+	r.Equal(e.Symbol, a.Symbol, "Symbol")
+	r.Equal(e.Pair, a.Pair, "Pair")
+	r.Equal(e.FirstUpdateID, a.FirstUpdateID, "FirstUpdateID")
+	r.Equal(e.LastUpdateID, a.LastUpdateID, "LastUpdateID")
+	r.Equal(e.PrevLastUpdateID, a.PrevLastUpdateID, "PrevLastUpdateID")
+	for i, b := range e.Bids {
+		r.Equal(b.Price, a.Bids[i].Price, "Price")
+		r.Equal(b.Quantity, a.Bids[i].Quantity, "Quantity")
+	}
+	for i, b := range e.Asks {
+		r.Equal(b.Price, a.Asks[i].Price, "Price")
+		r.Equal(b.Quantity, a.Asks[i].Quantity, "Quantity")
+	}
+}

--- a/v2/delivery/client.go
+++ b/v2/delivery/client.go
@@ -266,6 +266,21 @@ func (c *Client) callAPI(ctx context.Context, r *request, opts ...RequestOption)
 	return data, nil
 }
 
+// NewStartUserStreamService init starting user stream service
+func (c *Client) NewStartUserStreamService() *StartUserStreamService {
+	return &StartUserStreamService{c: c}
+}
+
+// NewKeepaliveUserStreamService init keep alive user stream service
+func (c *Client) NewKeepaliveUserStreamService() *KeepaliveUserStreamService {
+	return &KeepaliveUserStreamService{c: c}
+}
+
+// NewCloseUserStreamService init closing user stream service
+func (c *Client) NewCloseUserStreamService() *CloseUserStreamService {
+	return &CloseUserStreamService{c: c}
+}
+
 // NewExchangeInfoService init exchange info service
 func (c *Client) NewExchangeInfoService() *ExchangeInfoService {
 	return &ExchangeInfoService{c: c}

--- a/v2/delivery/depth_service.go
+++ b/v2/delivery/depth_service.go
@@ -1,0 +1,13 @@
+package delivery
+
+// Bid define bid info with price and quantity
+type Bid struct {
+	Price    string
+	Quantity string
+}
+
+// Ask define ask info with price and quantity
+type Ask struct {
+	Price    string
+	Quantity string
+}

--- a/v2/delivery/user_stream_service.go
+++ b/v2/delivery/user_stream_service.go
@@ -1,0 +1,77 @@
+package delivery
+
+import (
+	"context"
+)
+
+// StartUserStreamService create listen key for user stream service
+type StartUserStreamService struct {
+	c *Client
+}
+
+// Do send request
+func (s *StartUserStreamService) Do(ctx context.Context, opts ...RequestOption) (listenKey string, err error) {
+	r := &request{
+		method:   "POST",
+		endpoint: "/dapi/v1/listenKey",
+		secType:  secTypeSigned,
+	}
+	data, err := s.c.callAPI(ctx, r, opts...)
+	if err != nil {
+		return "", err
+	}
+	j, err := newJSON(data)
+	if err != nil {
+		return "", err
+	}
+	listenKey = j.Get("listenKey").MustString()
+	return listenKey, nil
+}
+
+// KeepaliveUserStreamService update listen key
+type KeepaliveUserStreamService struct {
+	c         *Client
+	listenKey string
+}
+
+// ListenKey set listen key
+func (s *KeepaliveUserStreamService) ListenKey(listenKey string) *KeepaliveUserStreamService {
+	s.listenKey = listenKey
+	return s
+}
+
+// Do send request
+func (s *KeepaliveUserStreamService) Do(ctx context.Context, opts ...RequestOption) (err error) {
+	r := &request{
+		method:   "PUT",
+		endpoint: "/dapi/v1/listenKey",
+		secType:  secTypeSigned,
+	}
+	r.setFormParam("listenKey", s.listenKey)
+	_, err = s.c.callAPI(ctx, r, opts...)
+	return err
+}
+
+// CloseUserStreamService delete listen key
+type CloseUserStreamService struct {
+	c         *Client
+	listenKey string
+}
+
+// ListenKey set listen key
+func (s *CloseUserStreamService) ListenKey(listenKey string) *CloseUserStreamService {
+	s.listenKey = listenKey
+	return s
+}
+
+// Do send request
+func (s *CloseUserStreamService) Do(ctx context.Context, opts ...RequestOption) (err error) {
+	r := &request{
+		method:   "DELETE",
+		endpoint: "/dapi/v1/listenKey",
+		secType:  secTypeSigned,
+	}
+	r.setFormParam("listenKey", s.listenKey)
+	_, err = s.c.callAPI(ctx, r, opts...)
+	return err
+}

--- a/v2/delivery/user_stream_service_test.go
+++ b/v2/delivery/user_stream_service_test.go
@@ -1,0 +1,59 @@
+package delivery
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type userStreamServiceTestSuite struct {
+	baseTestSuite
+}
+
+func TestUserStreamService(t *testing.T) {
+	suite.Run(t, new(userStreamServiceTestSuite))
+}
+
+func (s *userStreamServiceTestSuite) TestStartUserStream() {
+	data := []byte(`{
+        "listenKey": "pqia91ma19a5s61cv6a81va65sdf19v8a65a1a5s61cv6a81va65sdf19v8a65a1"
+    }`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	s.assertReq(func(r *request) {
+		s.assertRequestEqual(newSignedRequest(), r)
+	})
+
+	listenKey, err := s.client.NewStartUserStreamService().Do(newContext())
+	s.r().NoError(err)
+	s.r().Equal("pqia91ma19a5s61cv6a81va65sdf19v8a65a1a5s61cv6a81va65sdf19v8a65a1", listenKey)
+}
+
+func (s *userStreamServiceTestSuite) TestKeepaliveUserStream() {
+	data := []byte(`{}`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	listenKey := "dummykey"
+	s.assertReq(func(r *request) {
+		s.assertRequestEqual(newSignedRequest().setFormParam("listenKey", listenKey), r)
+	})
+
+	err := s.client.NewKeepaliveUserStreamService().ListenKey(listenKey).Do(newContext())
+	s.r().NoError(err)
+}
+
+func (s *userStreamServiceTestSuite) TestCloseUserStream() {
+	data := []byte(`{}`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	listenKey := "dummykey"
+	s.assertReq(func(r *request) {
+		s.assertRequestEqual(newSignedRequest().setFormParam("listenKey", listenKey), r)
+	})
+
+	err := s.client.NewCloseUserStreamService().ListenKey(listenKey).Do(newContext())
+	s.r().NoError(err)
+}

--- a/v2/delivery/websocket.go
+++ b/v2/delivery/websocket.go
@@ -1,0 +1,91 @@
+package delivery
+
+import (
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// WsHandler handle raw websocket message
+type WsHandler func(message []byte)
+
+// ErrHandler handles errors
+type ErrHandler func(err error)
+
+// WsConfig webservice configuration
+type WsConfig struct {
+	Endpoint string
+}
+
+func newWsConfig(endpoint string) *WsConfig {
+	return &WsConfig{
+		Endpoint: endpoint,
+	}
+}
+
+var wsServe = func(cfg *WsConfig, handler WsHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	c, _, err := websocket.DefaultDialer.Dial(cfg.Endpoint, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	doneC = make(chan struct{})
+	stopC = make(chan struct{})
+	go func() {
+		// This function will exit either on error from
+		// websocket.Conn.ReadMessage or when the stopC channel is
+		// closed by the client.
+		defer close(doneC)
+		if WebsocketKeepalive {
+			keepAlive(c, WebsocketTimeout)
+		}
+		// Wait for the stopC channel to be closed.  We do that in a
+		// separate goroutine because ReadMessage is a blocking
+		// operation.
+		silent := false
+		go func() {
+			select {
+			case <-stopC:
+				silent = true
+			case <-doneC:
+			}
+			c.Close()
+		}()
+		for {
+			_, message, err := c.ReadMessage()
+			if err != nil {
+				if !silent {
+					errHandler(err)
+				}
+				return
+			}
+			handler(message)
+		}
+	}()
+	return
+}
+
+func keepAlive(c *websocket.Conn, timeout time.Duration) {
+	ticker := time.NewTicker(timeout)
+
+	lastResponse := time.Now()
+	c.SetPongHandler(func(msg string) error {
+		lastResponse = time.Now()
+		return nil
+	})
+
+	go func() {
+		defer ticker.Stop()
+		for {
+			deadline := time.Now().Add(10 * time.Second)
+			err := c.WriteControl(websocket.PingMessage, []byte{}, deadline)
+			if err != nil {
+				return
+			}
+			<-ticker.C
+			if time.Since(lastResponse) > timeout {
+				c.Close()
+				return
+			}
+		}
+	}()
+}

--- a/v2/delivery/websocket_service.go
+++ b/v2/delivery/websocket_service.go
@@ -1,0 +1,605 @@
+package delivery
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	baseURL = "wss://dstream.binance.com/ws"
+)
+
+var (
+
+	// WebsocketTimeout is an interval for sending ping/pong messages if WebsocketKeepalive is enabled
+	WebsocketTimeout = time.Second * 60
+	// WebsocketKeepalive enables sending ping/pong messages to check the connection stability
+	WebsocketKeepalive = false
+)
+
+// WsAggTradeEvent define websocket aggTrde event.
+type WsAggTradeEvent struct {
+	Event            string `json:"e"`
+	Time             int64  `json:"E"`
+	AggregateTradeID int64  `json:"a"`
+	Symbol           string `json:"s"`
+	Price            string `json:"p"`
+	Quantity         string `json:"q"`
+	FirstTradeID     int64  `json:"f"`
+	LastTradeID      int64  `json:"l"`
+	TradeTime        int64  `json:"T"`
+	Maker            bool   `json:"m"`
+}
+
+// WsAggTradeHandler handle websocket that push trade information that is aggregated for a single taker order.
+type WsAggTradeHandler func(event *WsAggTradeEvent)
+
+// WsAggTradeServe serve websocket that push trade information that is aggregated for a single taker order.
+func WsAggTradeServe(symbol string, handler WsAggTradeHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	endpoint := fmt.Sprintf("%s/%s@aggTrade", baseURL, strings.ToLower(symbol))
+	cfg := newWsConfig(endpoint)
+	wsHandler := func(message []byte) {
+		event := new(WsAggTradeEvent)
+		err := json.Unmarshal(message, &event)
+		if err != nil {
+			errHandler(err)
+			return
+		}
+		handler(event)
+	}
+	return wsServe(cfg, wsHandler, errHandler)
+}
+
+// WsIndexPriceEvent define websocket indexPriceUpdate event.
+type WsIndexPriceEvent struct {
+	Event      string `json:"e"`
+	Time       int64  `json:"E"`
+	Pair       string `json:"i"`
+	IndexPrice string `json:"p"`
+}
+
+// WsIndexPriceHandler handle websocket that push index price for a pair.
+type WsIndexPriceHandler func(event *WsIndexPriceEvent)
+
+// WsIndexPriceServe serve websocket that pushes index price for a pair.
+func WsIndexPriceServe(symbol string, handler WsIndexPriceHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	endpoint := fmt.Sprintf("%s/%s@indexPrice", baseURL, strings.ToLower(symbol))
+	cfg := newWsConfig(endpoint)
+	wsHandler := func(message []byte) {
+		event := new(WsIndexPriceEvent)
+		err := json.Unmarshal(message, &event)
+		if err != nil {
+			errHandler(err)
+			return
+		}
+		handler(event)
+	}
+	return wsServe(cfg, wsHandler, errHandler)
+}
+
+// WsMarkPriceEvent define websocket markPriceUpdate event.
+type WsMarkPriceEvent struct {
+	Event                string `json:"e"`
+	Time                 int64  `json:"E"`
+	Symbol               string `json:"s"`
+	MarkPrice            string `json:"p"`
+	EstimatedSettlePrice string `json:"P"`
+	FundingRate          string `json:"r"`
+	NextFundingTime      int64  `json:"T"`
+}
+
+// WsMarkPriceHandler handle websocket that pushes price and funding rate for a single symbol.
+type WsMarkPriceHandler func(event *WsMarkPriceEvent)
+
+// WsMarkPriceServe serve websocket that pushes price and funding rate for a single symbol.
+func WsMarkPriceServe(symbol string, handler WsMarkPriceHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	endpoint := fmt.Sprintf("%s/%s@markPrice", baseURL, strings.ToLower(symbol))
+	cfg := newWsConfig(endpoint)
+	wsHandler := func(message []byte) {
+		event := new(WsMarkPriceEvent)
+		err := json.Unmarshal(message, &event)
+		if err != nil {
+			errHandler(err)
+			return
+		}
+		handler(event)
+	}
+	return wsServe(cfg, wsHandler, errHandler)
+}
+
+// WsPairMarkPriceEvent defines an array of websocket markPriceUpdate events.
+type WsPairMarkPriceEvent []*WsMarkPriceEvent
+
+// WsPairMarkPriceHandler handle websocket that pushes price and funding rate for all symbol.
+type WsPairMarkPriceHandler func(event WsPairMarkPriceEvent)
+
+// WsPairMarkPriceServe serve websocket that pushes price and funding rate for all symbol.
+func WsPairMarkPriceServe(handler WsPairMarkPriceHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	endpoint := fmt.Sprintf("%s/markPrice@arr", baseURL)
+	cfg := newWsConfig(endpoint)
+	wsHandler := func(message []byte) {
+		var event WsPairMarkPriceEvent
+		err := json.Unmarshal(message, &event)
+		if err != nil {
+			errHandler(err)
+			return
+		}
+		handler(event)
+	}
+	return wsServe(cfg, wsHandler, errHandler)
+}
+
+// WsKlineEvent define websocket kline event
+type WsKlineEvent struct {
+	Event  string  `json:"e"`
+	Time   int64   `json:"E"`
+	Symbol string  `json:"s"`
+	Kline  WsKline `json:"k"`
+}
+
+// WsKline define websocket kline
+type WsKline struct {
+	StartTime            int64  `json:"t"`
+	EndTime              int64  `json:"T"`
+	Symbol               string `json:"s"`
+	Interval             string `json:"i"`
+	FirstTradeID         int64  `json:"f"`
+	LastTradeID          int64  `json:"L"`
+	Open                 string `json:"o"`
+	Close                string `json:"c"`
+	High                 string `json:"h"`
+	Low                  string `json:"l"`
+	Volume               string `json:"v"`
+	TradeNum             int64  `json:"n"`
+	IsFinal              bool   `json:"x"`
+	QuoteVolume          string `json:"q"`
+	ActiveBuyVolume      string `json:"V"`
+	ActiveBuyQuoteVolume string `json:"Q"`
+}
+
+// WsKlineHandler handle websocket kline event
+type WsKlineHandler func(event *WsKlineEvent)
+
+// WsKlineServe serve websocket kline handler with a symbol and interval like 15m, 30s
+func WsKlineServe(symbol string, interval string, handler WsKlineHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	endpoint := fmt.Sprintf("%s/%s@kline_%s", baseURL, strings.ToLower(symbol), interval)
+	cfg := newWsConfig(endpoint)
+	wsHandler := func(message []byte) {
+		event := new(WsKlineEvent)
+		err := json.Unmarshal(message, event)
+		if err != nil {
+			errHandler(err)
+			return
+		}
+		handler(event)
+	}
+	return wsServe(cfg, wsHandler, errHandler)
+}
+
+// WsContinuousKlineEvent define websocket continuous kline event
+type WsContinuousKlineEvent struct {
+	Event        string            `json:"e"`
+	Time         int64             `json:"E"`
+	Pair         string            `json:"ps"`
+	ContractType string            `json:"ct"`
+	Kline        WsContinuousKline `json:"k"`
+}
+
+// WsContinuousKline define websocket continuous kline
+type WsContinuousKline struct {
+	StartTime            int64  `json:"t"`
+	EndTime              int64  `json:"T"`
+	Interval             string `json:"i"`
+	FirstTradeID         int64  `json:"f"`
+	LastTradeID          int64  `json:"L"`
+	Open                 string `json:"o"`
+	Close                string `json:"c"`
+	High                 string `json:"h"`
+	Low                  string `json:"l"`
+	Volume               string `json:"v"`
+	TradeNum             int64  `json:"n"`
+	IsFinal              bool   `json:"x"`
+	QuoteVolume          string `json:"q"`
+	ActiveBuyVolume      string `json:"V"`
+	ActiveBuyQuoteVolume string `json:"Q"`
+}
+
+// WsContinuousKlineHandler handle websocket continuous kline event
+type WsContinuousKlineHandler func(event *WsContinuousKlineEvent)
+
+// WsContinuousKlineServe serve websocket kline handler with a pair, a contract type and interval like 15m, 30s
+func WsContinuousKlineServe(pair string, contractType string, interval string, handler WsContinuousKlineHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	endpoint := fmt.Sprintf("%s/%s_%s@continuousKline_%s", baseURL, strings.ToLower(pair), strings.ToLower(contractType), interval)
+	cfg := newWsConfig(endpoint)
+	wsHandler := func(message []byte) {
+		event := new(WsContinuousKlineEvent)
+		err := json.Unmarshal(message, event)
+		if err != nil {
+			errHandler(err)
+			return
+		}
+		handler(event)
+	}
+	return wsServe(cfg, wsHandler, errHandler)
+}
+
+// WsIndexPriceKlineEvent define websocket index price kline event
+type WsIndexPriceKlineEvent struct {
+	Event string            `json:"e"`
+	Time  int64             `json:"E"`
+	Pair  string            `json:"ps"`
+	Kline WsIndexPriceKline `json:"k"`
+}
+
+// WsIndexPriceKline define websocket index price kline
+type WsIndexPriceKline struct {
+	StartTime   int64  `json:"t"`
+	EndTime     int64  `json:"T"`
+	Interval    string `json:"i"`
+	LastTradeId int64  `json:"L"` // LastTradeId Ignore
+	Open        string `json:"o"`
+	Close       string `json:"c"`
+	High        string `json:"h"`
+	Low         string `json:"l"`
+	TradeNum    int64  `json:"n"`
+	IsFinal     bool   `json:"x"`
+}
+
+// WsIndexPriceKlineHandler handle websocket index kline event
+type WsIndexPriceKlineHandler func(event *WsIndexPriceKlineEvent)
+
+// WsIndexPriceKlineServe serve websocket kline handler with a pair and interval like 15m, 30s
+func WsIndexPriceKlineServe(pair string, interval string, handler WsIndexPriceKlineHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	endpoint := fmt.Sprintf("%s/%s@indexPriceKline_%s", baseURL, strings.ToLower(pair), interval)
+	cfg := newWsConfig(endpoint)
+	wsHandler := func(message []byte) {
+		event := new(WsIndexPriceKlineEvent)
+		err := json.Unmarshal(message, event)
+		if err != nil {
+			errHandler(err)
+			return
+		}
+		handler(event)
+	}
+	return wsServe(cfg, wsHandler, errHandler)
+}
+
+// WsMarkPriceKlineEvent define websocket market price kline event
+type WsMarkPriceKlineEvent struct {
+	Event string           `json:"e"`
+	Time  int64            `json:"E"`
+	Pair  string           `json:"ps"`
+	Kline WsMarkPriceKline `json:"k"`
+}
+
+// WsMarkPriceKline define websocket market price kline
+type WsMarkPriceKline struct {
+	StartTime   int64  `json:"t"`
+	EndTime     int64  `json:"T"`
+	Symbol      string `json:"s"`
+	Interval    string `json:"i"`
+	LastTradeID int64  `json:"L"` // LastTradeID Ignore
+	Open        string `json:"o"`
+	Close       string `json:"c"`
+	High        string `json:"h"`
+	Low         string `json:"l"`
+	TradeNum    int64  `json:"n"`
+	IsFinal     bool   `json:"x"`
+}
+
+// WsMarkPriceKlineHandler handle websocket market price kline event
+type WsMarkPriceKlineHandler func(event *WsMarkPriceKlineEvent)
+
+// WsMarkPriceKlineServe serve websocket kline handler with a symbol and interval like 15m, 30s
+func WsMarkPriceKlineServe(symbol string, interval string, handler WsMarkPriceKlineHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	endpoint := fmt.Sprintf("%s/%s@markPriceKline_%s", baseURL, strings.ToLower(symbol), interval)
+	cfg := newWsConfig(endpoint)
+	wsHandler := func(message []byte) {
+		event := new(WsMarkPriceKlineEvent)
+		err := json.Unmarshal(message, event)
+		if err != nil {
+			errHandler(err)
+			return
+		}
+		handler(event)
+	}
+	return wsServe(cfg, wsHandler, errHandler)
+}
+
+// WsMiniMarketTickerEvent define websocket mini market ticker event.
+type WsMiniMarketTickerEvent struct {
+	Event       string `json:"e"`
+	Time        int64  `json:"E"`
+	Symbol      string `json:"s"`
+	Pair        string `json:"ps"`
+	ClosePrice  string `json:"c"`
+	OpenPrice   string `json:"o"`
+	HighPrice   string `json:"h"`
+	LowPrice    string `json:"l"`
+	Volume      string `json:"v"`
+	QuoteVolume string `json:"q"`
+}
+
+// WsMiniMarketTickerHandler handle websocket that pushes 24hr rolling window mini-ticker statistics for a single symbol.
+type WsMiniMarketTickerHandler func(event *WsMiniMarketTickerEvent)
+
+// WsMiniMarketTickerServe serve websocket that pushes 24hr rolling window mini-ticker statistics for a single symbol.
+func WsMiniMarketTickerServe(symbol string, handler WsMiniMarketTickerHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	endpoint := fmt.Sprintf("%s/%s@miniTicker", baseURL, strings.ToLower(symbol))
+	cfg := newWsConfig(endpoint)
+	wsHandler := func(message []byte) {
+		event := new(WsMiniMarketTickerEvent)
+		err := json.Unmarshal(message, &event)
+		if err != nil {
+			errHandler(err)
+			return
+		}
+		handler(event)
+	}
+	return wsServe(cfg, wsHandler, errHandler)
+}
+
+// WsAllMiniMarketTickerEvent define an array of websocket mini market ticker events.
+type WsAllMiniMarketTickerEvent []*WsMiniMarketTickerEvent
+
+// WsAllMiniMarketTickerHandler handle websocket that pushes price and funding rate for all markets.
+type WsAllMiniMarketTickerHandler func(event WsAllMiniMarketTickerEvent)
+
+// WsAllMiniMarketTickerServe serve websocket that pushes price and funding rate for all markets.
+func WsAllMiniMarketTickerServe(handler WsAllMiniMarketTickerHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	endpoint := fmt.Sprintf("%s/!miniTicker@arr", baseURL)
+	cfg := newWsConfig(endpoint)
+	wsHandler := func(message []byte) {
+		var event WsAllMiniMarketTickerEvent
+		err := json.Unmarshal(message, &event)
+		if err != nil {
+			errHandler(err)
+			return
+		}
+		handler(event)
+	}
+	return wsServe(cfg, wsHandler, errHandler)
+}
+
+// WsMarketTickerEvent define websocket market ticker event.
+type WsMarketTickerEvent struct {
+	Event              string `json:"e"`
+	Time               int64  `json:"E"`
+	Symbol             string `json:"s"`
+	Pair               string `json:"ps"`
+	PriceChange        string `json:"p"`
+	PriceChangePercent string `json:"P"`
+	WeightedAvgPrice   string `json:"w"`
+	ClosePrice         string `json:"c"`
+	CloseQty           string `json:"Q"`
+	OpenPrice          string `json:"o"`
+	HighPrice          string `json:"h"`
+	LowPrice           string `json:"l"`
+	BaseVolume         string `json:"v"`
+	QuoteVolume        string `json:"q"`
+	OpenTime           int64  `json:"O"`
+	CloseTime          int64  `json:"C"`
+	FirstID            int64  `json:"F"`
+	LastID             int64  `json:"L"`
+	TradeCount         int64  `json:"n"`
+}
+
+// WsMarketTickerHandler handle websocket that pushes 24hr rolling window mini-ticker statistics for a single symbol.
+type WsMarketTickerHandler func(event *WsMarketTickerEvent)
+
+// WsMarketTickerServe serve websocket that pushes 24hr rolling window mini-ticker statistics for a single symbol.
+func WsMarketTickerServe(symbol string, handler WsMarketTickerHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	endpoint := fmt.Sprintf("%s/%s@ticker", baseURL, strings.ToLower(symbol))
+	cfg := newWsConfig(endpoint)
+	wsHandler := func(message []byte) {
+		event := new(WsMarketTickerEvent)
+		err := json.Unmarshal(message, &event)
+		if err != nil {
+			errHandler(err)
+			return
+		}
+		handler(event)
+	}
+	return wsServe(cfg, wsHandler, errHandler)
+}
+
+// WsAllMarketTickerEvent define an array of websocket mini ticker events.
+type WsAllMarketTickerEvent []*WsMarketTickerEvent
+
+// WsAllMarketTickerHandler handle websocket that pushes price and funding rate for all markets.
+type WsAllMarketTickerHandler func(event WsAllMarketTickerEvent)
+
+// WsAllMarketTickerServe serve websocket that pushes price and funding rate for all markets.
+func WsAllMarketTickerServe(handler WsAllMarketTickerHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	endpoint := fmt.Sprintf("%s/!ticker@arr", baseURL)
+	cfg := newWsConfig(endpoint)
+	wsHandler := func(message []byte) {
+		var event WsAllMarketTickerEvent
+		err := json.Unmarshal(message, &event)
+		if err != nil {
+			errHandler(err)
+			return
+		}
+		handler(event)
+	}
+	return wsServe(cfg, wsHandler, errHandler)
+}
+
+// WsBookTickerEvent define websocket best book ticker event.
+type WsBookTickerEvent struct {
+	Event           string `json:"e"`
+	UpdateID        int64  `json:"u"`
+	Symbol          string `json:"s"`
+	Pair            string `json:"ps"`
+	BestBidPrice    string `json:"b"`
+	BestBidQty      string `json:"B"`
+	BestAskPrice    string `json:"a"`
+	BestAskQty      string `json:"A"`
+	TransactionTime int64  `json:"T"`
+	Time            int64  `json:"E"`
+}
+
+// WsBookTickerHandler handle websocket that pushes updates to the best bid or ask price or quantity in real-time for a specified symbol.
+type WsBookTickerHandler func(event *WsBookTickerEvent)
+
+// WsBookTickerServe serve websocket that pushes updates to the best bid or ask price or quantity in real-time for a specified symbol.
+func WsBookTickerServe(symbol string, handler WsBookTickerHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	endpoint := fmt.Sprintf("%s/%s@bookTicker", baseURL, strings.ToLower(symbol))
+	cfg := newWsConfig(endpoint)
+	wsHandler := func(message []byte) {
+		event := new(WsBookTickerEvent)
+		err := json.Unmarshal(message, &event)
+		if err != nil {
+			errHandler(err)
+			return
+		}
+		handler(event)
+	}
+	return wsServe(cfg, wsHandler, errHandler)
+}
+
+// WsAllBookTickerServe serve websocket that pushes updates to the best bid or ask price or quantity in real-time for all symbols.
+func WsAllBookTickerServe(handler WsBookTickerHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	endpoint := fmt.Sprintf("%s/!bookTicker", baseURL)
+	cfg := newWsConfig(endpoint)
+	wsHandler := func(message []byte) {
+		event := new(WsBookTickerEvent)
+		err := json.Unmarshal(message, &event)
+		if err != nil {
+			errHandler(err)
+			return
+		}
+		handler(event)
+	}
+	return wsServe(cfg, wsHandler, errHandler)
+}
+
+// WsLiquidationOrderEvent define websocket liquidation order event.
+type WsLiquidationOrderEvent struct {
+	Event            string             `json:"e"`
+	Time             int64              `json:"E"`
+	LiquidationOrder WsLiquidationOrder `json:"o"`
+}
+
+// WsLiquidationOrder define websocket liquidation order.
+type WsLiquidationOrder struct {
+	Symbol               string          `json:"s"`
+	Pair                 string          `json:"ps"`
+	Side                 SideType        `json:"S"`
+	OrderType            OrderType       `json:"o"`
+	TimeInForce          TimeInForceType `json:"f"`
+	OrigQuantity         string          `json:"q"`
+	Price                string          `json:"p"`
+	AvgPrice             string          `json:"ap"`
+	OrderStatus          OrderStatusType `json:"X"`
+	LastFilledQty        string          `json:"l"`
+	AccumulatedFilledQty string          `json:"z"`
+	TradeTime            int64           `json:"T"`
+}
+
+// WsLiquidationOrderHandler handle websocket that pushes force liquidation order information for specific symbol.
+type WsLiquidationOrderHandler func(event *WsLiquidationOrderEvent)
+
+// WsLiquidationOrderServe serve websocket that pushes force liquidation order information for specific symbol.
+func WsLiquidationOrderServe(symbol string, handler WsLiquidationOrderHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	endpoint := fmt.Sprintf("%s/%s@forceOrder", baseURL, strings.ToLower(symbol))
+	cfg := newWsConfig(endpoint)
+	wsHandler := func(message []byte) {
+		event := new(WsLiquidationOrderEvent)
+		err := json.Unmarshal(message, &event)
+		if err != nil {
+			errHandler(err)
+			return
+		}
+		handler(event)
+	}
+	return wsServe(cfg, wsHandler, errHandler)
+}
+
+// WsAllLiquidationOrderServe serve websocket that pushes force liquidation order information for all symbols.
+func WsAllLiquidationOrderServe(handler WsLiquidationOrderHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	endpoint := fmt.Sprintf("%s/!forceOrder@arr", baseURL)
+	cfg := newWsConfig(endpoint)
+	wsHandler := func(message []byte) {
+		event := new(WsLiquidationOrderEvent)
+		err := json.Unmarshal(message, &event)
+		if err != nil {
+			errHandler(err)
+			return
+		}
+		handler(event)
+	}
+	return wsServe(cfg, wsHandler, errHandler)
+}
+
+// WsDepthEvent define websocket depth book event
+type WsDepthEvent struct {
+	Event            string `json:"e"`
+	Time             int64  `json:"E"`
+	TransactionTime  int64  `json:"T"`
+	Symbol           string `json:"s"`
+	Pair             string `json:"ps"`
+	FirstUpdateID    int64  `json:"U"`
+	LastUpdateID     int64  `json:"u"`
+	PrevLastUpdateID int64  `json:"pu"`
+	Bids             []Bid  `json:"b"`
+	Asks             []Ask  `json:"a"`
+}
+
+// WsDepthHandler handle websocket depth event
+type WsDepthHandler func(event *WsDepthEvent)
+
+// WsPartialDepthServe serve websocket partial depth handler.
+func WsPartialDepthServe(symbol string, levels int, handler WsDepthHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	endpoint := fmt.Sprintf("%s/%s@depth%d", baseURL, strings.ToLower(symbol), levels)
+	cfg := newWsConfig(endpoint)
+	return wsDepthServe(cfg, handler, errHandler)
+}
+
+// WsDiffDepthServe serve websocket diff. depth handler.
+func WsDiffDepthServe(symbol string, handler WsDepthHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	endpoint := fmt.Sprintf("%s/%s@depth", baseURL, strings.ToLower(symbol))
+	cfg := newWsConfig(endpoint)
+	return wsDepthServe(cfg, handler, errHandler)
+}
+
+func wsDepthServe(cfg *WsConfig, handler WsDepthHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	wsHandler := func(message []byte) {
+		j, err := newJSON(message)
+		if err != nil {
+			errHandler(err)
+			return
+		}
+		event := new(WsDepthEvent)
+		event.Event = j.Get("e").MustString()
+		event.Time = j.Get("E").MustInt64()
+		event.TransactionTime = j.Get("T").MustInt64()
+		event.Symbol = j.Get("s").MustString()
+		event.Pair = j.Get("ps").MustString()
+		event.FirstUpdateID = j.Get("U").MustInt64()
+		event.LastUpdateID = j.Get("u").MustInt64()
+		event.PrevLastUpdateID = j.Get("pu").MustInt64()
+		bidsLen := len(j.Get("b").MustArray())
+		event.Bids = make([]Bid, bidsLen)
+		for i := 0; i < bidsLen; i++ {
+			item := j.Get("b").GetIndex(i)
+			event.Bids[i] = Bid{
+				Price:    item.GetIndex(0).MustString(),
+				Quantity: item.GetIndex(1).MustString(),
+			}
+		}
+		asksLen := len(j.Get("a").MustArray())
+		event.Asks = make([]Ask, asksLen)
+		for i := 0; i < asksLen; i++ {
+			item := j.Get("a").GetIndex(i)
+			event.Asks[i] = Ask{
+				Price:    item.GetIndex(0).MustString(),
+				Quantity: item.GetIndex(1).MustString(),
+			}
+		}
+		handler(event)
+	}
+	return wsServe(cfg, wsHandler, errHandler)
+}

--- a/v2/delivery/websocket_service.go
+++ b/v2/delivery/websocket_service.go
@@ -12,12 +12,18 @@ const (
 )
 
 var (
-
 	// WebsocketTimeout is an interval for sending ping/pong messages if WebsocketKeepalive is enabled
 	WebsocketTimeout = time.Second * 60
 	// WebsocketKeepalive enables sending ping/pong messages to check the connection stability
 	WebsocketKeepalive = false
 )
+
+// WsUserDataServe serve user data handler with listen key
+func WsUserDataServe(listenKey string, handler WsHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	endpoint := fmt.Sprintf("%s/%s", baseURL, listenKey)
+	cfg := newWsConfig(endpoint)
+	return wsServe(cfg, handler, errHandler)
+}
 
 // WsAggTradeEvent define websocket aggTrde event.
 type WsAggTradeEvent struct {

--- a/v2/delivery/websocket_service_test.go
+++ b/v2/delivery/websocket_service_test.go
@@ -1,0 +1,1168 @@
+package delivery
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type websocketServiceTestSuite struct {
+	baseTestSuite
+	origWsServe func(*WsConfig, WsHandler, ErrHandler) (chan struct{}, chan struct{}, error)
+	serveCount  int
+}
+
+func TestWebsocketService(t *testing.T) {
+	suite.Run(t, new(websocketServiceTestSuite))
+}
+
+func (s *websocketServiceTestSuite) SetupTest() {
+	s.origWsServe = wsServe
+}
+
+func (s *websocketServiceTestSuite) TearDownTest() {
+	wsServe = s.origWsServe
+	s.serveCount = 0
+}
+
+func (s *websocketServiceTestSuite) mockWsServe(data []byte, err error) {
+	wsServe = func(cfg *WsConfig, handler WsHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, innerErr error) {
+		s.serveCount++
+		doneC = make(chan struct{})
+		stopC = make(chan struct{})
+		go func() {
+			<-stopC
+			close(doneC)
+		}()
+		handler(data)
+		if err != nil {
+			errHandler(err)
+		}
+		return doneC, stopC, nil
+	}
+}
+
+func (s *websocketServiceTestSuite) assertWsServe(count ...int) {
+	e := 1
+	if len(count) > 0 {
+		e = count[0]
+	}
+	s.r().Equal(e, s.serveCount)
+}
+
+// https://binance-docs.github.io/apidocs/delivery/en/#aggregate-trade-streams
+func (s *websocketServiceTestSuite) TestAggTradeServe() {
+	data := []byte(`{
+		  "e":"aggTrade",
+		  "E":1591261134288,
+		  "a":424951,
+		  "s":"BTCUSD_200626",
+		  "p":"9643.5",
+		  "q":"2",
+		  "f":606073,
+		  "l":606073,
+		  "T":1591261134199,
+		  "m":false
+	  }`)
+	fakeErrMsg := "fake error"
+	s.mockWsServe(data, errors.New(fakeErrMsg))
+	defer s.assertWsServe()
+
+	doneC, stopC, err := WsAggTradeServe("BTCUSD_200626", func(event *WsAggTradeEvent) {
+		e := &WsAggTradeEvent{
+			Event:            "aggTrade",
+			Time:             1591261134288,
+			AggregateTradeID: 424951,
+			Symbol:           "BTCUSD_200626",
+			Price:            "9643.5",
+			Quantity:         "2",
+			FirstTradeID:     606073,
+			LastTradeID:      606073,
+			TradeTime:        1591261134199,
+			Maker:            false,
+		}
+		s.assertWsAggTradeEvent(e, event)
+	},
+		func(err error) {
+			s.r().EqualError(err, fakeErrMsg)
+		})
+
+	s.r().NoError(err)
+	stopC <- struct{}{}
+	<-doneC
+}
+
+func (s *websocketServiceTestSuite) assertWsAggTradeEvent(e, a *WsAggTradeEvent) {
+	r := s.r()
+	r.Equal(e.Event, a.Event, "Event")
+	r.Equal(e.Time, a.Time, "Time")
+	r.Equal(e.Symbol, a.Symbol, "Symbol")
+	r.Equal(e.AggregateTradeID, a.AggregateTradeID, "AggregateTradeID")
+	r.Equal(e.Price, a.Price, "Price")
+	r.Equal(e.Quantity, a.Quantity, "Quantity")
+	r.Equal(e.FirstTradeID, a.FirstTradeID, "FirstTradeID")
+	r.Equal(e.LastTradeID, a.LastTradeID, "LastTradeID")
+	r.Equal(e.TradeTime, a.TradeTime, "TradeTime")
+	r.Equal(e.Maker, a.Maker, "Maker")
+}
+
+// https://binance-docs.github.io/apidocs/delivery/en/#index-price-stream
+func (s *websocketServiceTestSuite) TestIndexPriceServe() {
+	data := []byte(`{
+		"e": "indexPriceUpdate",
+		"E": 1591261236000,
+		"i": "BTCUSD",
+		"p": "9636.57860000"
+	  }`)
+	fakeErrMsg := "fake error"
+	s.mockWsServe(data, errors.New(fakeErrMsg))
+	defer s.assertWsServe()
+
+	doneC, stopC, err := WsIndexPriceServe("BTCUSD", func(event *WsIndexPriceEvent) {
+		e := &WsIndexPriceEvent{
+			Event:      "indexPriceUpdate",
+			Time:       1591261236000,
+			Pair:       "BTCUSD",
+			IndexPrice: "9636.57860000",
+		}
+		s.assertWsIndexPriceEvent(e, event)
+	},
+		func(err error) {
+			s.r().EqualError(err, fakeErrMsg)
+		})
+
+	s.r().NoError(err)
+	stopC <- struct{}{}
+	<-doneC
+}
+
+func (s *websocketServiceTestSuite) assertWsIndexPriceEvent(e, a *WsIndexPriceEvent) {
+	r := s.r()
+	r.Equal(e.Event, a.Event, "Event")
+	r.Equal(e.Time, a.Time, "Time")
+	r.Equal(e.Pair, a.Pair, "Pair")
+	r.Equal(e.IndexPrice, a.IndexPrice, "IndexPrice")
+}
+
+// https://binance-docs.github.io/apidocs/delivery/en/#mark-price-stream
+func (s *websocketServiceTestSuite) TestMarkPriceServe() {
+	data := []byte(`{
+    	"e":"markPriceUpdate",
+    	"E":1596095725000,
+    	"s":"BTCUSD_201225",
+    	"p":"10934.62615417",
+    	"P":"10962.17178236",
+    	"r":"",
+    	"T":0
+	  }`)
+	fakeErrMsg := "fake error"
+	s.mockWsServe(data, errors.New(fakeErrMsg))
+	defer s.assertWsServe()
+
+	doneC, stopC, err := WsMarkPriceServe("BTCUSD_201225", func(event *WsMarkPriceEvent) {
+		e := &WsMarkPriceEvent{
+			Event:                "markPriceUpdate",
+			Time:                 1596095725000,
+			Symbol:               "BTCUSD_201225",
+			MarkPrice:            "10934.62615417",
+			EstimatedSettlePrice: "10962.17178236",
+			FundingRate:          "",
+			NextFundingTime:      0,
+		}
+		s.assertWsMarkPriceEvent(e, event)
+	},
+		func(err error) {
+			s.r().EqualError(err, fakeErrMsg)
+		})
+
+	s.r().NoError(err)
+	stopC <- struct{}{}
+	<-doneC
+}
+
+// https://binance-docs.github.io/apidocs/delivery/en/#mark-price-of-all-symbols-of-a-pair
+func (s *websocketServiceTestSuite) TestPairMarkPriceServe() {
+	data := []byte(`[
+	  {
+		"e":"markPriceUpdate",
+		"E":1596095725000,
+		"s":"BTCUSD_201225",
+		"p":"10934.62615417",
+		"P":"10962.17178236",
+		"r":"",
+		"T":0
+	  },
+	  {
+		"e":"markPriceUpdate",
+		"E":1596095725000,
+		"s":"BTCUSD_PERP",
+		"p":"11012.31359011",
+		"P":"10962.17178236",
+		"r":"0.00000000",
+		"T":1596096000000
+  }]`)
+	fakeErrMsg := "fake error"
+	s.mockWsServe(data, errors.New(fakeErrMsg))
+	defer s.assertWsServe()
+
+	doneC, stopC, err := WsPairMarkPriceServe(func(event WsPairMarkPriceEvent) {
+		e := WsPairMarkPriceEvent{{
+			Event:                "markPriceUpdate",
+			Time:                 1596095725000,
+			Symbol:               "BTCUSD_201225",
+			MarkPrice:            "10934.62615417",
+			EstimatedSettlePrice: "10962.17178236",
+			FundingRate:          "",
+			NextFundingTime:      0,
+		}, {
+			Event:                "markPriceUpdate",
+			Time:                 1596095725000,
+			Symbol:               "BTCUSD_PERP",
+			MarkPrice:            "11012.31359011",
+			EstimatedSettlePrice: "10962.17178236",
+			FundingRate:          "0.00000000",
+			NextFundingTime:      1596096000000,
+		}}
+		s.assertWsMarkPriceEvent(e[0], event[0])
+		s.assertWsMarkPriceEvent(e[1], event[1])
+	},
+		func(err error) {
+			s.r().EqualError(err, fakeErrMsg)
+		})
+
+	s.r().NoError(err)
+	stopC <- struct{}{}
+	<-doneC
+}
+
+func (s *websocketServiceTestSuite) assertWsMarkPriceEvent(e, a *WsMarkPriceEvent) {
+	r := s.r()
+	r.Equal(e.Event, a.Event, "Event")
+	r.Equal(e.Time, a.Time, "Time")
+	r.Equal(e.Symbol, a.Symbol, "Symbol")
+	r.Equal(e.MarkPrice, a.MarkPrice, "MarkPrice")
+	r.Equal(e.EstimatedSettlePrice, a.EstimatedSettlePrice, "EstimatedSettlePrice")
+	r.Equal(e.FundingRate, a.FundingRate, "FundingRate")
+	r.Equal(e.NextFundingTime, a.NextFundingTime, "NextFundingTime")
+}
+
+// https://binance-docs.github.io/apidocs/delivery/en/#kline-candlestick-streams
+func (s *websocketServiceTestSuite) TestKlineServe() {
+	data := []byte(`{
+	  "e":"kline",
+	  "E":1591261542539,
+	  "s":"BTCUSD_200626",
+	  "k":{
+		"t":1591261500000,
+		"T":1591261559999,
+		"s":"BTCUSD_200626",
+		"i":"1m",
+		"f":606400,
+		"L":606430,
+		"o":"9638.9",
+		"c":"9639.8",
+		"h":"9639.8",
+		"l":"9638.6",
+		"v":"156",
+		"n":31,
+		"x":false,
+		"q":"1.61836886",
+		"V":"73",
+		"Q":"0.75731156",
+		"B":"0"
+      }
+	}`)
+	fakeErrMsg := "fake error"
+	s.mockWsServe(data, errors.New(fakeErrMsg))
+	defer s.assertWsServe()
+
+	doneC, stopC, err := WsKlineServe("BTCUSD_200626", "1m", func(event *WsKlineEvent) {
+		e := &WsKlineEvent{
+			Event:  "kline",
+			Time:   1591261542539,
+			Symbol: "BTCUSD_200626",
+			Kline: WsKline{
+				StartTime:            1591261500000,
+				EndTime:              1591261559999,
+				Symbol:               "BTCUSD_200626",
+				Interval:             "1m",
+				FirstTradeID:         606400,
+				LastTradeID:          606430,
+				Open:                 "9638.9",
+				Close:                "9639.8",
+				High:                 "9639.8",
+				Low:                  "9638.6",
+				Volume:               "156",
+				TradeNum:             31,
+				IsFinal:              false,
+				QuoteVolume:          "1.61836886",
+				ActiveBuyVolume:      "73",
+				ActiveBuyQuoteVolume: "0.75731156",
+			},
+		}
+		s.assertWsKlineEventEqual(e, event)
+	}, func(err error) {
+		s.r().EqualError(err, fakeErrMsg)
+	})
+	s.r().NoError(err)
+	stopC <- struct{}{}
+	<-doneC
+}
+
+func (s *websocketServiceTestSuite) assertWsKlineEventEqual(e, a *WsKlineEvent) {
+	r := s.r()
+	r.Equal(e.Event, a.Event, "Event")
+	r.Equal(e.Time, a.Time, "Time")
+	r.Equal(e.Symbol, a.Symbol, "Symbol")
+	ek, ak := e.Kline, a.Kline
+	r.Equal(ek.StartTime, ak.StartTime, "StartTime")
+	r.Equal(ek.EndTime, ak.EndTime, "EndTime")
+	r.Equal(ek.Symbol, ak.Symbol, "Symbol")
+	r.Equal(ek.Interval, ak.Interval, "Interval")
+	r.Equal(ek.FirstTradeID, ak.FirstTradeID, "FirstTradeID")
+	r.Equal(ek.LastTradeID, ak.LastTradeID, "LastTradeID")
+	r.Equal(ek.Open, ak.Open, "Open")
+	r.Equal(ek.Close, ak.Close, "Close")
+	r.Equal(ek.High, ak.High, "High")
+	r.Equal(ek.Low, ak.Low, "Low")
+	r.Equal(ek.Volume, ak.Volume, "Volume")
+	r.Equal(ek.TradeNum, ak.TradeNum, "TradeNum")
+	r.Equal(ek.IsFinal, ak.IsFinal, "IsFinal")
+	r.Equal(ek.QuoteVolume, ak.QuoteVolume, "QuoteVolume")
+	r.Equal(ek.ActiveBuyVolume, ak.ActiveBuyVolume, "ActiveBuyVolume")
+	r.Equal(ek.ActiveBuyQuoteVolume, ak.ActiveBuyQuoteVolume, "ActiveBuyQuoteVolume")
+}
+
+// https://binance-docs.github.io/apidocs/delivery/en/#continues-contract-kline-candlestick-streams
+func (s *websocketServiceTestSuite) TestContinuousKlineServe() {
+	data := []byte(`{
+	  "e":"continuous_kline",
+	  "E":1591261542539,
+	  "ps":"BTCUSD",
+      "ct":"NEXT_QUARTER",
+	  "k":{
+		"t":1591261500000,
+		"T":1591261559999,
+		"i":"1m",
+		"f":606400,
+		"L":606430,
+		"o":"9638.9",
+		"c":"9639.8",
+		"h":"9639.8",
+		"l":"9638.6",
+		"v":"156",
+		"n":31,
+		"x":false,
+		"q":"1.61836886",
+		"V":"73",
+		"Q":"0.75731156",
+		"B":"0"
+      }
+	}`)
+	fakeErrMsg := "fake error"
+	s.mockWsServe(data, errors.New(fakeErrMsg))
+	defer s.assertWsServe()
+
+	doneC, stopC, err := WsContinuousKlineServe("BTCUSD", "NEXT_QUARTER", "1m", func(event *WsContinuousKlineEvent) {
+		e := &WsContinuousKlineEvent{
+			Event:        "continuous_kline",
+			Time:         1591261542539,
+			Pair:         "BTCUSD",
+			ContractType: "NEXT_QUARTER",
+			Kline: WsContinuousKline{
+				StartTime:            1591261500000,
+				EndTime:              1591261559999,
+				Interval:             "1m",
+				FirstTradeID:         606400,
+				LastTradeID:          606430,
+				Open:                 "9638.9",
+				Close:                "9639.8",
+				High:                 "9639.8",
+				Low:                  "9638.6",
+				Volume:               "156",
+				TradeNum:             31,
+				IsFinal:              false,
+				QuoteVolume:          "1.61836886",
+				ActiveBuyVolume:      "73",
+				ActiveBuyQuoteVolume: "0.75731156",
+			},
+		}
+		s.assertWsContinuousKlineEventEqual(e, event)
+	}, func(err error) {
+		s.r().EqualError(err, fakeErrMsg)
+	})
+	s.r().NoError(err)
+	stopC <- struct{}{}
+	<-doneC
+}
+
+func (s *websocketServiceTestSuite) assertWsContinuousKlineEventEqual(e, a *WsContinuousKlineEvent) {
+	r := s.r()
+	r.Equal(e.Event, a.Event, "Event")
+	r.Equal(e.Time, a.Time, "Time")
+	r.Equal(e.Pair, a.Pair, "Pair")
+	r.Equal(e.ContractType, a.ContractType, "ContractType")
+	ek, ak := e.Kline, a.Kline
+	r.Equal(ek.StartTime, ak.StartTime, "StartTime")
+	r.Equal(ek.EndTime, ak.EndTime, "EndTime")
+	r.Equal(ek.Interval, ak.Interval, "Interval")
+	r.Equal(ek.FirstTradeID, ak.FirstTradeID, "FirstTradeID")
+	r.Equal(ek.LastTradeID, ak.LastTradeID, "LastTradeID")
+	r.Equal(ek.Open, ak.Open, "Open")
+	r.Equal(ek.Close, ak.Close, "Close")
+	r.Equal(ek.High, ak.High, "High")
+	r.Equal(ek.Low, ak.Low, "Low")
+	r.Equal(ek.Volume, ak.Volume, "Volume")
+	r.Equal(ek.TradeNum, ak.TradeNum, "TradeNum")
+	r.Equal(ek.IsFinal, ak.IsFinal, "IsFinal")
+	r.Equal(ek.QuoteVolume, ak.QuoteVolume, "QuoteVolume")
+	r.Equal(ek.ActiveBuyVolume, ak.ActiveBuyVolume, "ActiveBuyVolume")
+	r.Equal(ek.ActiveBuyQuoteVolume, ak.ActiveBuyQuoteVolume, "ActiveBuyQuoteVolume")
+}
+
+// https://binance-docs.github.io/apidocs/delivery/en/#index-kline-candlestick-streams
+func (s *websocketServiceTestSuite) TestIndexKlineServe() {
+	data := []byte(`{
+	  "e":"indexPrice_kline",
+	  "E":1591267070033,
+	  "ps":"BTCUSD",
+	  "k":{
+		"t":1591267020000,
+		"T":1591267079999,
+		"s":"0",
+		"i":"1m",
+		"f":1591267020000,
+		"L":1591267070000,
+		"o":"9542.21900000",
+		"c":"9542.50440000",
+		"h":"9542.71640000",
+		"l":"9542.21040000",
+		"v":"0",
+		"n":51,
+		"x":false,
+		"q":"0",
+		"V":"0",
+		"Q":"0",
+		"B":"0"
+	  }
+	}`)
+	fakeErrMsg := "fake error"
+	s.mockWsServe(data, errors.New(fakeErrMsg))
+	defer s.assertWsServe()
+
+	doneC, stopC, err := WsIndexPriceKlineServe("BTCUSD", "1m", func(event *WsIndexPriceKlineEvent) {
+		e := &WsIndexPriceKlineEvent{
+			Event: "indexPrice_kline",
+			Time:  1591267070033,
+			Pair:  "BTCUSD",
+			Kline: WsIndexPriceKline{
+				StartTime: 1591267020000,
+				EndTime:   1591267079999,
+				Interval:  "1m",
+				Open:      "9542.21900000",
+				Close:     "9542.50440000",
+				High:      "9542.71640000",
+				Low:       "9542.21040000",
+				TradeNum:  51,
+				IsFinal:   false,
+			},
+		}
+		s.assertWsIndexKlineEventEqual(e, event)
+	}, func(err error) {
+		s.r().EqualError(err, fakeErrMsg)
+	})
+	s.r().NoError(err)
+	stopC <- struct{}{}
+	<-doneC
+}
+
+func (s *websocketServiceTestSuite) assertWsIndexKlineEventEqual(e, a *WsIndexPriceKlineEvent) {
+	r := s.r()
+	r.Equal(e.Event, a.Event, "Event")
+	r.Equal(e.Time, a.Time, "Time")
+	r.Equal(e.Pair, a.Pair, "Pair")
+	ek, ak := e.Kline, a.Kline
+	r.Equal(ek.StartTime, ak.StartTime, "StartTime")
+	r.Equal(ek.EndTime, ak.EndTime, "EndTime")
+	r.Equal(ek.Interval, ak.Interval, "Interval")
+	r.Equal(ek.Open, ak.Open, "Open")
+	r.Equal(ek.Close, ak.Close, "Close")
+	r.Equal(ek.High, ak.High, "High")
+	r.Equal(ek.Low, ak.Low, "Low")
+	r.Equal(ek.TradeNum, ak.TradeNum, "TradeNum")
+	r.Equal(ek.IsFinal, ak.IsFinal, "IsFinal")
+}
+
+// https://binance-docs.github.io/apidocs/delivery/en/#mark-price-kline-candlestick-streams
+func (s *websocketServiceTestSuite) TestMarkPriceKlineServe() {
+	data := []byte(`{
+	  "e":"markPrice_kline",
+	  "E":1591267398004,
+	  "ps":"BTCUSD",
+	  "k":{
+		"t":1591267380000,
+		"T":1591267439999,
+		"s":"BTCUSD_200626",
+		"i":"1m",
+		"f":1591267380000,
+		"L":1591267398000,
+		"o":"9539.67161333",
+		"c":"9540.82761333",
+		"h":"9540.82761333",
+		"l":"9539.66961333",
+		"v":"0",
+		"n":19,
+		"x":false,
+		"q":"0",
+		"V":"0",
+		"Q":"0",
+		"B":"0"
+	  }
+	}`)
+	fakeErrMsg := "fake error"
+	s.mockWsServe(data, errors.New(fakeErrMsg))
+	defer s.assertWsServe()
+
+	doneC, stopC, err := WsMarkPriceKlineServe("BTCUSD_200626", "1m", func(event *WsMarkPriceKlineEvent) {
+		e := &WsMarkPriceKlineEvent{
+			Event: "markPrice_kline",
+			Time:  1591267398004,
+			Pair:  "BTCUSD",
+			Kline: WsMarkPriceKline{
+				StartTime: 1591267380000,
+				EndTime:   1591267439999,
+				Symbol:    "BTCUSD_200626",
+				Interval:  "1m",
+				Open:      "9539.67161333",
+				Close:     "9540.82761333",
+				High:      "9540.82761333",
+				Low:       "9539.66961333",
+				TradeNum:  19,
+				IsFinal:   false,
+			},
+		}
+		s.assertWsMarkPriceKlineEventEqual(e, event)
+	}, func(err error) {
+		s.r().EqualError(err, fakeErrMsg)
+	})
+	s.r().NoError(err)
+	stopC <- struct{}{}
+	<-doneC
+}
+
+func (s *websocketServiceTestSuite) assertWsMarkPriceKlineEventEqual(e, a *WsMarkPriceKlineEvent) {
+	r := s.r()
+	r.Equal(e.Event, a.Event, "Event")
+	r.Equal(e.Time, a.Time, "Time")
+	r.Equal(e.Pair, a.Pair, "Pair")
+	ek, ak := e.Kline, a.Kline
+	r.Equal(ek.StartTime, ak.StartTime, "StartTime")
+	r.Equal(ek.EndTime, ak.EndTime, "EndTime")
+	r.Equal(ek.Interval, ak.Interval, "Interval")
+	r.Equal(ek.Symbol, ak.Symbol, "Symbol")
+	r.Equal(ek.Open, ak.Open, "Open")
+	r.Equal(ek.Close, ak.Close, "Close")
+	r.Equal(ek.High, ak.High, "High")
+	r.Equal(ek.Low, ak.Low, "Low")
+	r.Equal(ek.TradeNum, ak.TradeNum, "TradeNum")
+	r.Equal(ek.IsFinal, ak.IsFinal, "IsFinal")
+}
+
+// https://binance-docs.github.io/apidocs/delivery/en/#individual-symbol-mini-ticker-stream
+func (s *websocketServiceTestSuite) TestMiniMarketTickerServe() {
+	data := []byte(`{
+	    "e":"24hrMiniTicker",
+	    "E":1591267704450,
+	    "s":"BTCUSD_200626",
+	    "ps":"BTCUSD",
+	    "c":"9561.7",
+	    "o":"9580.9",
+	    "h":"10000.0",
+	    "l":"7000.0",
+	    "v":"487476",
+	    "q":"33264343847.22378500"
+	  }`)
+	fakeErrMsg := "fake error"
+	s.mockWsServe(data, errors.New(fakeErrMsg))
+	defer s.assertWsServe()
+
+	doneC, stopC, err := WsMiniMarketTickerServe("BTCUSD_200626", func(event *WsMiniMarketTickerEvent) {
+		e := &WsMiniMarketTickerEvent{
+			Event:       "24hrMiniTicker",
+			Time:        1591267704450,
+			Symbol:      "BTCUSD_200626",
+			Pair:        "BTCUSD",
+			ClosePrice:  "9561.7",
+			OpenPrice:   "9580.9",
+			HighPrice:   "10000.0",
+			LowPrice:    "7000.0",
+			Volume:      "487476",
+			QuoteVolume: "33264343847.22378500",
+		}
+		s.assertWsMinMarketTickerEvent(e, event)
+	},
+		func(err error) {
+			s.r().EqualError(err, fakeErrMsg)
+		})
+
+	s.r().NoError(err)
+	stopC <- struct{}{}
+	<-doneC
+}
+
+// https://binance-docs.github.io/apidocs/delivery/en/#all-market-mini-tickers-stream
+func (s *websocketServiceTestSuite) TestAllMiniMarketTickerServe() {
+	data := []byte(`[{
+		"e":"24hrMiniTicker",
+		"E":1591267704450,
+		"s":"BTCUSD_200626",
+		"ps":"BTCUSD",
+		"c":"9561.7",
+		"o":"9580.9",
+		"h":"10000.0",
+		"l":"7000.0",
+		"v":"487476",
+		"q":"33264343847.22378500"
+	  }]`)
+	fakeErrMsg := "fake error"
+	s.mockWsServe(data, errors.New(fakeErrMsg))
+	defer s.assertWsServe()
+
+	doneC, stopC, err := WsAllMiniMarketTickerServe(func(event WsAllMiniMarketTickerEvent) {
+		e := []*WsMiniMarketTickerEvent{{
+			Event:       "24hrMiniTicker",
+			Time:        1591267704450,
+			Symbol:      "BTCUSD_200626",
+			Pair:        "BTCUSD",
+			ClosePrice:  "9561.7",
+			OpenPrice:   "9580.9",
+			HighPrice:   "10000.0",
+			LowPrice:    "7000.0",
+			Volume:      "487476",
+			QuoteVolume: "33264343847.22378500",
+		}}
+		s.assertWsMinMarketTickerEvent(e[0], event[0])
+	},
+		func(err error) {
+			s.r().EqualError(err, fakeErrMsg)
+		})
+
+	s.r().NoError(err)
+	stopC <- struct{}{}
+	<-doneC
+}
+
+func (s *websocketServiceTestSuite) assertWsMinMarketTickerEvent(e, a *WsMiniMarketTickerEvent) {
+	r := s.r()
+	r.Equal(e.Event, a.Event, "Event")
+	r.Equal(e.Time, a.Time, "Time")
+	r.Equal(e.Symbol, a.Symbol, "Symbol")
+	r.Equal(e.Pair, a.Pair, "Pair")
+	r.Equal(e.ClosePrice, a.ClosePrice, "ClosePrice")
+	r.Equal(e.OpenPrice, a.OpenPrice, "OpenPrice")
+	r.Equal(e.HighPrice, a.HighPrice, "HighPrice")
+	r.Equal(e.LowPrice, a.LowPrice, "LowPrice")
+	r.Equal(e.Volume, a.Volume, "Volume")
+	r.Equal(e.QuoteVolume, a.QuoteVolume, "QuoteVolume")
+}
+
+// https://binance-docs.github.io/apidocs/delivery/en/#individual-symbol-ticker-streams
+func (s *websocketServiceTestSuite) TestMarketTickerServe() {
+	data := []byte(`{
+		"e":"24hrTicker",
+		"E":1591268262453,
+		"s":"BTCUSD_200626",
+		"ps":"BTCUSD",
+		"p":"-43.4",
+		"P":"-0.452",
+		"w":"0.00147974",
+		"c":"9548.5",
+		"Q":"2",
+		"o":"9591.9",
+		"h":"10000.0",
+		"l":"7000.0",
+		"v":"487850",
+		"q":"32968676323.46222700",
+		"O":1591181820000,
+		"C":1591268262442,
+		"F":512014,
+		"L":615289,
+		"n":103272
+	  }`)
+	fakeErrMsg := "fake error"
+	s.mockWsServe(data, errors.New(fakeErrMsg))
+	defer s.assertWsServe()
+
+	doneC, stopC, err := WsMarketTickerServe("BTCUSDT", func(event *WsMarketTickerEvent) {
+		e := &WsMarketTickerEvent{
+			Event:              "24hrTicker",
+			Time:               1591268262453,
+			Symbol:             "BTCUSD_200626",
+			Pair:               "BTCUSD",
+			PriceChange:        "-43.4",
+			PriceChangePercent: "-0.452",
+			WeightedAvgPrice:   "0.00147974",
+			ClosePrice:         "9548.5",
+			CloseQty:           "2",
+			OpenPrice:          "9591.9",
+			HighPrice:          "10000.0",
+			LowPrice:           "7000.0",
+			BaseVolume:         "487850",
+			QuoteVolume:        "32968676323.46222700",
+			OpenTime:           1591181820000,
+			CloseTime:          1591268262442,
+			FirstID:            512014,
+			LastID:             615289,
+			TradeCount:         103272,
+		}
+		s.assertWsMarketTickerEvent(e, event)
+	},
+		func(err error) {
+			s.r().EqualError(err, fakeErrMsg)
+		})
+
+	s.r().NoError(err)
+	stopC <- struct{}{}
+	<-doneC
+}
+
+// https://binance-docs.github.io/apidocs/delivery/en/#all-market-tickers-streams
+func (s *websocketServiceTestSuite) TestAllMarketTickerServe() {
+	data := []byte(`[{
+		"e":"24hrTicker",
+		"E":1591268262453,
+		"s":"BTCUSD_200626",
+		"ps":"BTCUSD",
+		"p":"-43.4",
+		"P":"-0.452",
+		"w":"0.00147974",
+		"c":"9548.5",
+		"Q":"2",
+		"o":"9591.9",
+		"h":"10000.0",
+		"l":"7000.0",
+		"v":"487850",
+		"q":"32968676323.46222700",
+		"O":1591181820000,
+		"C":1591268262442,
+		"F":512014,
+		"L":615289,
+		"n":103272
+	  }]`)
+	fakeErrMsg := "fake error"
+	s.mockWsServe(data, errors.New(fakeErrMsg))
+	defer s.assertWsServe()
+
+	doneC, stopC, err := WsAllMarketTickerServe(func(event WsAllMarketTickerEvent) {
+		e := WsAllMarketTickerEvent{{
+			Event:              "24hrTicker",
+			Time:               1591268262453,
+			Symbol:             "BTCUSD_200626",
+			Pair:               "BTCUSD",
+			PriceChange:        "-43.4",
+			PriceChangePercent: "-0.452",
+			WeightedAvgPrice:   "0.00147974",
+			ClosePrice:         "9548.5",
+			CloseQty:           "2",
+			OpenPrice:          "9591.9",
+			HighPrice:          "10000.0",
+			LowPrice:           "7000.0",
+			BaseVolume:         "487850",
+			QuoteVolume:        "32968676323.46222700",
+			OpenTime:           1591181820000,
+			CloseTime:          1591268262442,
+			FirstID:            512014,
+			LastID:             615289,
+			TradeCount:         103272,
+		}}
+		s.assertWsMarketTickerEvent(e[0], event[0])
+	},
+		func(err error) {
+			s.r().EqualError(err, fakeErrMsg)
+		})
+
+	s.r().NoError(err)
+	stopC <- struct{}{}
+	<-doneC
+}
+
+func (s *websocketServiceTestSuite) assertWsMarketTickerEvent(e, a *WsMarketTickerEvent) {
+	r := s.r()
+	r.Equal(e.Event, a.Event, "Event")
+	r.Equal(e.Time, a.Time, "Time")
+	r.Equal(e.Symbol, a.Symbol, "Symbol")
+	r.Equal(e.Pair, a.Pair, "Pair")
+	r.Equal(e.PriceChange, a.PriceChange, "PriceChange")
+	r.Equal(e.PriceChangePercent, a.PriceChangePercent, "PriceChangePercent")
+	r.Equal(e.WeightedAvgPrice, a.WeightedAvgPrice, "WeightedAvgPrice")
+	r.Equal(e.ClosePrice, a.ClosePrice, "ClosePrice")
+	r.Equal(e.CloseQty, a.CloseQty, "CloseQty")
+	r.Equal(e.OpenPrice, a.OpenPrice, "OpenPrice")
+	r.Equal(e.HighPrice, a.HighPrice, "HighPrice")
+	r.Equal(e.LowPrice, a.LowPrice, "LowPrice")
+	r.Equal(e.BaseVolume, a.BaseVolume, "BaseVolume")
+	r.Equal(e.QuoteVolume, a.QuoteVolume, "QuoteVolume")
+	r.Equal(e.OpenTime, a.OpenTime, "OpenTime")
+	r.Equal(e.CloseTime, a.CloseTime, "CloseTime")
+	r.Equal(e.FirstID, a.FirstID, "FirstID")
+	r.Equal(e.LastID, a.LastID, "LastID")
+	r.Equal(e.TradeCount, a.TradeCount, "TradeCount")
+}
+
+// https://binance-docs.github.io/apidocs/delivery/en/#individual-symbol-book-ticker-streams
+func (s *websocketServiceTestSuite) TestBookTickerServe() {
+	data := []byte(`{
+  		"e":"bookTicker",
+  		"u":17242169,
+  		"s":"BTCUSD_200626",
+  		"ps":"BTCUSD",
+  		"b":"9548.1",
+  		"B":"52",
+  		"a":"9548.5",
+  		"A":"11",
+  		"T":1591268628155,
+  		"E":1591268628166
+	  }`)
+	fakeErrMsg := "fake error"
+	s.mockWsServe(data, errors.New(fakeErrMsg))
+	defer s.assertWsServe()
+
+	doneC, stopC, err := WsBookTickerServe("BTCUSD_200626", func(event *WsBookTickerEvent) {
+		e := &WsBookTickerEvent{
+			Event:           "bookTicker",
+			UpdateID:        17242169,
+			Symbol:          "BTCUSD_200626",
+			Pair:            "BTCUSD",
+			BestBidPrice:    "9548.1",
+			BestBidQty:      "52",
+			BestAskPrice:    "9548.5",
+			BestAskQty:      "11",
+			TransactionTime: 1591268628155,
+			Time:            1591268628166,
+		}
+		s.assertWsBookTickerEvent(e, event)
+	},
+		func(err error) {
+			s.r().EqualError(err, fakeErrMsg)
+		})
+
+	s.r().NoError(err)
+	stopC <- struct{}{}
+	<-doneC
+}
+
+// https://binance-docs.github.io/apidocs/delivery/en/#all-book-tickers-stream
+func (s *websocketServiceTestSuite) TestAllBookTickerServe() {
+	data := []byte(`{
+  		"e":"bookTicker",
+  		"u":17242169,
+  		"s":"BTCUSD_200626",
+  		"ps":"BTCUSD",
+  		"b":"9548.1",
+  		"B":"52",
+  		"a":"9548.5",
+  		"A":"11",
+  		"T":1591268628155,
+  		"E":1591268628166
+	  }`)
+	fakeErrMsg := "fake error"
+	s.mockWsServe(data, errors.New(fakeErrMsg))
+	defer s.assertWsServe()
+
+	doneC, stopC, err := WsAllBookTickerServe(func(event *WsBookTickerEvent) {
+		e := &WsBookTickerEvent{
+			Event:           "bookTicker",
+			UpdateID:        17242169,
+			Symbol:          "BTCUSD_200626",
+			Pair:            "BTCUSD",
+			BestBidPrice:    "9548.1",
+			BestBidQty:      "52",
+			BestAskPrice:    "9548.5",
+			BestAskQty:      "11",
+			TransactionTime: 1591268628155,
+			Time:            1591268628166,
+		}
+		s.assertWsBookTickerEvent(e, event)
+	},
+		func(err error) {
+			s.r().EqualError(err, fakeErrMsg)
+		})
+
+	s.r().NoError(err)
+	stopC <- struct{}{}
+	<-doneC
+}
+
+func (s *websocketServiceTestSuite) assertWsBookTickerEvent(e, a *WsBookTickerEvent) {
+	r := s.r()
+	r.Equal(e.Event, a.Event, "Event")
+	r.Equal(e.UpdateID, a.UpdateID, "UpdateID")
+	r.Equal(e.Time, a.Time, "Time")
+	r.Equal(e.TransactionTime, a.TransactionTime, "TransactionTime")
+	r.Equal(e.Symbol, a.Symbol, "Symbol")
+	r.Equal(e.Pair, a.Pair, "Pair")
+	r.Equal(e.BestBidPrice, a.BestBidPrice, "BestBidPrice")
+	r.Equal(e.BestBidQty, a.BestBidQty, "BestBidQty")
+	r.Equal(e.BestAskPrice, a.BestAskPrice, "BestAskPrice")
+	r.Equal(e.BestAskQty, a.BestAskQty, "BestAskQty")
+}
+
+// https://binance-docs.github.io/apidocs/delivery/en/#liquidation-order-streams
+func (s *websocketServiceTestSuite) TestLiquidationOrderServe() {
+	data := []byte(`{
+	  "e":"forceOrder",
+	  "E": 1591154240950,
+	  "o":{
+	    "s":"BTCUSD_200925",
+	    "ps": "BTCUSD",
+	    "S":"SELL",
+	    "o":"LIMIT",
+	    "f":"IOC",
+	    "q":"1",
+	    "p":"9425.5",
+	    "ap":"9496.5",
+	    "X":"FILLED",
+	    "l":"1",
+	    "z":"1",
+	    "T": 1591154240949
+	  }
+	}`)
+	fakeErrMsg := "fake error"
+	s.mockWsServe(data, errors.New(fakeErrMsg))
+	defer s.assertWsServe()
+
+	doneC, stopC, err := WsLiquidationOrderServe("BTCUSD_200925", func(event *WsLiquidationOrderEvent) {
+		e := &WsLiquidationOrderEvent{
+			Event: "forceOrder",
+			Time:  1591154240950,
+			LiquidationOrder: WsLiquidationOrder{
+				Symbol:               "BTCUSD_200925",
+				Pair:                 "BTCUSD",
+				Side:                 SideTypeSell,
+				OrderType:            OrderTypeLimit,
+				TimeInForce:          TimeInForceTypeIOC,
+				OrigQuantity:         "1",
+				Price:                "9425.5",
+				AvgPrice:             "9496.5",
+				OrderStatus:          OrderStatusTypeFilled,
+				LastFilledQty:        "1",
+				AccumulatedFilledQty: "1",
+				TradeTime:            1591154240949,
+			},
+		}
+		s.assertLiquidationOrderEvent(e, event)
+	},
+		func(err error) {
+			s.r().EqualError(err, fakeErrMsg)
+		})
+
+	s.r().NoError(err)
+	stopC <- struct{}{}
+	<-doneC
+}
+
+// https://binance-docs.github.io/apidocs/delivery/en/#all-market-liquidation-order-streams
+func (s *websocketServiceTestSuite) TestAllLiquidationOrderServe() {
+	data := []byte(`{
+	  "e":"forceOrder",
+	  "E": 1591154240950,
+	  "o":{
+		"s":"BTCUSD_200925",
+		"ps": "BTCUSD",
+		"S":"SELL",
+		"o":"LIMIT",
+		"f":"IOC",
+		"q":"1",
+		"p":"9425.5",
+		"ap":"9496.5",
+		"X":"FILLED",
+		"l":"1",
+		"z":"1",
+		"T": 1591154240949
+	  }
+	}`)
+	fakeErrMsg := "fake error"
+	s.mockWsServe(data, errors.New(fakeErrMsg))
+	defer s.assertWsServe()
+
+	doneC, stopC, err := WsAllLiquidationOrderServe(func(event *WsLiquidationOrderEvent) {
+		e := &WsLiquidationOrderEvent{
+			Event: "forceOrder",
+			Time:  1591154240950,
+			LiquidationOrder: WsLiquidationOrder{
+				Symbol:               "BTCUSD_200925",
+				Pair:                 "BTCUSD",
+				Side:                 SideTypeSell,
+				OrderType:            OrderTypeLimit,
+				TimeInForce:          TimeInForceTypeIOC,
+				OrigQuantity:         "1",
+				Price:                "9425.5",
+				AvgPrice:             "9496.5",
+				OrderStatus:          OrderStatusTypeFilled,
+				LastFilledQty:        "1",
+				AccumulatedFilledQty: "1",
+				TradeTime:            1591154240949,
+			},
+		}
+		s.assertLiquidationOrderEvent(e, event)
+	},
+		func(err error) {
+			s.r().EqualError(err, fakeErrMsg)
+		})
+
+	s.r().NoError(err)
+	stopC <- struct{}{}
+	<-doneC
+}
+
+func (s *websocketServiceTestSuite) assertLiquidationOrderEvent(e, a *WsLiquidationOrderEvent) {
+	r := s.r()
+	r.Equal(e.Event, a.Event, "Event")
+	r.Equal(e.Time, a.Time, "Time")
+	elo, alo := e.LiquidationOrder, a.LiquidationOrder
+	r.Equal(elo.Symbol, alo.Symbol, "Symbol")
+	r.Equal(elo.Pair, alo.Pair, "Pair")
+	r.Equal(elo.Side, alo.Side, "Side")
+	r.Equal(elo.OrderType, alo.OrderType, "OrderType")
+	r.Equal(elo.TimeInForce, alo.TimeInForce, "TimeInForce")
+	r.Equal(elo.OrigQuantity, alo.OrigQuantity, "OrigQuantity")
+	r.Equal(elo.Price, alo.Price, "Price")
+	r.Equal(elo.AvgPrice, alo.AvgPrice, "AvgPrice")
+	r.Equal(elo.OrderStatus, alo.OrderStatus, "OrderStatus")
+	r.Equal(elo.LastFilledQty, alo.LastFilledQty, "LastFilledQty")
+	r.Equal(elo.AccumulatedFilledQty, alo.AccumulatedFilledQty, "AccumulatedFilledQty")
+	r.Equal(elo.TradeTime, alo.TradeTime, "TradeTime")
+}
+
+// https://binance-docs.github.io/apidocs/delivery/en/#partial-book-depth-streams
+func (s *websocketServiceTestSuite) TestPartialDepthServe() {
+	data := []byte(`{
+	  "e":"depthUpdate",     
+	  "E":1591269996801,     
+	  "T":1591269996646,     
+	  "s":"BTCUSD_200626",   
+	  "ps":"BTCUSD",         
+	  "U":17276694,
+	  "u":17276701,
+	  "pu":17276678,
+	  "b":[                  
+		["9523.0","5"],
+		["9522.8","8"],
+		["9522.6","2"],
+		["9522.4","1"],
+		["9522.0","5"]
+	  ],
+	  "a":[
+		["9524.6","2"],
+		["9524.7","3"],
+		["9524.9","16"],
+		["9525.1","10"],
+		["9525.3","6"]
+	  ]
+	}`)
+	fakeErrMsg := "fake error"
+	s.mockWsServe(data, errors.New(fakeErrMsg))
+	defer s.assertWsServe()
+
+	doneC, stopC, err := WsPartialDepthServe("BTCUSD_200626", 5, func(event *WsDepthEvent) {
+		e := &WsDepthEvent{
+			Event:            "depthUpdate",
+			Time:             1591269996801,
+			TransactionTime:  1591269996646,
+			Symbol:           "BTCUSD_200626",
+			Pair:             "BTCUSD",
+			FirstUpdateID:    17276694,
+			LastUpdateID:     17276701,
+			PrevLastUpdateID: 17276678,
+			Bids: []Bid{
+				{Price: "9523.0", Quantity: "5"},
+				{Price: "9522.8", Quantity: "8"},
+				{Price: "9522.6", Quantity: "2"},
+				{Price: "9522.4", Quantity: "1"},
+				{Price: "9522.0", Quantity: "5"},
+			},
+			Asks: []Ask{
+				{Price: "9524.6", Quantity: "2"},
+				{Price: "9524.7", Quantity: "3"},
+				{Price: "9524.9", Quantity: "16"},
+				{Price: "9525.1", Quantity: "10"},
+				{Price: "9525.3", Quantity: "6"},
+			},
+		}
+		s.assertDepthEvent(e, event)
+	},
+		func(err error) {
+			s.r().EqualError(err, fakeErrMsg)
+		})
+
+	s.r().NoError(err)
+	stopC <- struct{}{}
+	<-doneC
+}
+
+// https://binance-docs.github.io/apidocs/delivery/en/#diff-book-depth-streams
+func (s *websocketServiceTestSuite) TestDiffDepthServe() {
+	data := []byte(`{
+	  "e": "depthUpdate",
+	  "E": 1591270260907,
+	  "T": 1591270260891,
+	  "s": "BTCUSD_200626",
+	  "ps": "BTCUSD",
+	  "U": 17285681,
+	  "u": 17285702,
+	  "pu": 17285675,
+	  "b": [
+		["9517.6","10"]
+	  ],
+	  "a": [
+		["9518.5","45"]
+	  ]
+	}`)
+	fakeErrMsg := "fake error"
+	s.mockWsServe(data, errors.New(fakeErrMsg))
+	defer s.assertWsServe()
+
+	doneC, stopC, err := WsDiffDepthServe("BTCUSD_200626", func(event *WsDepthEvent) {
+		e := &WsDepthEvent{
+			Event:            "depthUpdate",
+			Time:             1591270260907,
+			TransactionTime:  1591270260891,
+			Symbol:           "BTCUSD_200626",
+			Pair:             "BTCUSD",
+			FirstUpdateID:    17285681,
+			LastUpdateID:     17285702,
+			PrevLastUpdateID: 17285675,
+			Bids:             []Bid{{Price: "9517.6", Quantity: "10"}},
+			Asks:             []Ask{{Price: "9518.5", Quantity: "45"}},
+		}
+		s.assertDepthEvent(e, event)
+	},
+		func(err error) {
+			s.r().EqualError(err, fakeErrMsg)
+		})
+
+	s.r().NoError(err)
+	stopC <- struct{}{}
+	<-doneC
+}
+
+func (s *websocketServiceTestSuite) assertDepthEvent(e, a *WsDepthEvent) {
+	r := s.r()
+	r.Equal(e.Event, a.Event, "Event")
+	r.Equal(e.Time, a.Time, "Time")
+	r.Equal(e.TransactionTime, a.TransactionTime, "TransactionTime")
+	r.Equal(e.Symbol, a.Symbol, "Symbol")
+	r.Equal(e.Pair, a.Pair, "Pair")
+	r.Equal(e.FirstUpdateID, a.FirstUpdateID, "FirstUpdateID")
+	r.Equal(e.LastUpdateID, a.LastUpdateID, "LastUpdateID")
+	r.Equal(e.PrevLastUpdateID, a.PrevLastUpdateID, "PrevLastUpdateID")
+	for i, b := range e.Bids {
+		r.Equal(b.Price, a.Bids[i].Price, "Price")
+		r.Equal(b.Quantity, a.Bids[i].Quantity, "Quantity")
+	}
+	for i, b := range e.Asks {
+		r.Equal(b.Price, a.Asks[i].Price, "Price")
+		r.Equal(b.Quantity, a.Asks[i].Quantity, "Quantity")
+	}
+}


### PR DESCRIPTION
# Content
- WsAggTradeServe
- WsIndexPriceServe
- WsMarkPriceServe
- WsPairMarkPriceServe
- WsKlineServe
- WsContinuousKlineServe
- WsIndexPriceKlineServe
- WsMarkPriceKlineServe
- WsMiniMarketTickerServe
- WsAllMiniMarketTickerServe
- WsMarketTickerServe
- WsAllMarketTickerServe
- WsBookTickerServe
- WsAllBookTickerServe
- WsLiquidationOrderServe
- WsAllLiquidationOrderServe
- WsPartialDepthServe
- WsDiffDepthServe

Note that all available ws have been implemented (even the ones not yet in the future package)

# Edit: 
- Add user stream service