### PR TITLE
Delivery API (CoinM futures) - Add PositionRisk Service

### DIFF
--- a/delivery/client.go
+++ b/delivery/client.go
@@ -325,3 +325,8 @@ func (c *Client) NewListOrdersService() *ListOrdersService {
 func (c *Client) NewListLiquidationOrdersService() *ListLiquidationOrdersService {
 	return &ListLiquidationOrdersService{c: c}
 }
+
+// NewGetPositionRiskService init getting position risk service
+func (c *Client) NewGetPositionRiskService() *GetPositionRiskService {
+	return &GetPositionRiskService{c: c}
+}

--- a/delivery/position_risk.go
+++ b/delivery/position_risk.go
@@ -1,0 +1,66 @@
+package delivery
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// GetPositionRiskService get account balance
+type GetPositionRiskService struct {
+	c           *Client
+	pair        *string
+	marginAsset *string
+}
+
+// MarginAsset set margin asset
+func (s *GetPositionRiskService) MarginAsset(marginAsset string) *GetPositionRiskService {
+	s.marginAsset = &marginAsset
+	return s
+}
+
+// Pair set pair
+func (s *GetPositionRiskService) Pair(pair string) *GetPositionRiskService {
+	s.pair = &pair
+	return s
+}
+
+// Do send request
+func (s *GetPositionRiskService) Do(ctx context.Context, opts ...RequestOption) (res []*PositionRisk, err error) {
+	r := &request{
+		method:   "GET",
+		endpoint: "/dapi/v1/positionRisk",
+		secType:  secTypeSigned,
+	}
+	if s.marginAsset != nil {
+		r.setParam("marginAsset", *s.marginAsset)
+	}
+	if s.pair != nil {
+		r.setParam("pair", *s.pair)
+	}
+	data, err := s.c.callAPI(ctx, r, opts...)
+	if err != nil {
+		return []*PositionRisk{}, err
+	}
+	res = make([]*PositionRisk, 0)
+	err = json.Unmarshal(data, &res)
+	if err != nil {
+		return []*PositionRisk{}, err
+	}
+	return res, nil
+}
+
+// PositionRisk define position risk info
+type PositionRisk struct {
+	Symbol           string `json:"symbol"`
+	PositionAmt      string `json:"positionAmt"`
+	EntryPrice       string `json:"entryPrice"`
+	MarkPrice        string `json:"markPrice"`
+	UnRealizedProfit string `json:"unRealizedProfit"`
+	LiquidationPrice string `json:"liquidationPrice"`
+	Leverage         string `json:"leverage"`
+	MaxQuantity      string `json:"maxQty"`
+	MarginType       string `json:"marginType"`
+	IsolatedMargin   string `json:"isolatedMargin"`
+	IsAutoAddMargin  string `json:"isAutoAddMargin"`
+	PositionSide     string `json:"positionSide"`
+}

--- a/delivery/position_risk_test.go
+++ b/delivery/position_risk_test.go
@@ -1,0 +1,133 @@
+package delivery
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type positionRiskServiceTestSuite struct {
+	baseTestSuite
+}
+
+func TestPositionRiskTestService(t *testing.T) {
+	suite.Run(t, new(positionRiskServiceTestSuite))
+}
+
+func (s *positionRiskServiceTestSuite) TestGetPositionRisk() {
+	data := []byte(`[
+		{
+			"symbol": "BTCUSD_201225",
+			"positionAmt": "0",
+			"entryPrice": "0.0",
+			"markPrice": "0.00000000",
+			"unRealizedProfit": "0.00000000",
+			"liquidationPrice": "0",
+			"leverage": "125",
+			"maxQty": "50",
+			"marginType": "cross",
+			"isolatedMargin": "0.00000000",
+			"isAutoAddMargin": "false",
+			"positionSide": "BOTH"
+		},
+		{
+			"symbol": "BTCUSD_201225",
+			"positionAmt": "1",
+			"entryPrice": "11707.70000003",
+			"markPrice": "11788.66626667",
+			"unRealizedProfit": "0.00005866",
+			"liquidationPrice": "11667.63509587",
+			"leverage": "125",
+			"maxQty": "50",
+			"marginType": "cross",
+			"isolatedMargin": "0.00012357",
+			"isAutoAddMargin": "false",
+			"positionSide": "LONG"
+		},
+		{
+			"symbol": "BTCUSD_201225",
+			"positionAmt": "0",
+			"entryPrice": "0.0",
+			"markPrice": "0.00000000",
+			"unRealizedProfit": "0.00000000",
+			"liquidationPrice": "0",
+			"leverage": "125",
+			"maxQty": "50",
+			"marginType": "cross",
+			"isolatedMargin": "0.00000000",
+			"isAutoAddMargin": "false",
+			"positionSide": "SHORT"
+	  }
+	]`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+	s.assertReq(func(r *request) {
+		e := newSignedRequest().setParams(params{
+			"pair": "BTCUSD",
+		})
+		s.assertRequestEqual(e, r)
+	})
+
+	res, err := s.client.NewGetPositionRiskService().Pair("BTCUSD").Do(newContext())
+	s.r().NoError(err)
+	s.r().Len(res, 3)
+	e := []PositionRisk{{
+		Symbol:           "BTCUSD_201225",
+		PositionAmt:      "0",
+		EntryPrice:       "0.0",
+		MarkPrice:        "0.00000000",
+		UnRealizedProfit: "0.00000000",
+		LiquidationPrice: "0",
+		Leverage:         "125",
+		MaxQuantity:      "50",
+		MarginType:       "cross",
+		IsolatedMargin:   "0.00000000",
+		IsAutoAddMargin:  "false",
+		PositionSide:     "BOTH",
+	}, {
+		Symbol:           "BTCUSD_201225",
+		PositionAmt:      "1",
+		EntryPrice:       "11707.70000003",
+		MarkPrice:        "11788.66626667",
+		UnRealizedProfit: "0.00005866",
+		LiquidationPrice: "11667.63509587",
+		Leverage:         "125",
+		MaxQuantity:      "50",
+		MarginType:       "cross",
+		IsolatedMargin:   "0.00012357",
+		IsAutoAddMargin:  "false",
+		PositionSide:     "LONG",
+	}, {
+		Symbol:           "BTCUSD_201225",
+		PositionAmt:      "0",
+		EntryPrice:       "0.0",
+		MarkPrice:        "0.00000000",
+		UnRealizedProfit: "0.00000000",
+		LiquidationPrice: "0",
+		Leverage:         "125",
+		MaxQuantity:      "50",
+		MarginType:       "cross",
+		IsolatedMargin:   "0.00000000",
+		IsAutoAddMargin:  "false",
+		PositionSide:     "SHORT",
+	}}
+	s.assertPositionRiskEqual(&e[0], res[0])
+	s.assertPositionRiskEqual(&e[1], res[1])
+	s.assertPositionRiskEqual(&e[2], res[2])
+}
+
+func (s *positionRiskServiceTestSuite) assertPositionRiskEqual(e, a *PositionRisk) {
+	r := s.r()
+	r.Equal(e.EntryPrice, a.EntryPrice, "EntryPrice")
+	r.Equal(e.MarginType, a.MarginType, "MarginType")
+	r.Equal(e.IsAutoAddMargin, a.IsAutoAddMargin, "IsAutoAddMargin")
+	r.Equal(e.IsolatedMargin, a.IsolatedMargin, "IsolatedMargin")
+	r.Equal(e.Leverage, a.Leverage, "Leverage")
+	r.Equal(e.LiquidationPrice, a.LiquidationPrice, "LiquidationPrice")
+	r.Equal(e.MarkPrice, a.MarkPrice, "MarkPrice")
+	r.Equal(e.MaxQuantity, a.MaxQuantity, "MaxQuantity")
+	r.Equal(e.PositionAmt, a.PositionAmt, "PositionAmt")
+	r.Equal(e.Symbol, a.Symbol, "Symbol")
+	r.Equal(e.UnRealizedProfit, a.UnRealizedProfit, "UnRealizedProfit")
+	r.Equal(e.PositionSide, a.PositionSide, "PositionSide")
+}

--- a/v2/delivery/client.go
+++ b/v2/delivery/client.go
@@ -325,3 +325,8 @@ func (c *Client) NewListOrdersService() *ListOrdersService {
 func (c *Client) NewListLiquidationOrdersService() *ListLiquidationOrdersService {
 	return &ListLiquidationOrdersService{c: c}
 }
+
+// NewGetPositionRiskService init getting position risk service
+func (c *Client) NewGetPositionRiskService() *GetPositionRiskService {
+	return &GetPositionRiskService{c: c}
+}

--- a/v2/delivery/position_risk.go
+++ b/v2/delivery/position_risk.go
@@ -1,0 +1,66 @@
+package delivery
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// GetPositionRiskService get account balance
+type GetPositionRiskService struct {
+	c           *Client
+	pair        *string
+	marginAsset *string
+}
+
+// MarginAsset set margin asset
+func (s *GetPositionRiskService) MarginAsset(marginAsset string) *GetPositionRiskService {
+	s.marginAsset = &marginAsset
+	return s
+}
+
+// Pair set pair
+func (s *GetPositionRiskService) Pair(pair string) *GetPositionRiskService {
+	s.pair = &pair
+	return s
+}
+
+// Do send request
+func (s *GetPositionRiskService) Do(ctx context.Context, opts ...RequestOption) (res []*PositionRisk, err error) {
+	r := &request{
+		method:   "GET",
+		endpoint: "/dapi/v1/positionRisk",
+		secType:  secTypeSigned,
+	}
+	if s.marginAsset != nil {
+		r.setParam("marginAsset", *s.marginAsset)
+	}
+	if s.pair != nil {
+		r.setParam("pair", *s.pair)
+	}
+	data, err := s.c.callAPI(ctx, r, opts...)
+	if err != nil {
+		return []*PositionRisk{}, err
+	}
+	res = make([]*PositionRisk, 0)
+	err = json.Unmarshal(data, &res)
+	if err != nil {
+		return []*PositionRisk{}, err
+	}
+	return res, nil
+}
+
+// PositionRisk define position risk info
+type PositionRisk struct {
+	Symbol           string `json:"symbol"`
+	PositionAmt      string `json:"positionAmt"`
+	EntryPrice       string `json:"entryPrice"`
+	MarkPrice        string `json:"markPrice"`
+	UnRealizedProfit string `json:"unRealizedProfit"`
+	LiquidationPrice string `json:"liquidationPrice"`
+	Leverage         string `json:"leverage"`
+	MaxQuantity      string `json:"maxQty"`
+	MarginType       string `json:"marginType"`
+	IsolatedMargin   string `json:"isolatedMargin"`
+	IsAutoAddMargin  string `json:"isAutoAddMargin"`
+	PositionSide     string `json:"positionSide"`
+}

--- a/v2/delivery/position_risk_test.go
+++ b/v2/delivery/position_risk_test.go
@@ -1,0 +1,133 @@
+package delivery
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type positionRiskServiceTestSuite struct {
+	baseTestSuite
+}
+
+func TestPositionRiskTestService(t *testing.T) {
+	suite.Run(t, new(positionRiskServiceTestSuite))
+}
+
+func (s *positionRiskServiceTestSuite) TestGetPositionRisk() {
+	data := []byte(`[
+		{
+			"symbol": "BTCUSD_201225",
+			"positionAmt": "0",
+			"entryPrice": "0.0",
+			"markPrice": "0.00000000",
+			"unRealizedProfit": "0.00000000",
+			"liquidationPrice": "0",
+			"leverage": "125",
+			"maxQty": "50",
+			"marginType": "cross",
+			"isolatedMargin": "0.00000000",
+			"isAutoAddMargin": "false",
+			"positionSide": "BOTH"
+		},
+		{
+			"symbol": "BTCUSD_201225",
+			"positionAmt": "1",
+			"entryPrice": "11707.70000003",
+			"markPrice": "11788.66626667",
+			"unRealizedProfit": "0.00005866",
+			"liquidationPrice": "11667.63509587",
+			"leverage": "125",
+			"maxQty": "50",
+			"marginType": "cross",
+			"isolatedMargin": "0.00012357",
+			"isAutoAddMargin": "false",
+			"positionSide": "LONG"
+		},
+		{
+			"symbol": "BTCUSD_201225",
+			"positionAmt": "0",
+			"entryPrice": "0.0",
+			"markPrice": "0.00000000",
+			"unRealizedProfit": "0.00000000",
+			"liquidationPrice": "0",
+			"leverage": "125",
+			"maxQty": "50",
+			"marginType": "cross",
+			"isolatedMargin": "0.00000000",
+			"isAutoAddMargin": "false",
+			"positionSide": "SHORT"
+	  }
+	]`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+	s.assertReq(func(r *request) {
+		e := newSignedRequest().setParams(params{
+			"pair": "BTCUSD",
+		})
+		s.assertRequestEqual(e, r)
+	})
+
+	res, err := s.client.NewGetPositionRiskService().Pair("BTCUSD").Do(newContext())
+	s.r().NoError(err)
+	s.r().Len(res, 3)
+	e := []PositionRisk{{
+		Symbol:           "BTCUSD_201225",
+		PositionAmt:      "0",
+		EntryPrice:       "0.0",
+		MarkPrice:        "0.00000000",
+		UnRealizedProfit: "0.00000000",
+		LiquidationPrice: "0",
+		Leverage:         "125",
+		MaxQuantity:      "50",
+		MarginType:       "cross",
+		IsolatedMargin:   "0.00000000",
+		IsAutoAddMargin:  "false",
+		PositionSide:     "BOTH",
+	}, {
+		Symbol:           "BTCUSD_201225",
+		PositionAmt:      "1",
+		EntryPrice:       "11707.70000003",
+		MarkPrice:        "11788.66626667",
+		UnRealizedProfit: "0.00005866",
+		LiquidationPrice: "11667.63509587",
+		Leverage:         "125",
+		MaxQuantity:      "50",
+		MarginType:       "cross",
+		IsolatedMargin:   "0.00012357",
+		IsAutoAddMargin:  "false",
+		PositionSide:     "LONG",
+	}, {
+		Symbol:           "BTCUSD_201225",
+		PositionAmt:      "0",
+		EntryPrice:       "0.0",
+		MarkPrice:        "0.00000000",
+		UnRealizedProfit: "0.00000000",
+		LiquidationPrice: "0",
+		Leverage:         "125",
+		MaxQuantity:      "50",
+		MarginType:       "cross",
+		IsolatedMargin:   "0.00000000",
+		IsAutoAddMargin:  "false",
+		PositionSide:     "SHORT",
+	}}
+	s.assertPositionRiskEqual(&e[0], res[0])
+	s.assertPositionRiskEqual(&e[1], res[1])
+	s.assertPositionRiskEqual(&e[2], res[2])
+}
+
+func (s *positionRiskServiceTestSuite) assertPositionRiskEqual(e, a *PositionRisk) {
+	r := s.r()
+	r.Equal(e.EntryPrice, a.EntryPrice, "EntryPrice")
+	r.Equal(e.MarginType, a.MarginType, "MarginType")
+	r.Equal(e.IsAutoAddMargin, a.IsAutoAddMargin, "IsAutoAddMargin")
+	r.Equal(e.IsolatedMargin, a.IsolatedMargin, "IsolatedMargin")
+	r.Equal(e.Leverage, a.Leverage, "Leverage")
+	r.Equal(e.LiquidationPrice, a.LiquidationPrice, "LiquidationPrice")
+	r.Equal(e.MarkPrice, a.MarkPrice, "MarkPrice")
+	r.Equal(e.MaxQuantity, a.MaxQuantity, "MaxQuantity")
+	r.Equal(e.PositionAmt, a.PositionAmt, "PositionAmt")
+	r.Equal(e.Symbol, a.Symbol, "Symbol")
+	r.Equal(e.UnRealizedProfit, a.UnRealizedProfit, "UnRealizedProfit")
+	r.Equal(e.PositionSide, a.PositionSide, "PositionSide")
+}


### PR DESCRIPTION
# New feature
Add position risk service. (https://binance-docs.github.io/apidocs/delivery/en/#position-information-user_data)

# Notes
Delivery Position risk service differs from Futures Position risk service with the `pair` and `marginAsset` parameters

# Related to...
#150 and #145 