### PR TITLE
Delivery API (CoinM futures) - Add Server Services (ping and time)

### DIFF
--- a/delivery/client.go
+++ b/delivery/client.go
@@ -266,6 +266,21 @@ func (c *Client) callAPI(ctx context.Context, r *request, opts ...RequestOption)
 	return data, nil
 }
 
+// NewPingService init ping service
+func (c *Client) NewPingService() *PingService {
+	return &PingService{c: c}
+}
+
+// NewServerTimeService init server time service
+func (c *Client) NewServerTimeService() *ServerTimeService {
+	return &ServerTimeService{c: c}
+}
+
+// NewSetServerTimeService init set server time service
+func (c *Client) NewSetServerTimeService() *SetServerTimeService {
+	return &SetServerTimeService{c: c}
+}
+
 // NewKlinesService init klines service
 func (c *Client) NewKlinesService() *KlinesService {
 	return &KlinesService{c: c}

--- a/delivery/server_service.go
+++ b/delivery/server_service.go
@@ -1,0 +1,59 @@
+package delivery
+
+import (
+	"context"
+)
+
+// PingService ping server
+type PingService struct {
+	c *Client
+}
+
+// Do send request
+func (s *PingService) Do(ctx context.Context, opts ...RequestOption) (err error) {
+	r := &request{
+		method:   "GET",
+		endpoint: "/dapi/v1/ping",
+	}
+	_, err = s.c.callAPI(ctx, r, opts...)
+	return err
+}
+
+// ServerTimeService get server time
+type ServerTimeService struct {
+	c *Client
+}
+
+// Do send request
+func (s *ServerTimeService) Do(ctx context.Context, opts ...RequestOption) (serverTime int64, err error) {
+	r := &request{
+		method:   "GET",
+		endpoint: "/dapi/v1/time",
+	}
+	data, err := s.c.callAPI(ctx, r, opts...)
+	if err != nil {
+		return 0, err
+	}
+	j, err := newJSON(data)
+	if err != nil {
+		return 0, err
+	}
+	serverTime = j.Get("serverTime").MustInt64()
+	return serverTime, nil
+}
+
+// SetServerTimeService set server time
+type SetServerTimeService struct {
+	c *Client
+}
+
+// Do send request
+func (s *SetServerTimeService) Do(ctx context.Context, opts ...RequestOption) (timeOffset int64, err error) {
+	serverTime, err := s.c.NewServerTimeService().Do(ctx)
+	if err != nil {
+		return 0, err
+	}
+	timeOffset = currentTimestamp() - serverTime
+	s.c.TimeOffset = timeOffset
+	return timeOffset, nil
+}

--- a/delivery/server_service_test.go
+++ b/delivery/server_service_test.go
@@ -1,0 +1,107 @@
+package delivery
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/adshao/go-binance/common"
+	"github.com/stretchr/testify/suite"
+)
+
+type serverServiceTestSuite struct {
+	baseTestSuite
+}
+
+func TestServerService(t *testing.T) {
+	suite.Run(t, new(serverServiceTestSuite))
+}
+
+func (s *serverServiceTestSuite) TestPing() {
+	data := []byte(`{}`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	s.assertReq(func(r *request) {
+		e := newRequest()
+		s.assertRequestEqual(e, r)
+	})
+
+	err := s.client.NewPingService().Do(newContext())
+	s.r().NoError(err)
+}
+
+func (s *serverServiceTestSuite) TestServerTime() {
+	data := []byte(`{
+        "serverTime": 1499827319559
+    }`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	s.assertReq(func(r *request) {
+		e := newRequest()
+		s.assertRequestEqual(e, r)
+	})
+
+	serverTime, err := s.client.NewServerTimeService().Do(newContext())
+	s.r().NoError(err)
+	s.r().EqualValues(1499827319559, serverTime)
+}
+
+func (s *serverServiceTestSuite) TestServerTimeError() {
+	s.mockDo([]byte("{}"), fmt.Errorf("dummy error"), http.StatusInternalServerError)
+	defer s.assertDo()
+
+	s.assertReq(func(r *request) {
+		e := newRequest()
+		s.assertRequestEqual(e, r)
+	})
+	_, err := s.client.NewServerTimeService().Do(newContext())
+	s.r().Error(err)
+	s.r().Contains(err.Error(), "dummy error")
+}
+
+func (s *serverServiceTestSuite) TestServerTimeBadRequest() {
+	s.mockDo([]byte(`{
+        "code": -1121,
+        "msg": "Invalid symbol."
+    }`), nil, http.StatusBadRequest)
+	defer s.assertDo()
+
+	s.assertReq(func(r *request) {
+		e := newRequest()
+		s.assertRequestEqual(e, r)
+	})
+	_, err := s.client.NewServerTimeService().Do(newContext())
+	s.r().Error(err)
+	s.r().True(common.IsAPIError(err))
+}
+
+func (s *serverServiceTestSuite) TestInvalidResponseBody() {
+	s.mockDo([]byte(``), nil)
+	defer s.assertDo()
+
+	s.assertReq(func(r *request) {
+		e := newRequest()
+		s.assertRequestEqual(e, r)
+	})
+	_, err := s.client.NewServerTimeService().Do(newContext())
+	s.r().Error(err)
+	s.r().False(common.IsAPIError(err))
+}
+
+func (s *serverServiceTestSuite) TestSetServerTime() {
+	data := []byte(`1399827319559`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	s.assertReq(func(r *request) {
+		e := newRequest()
+		s.assertRequestEqual(e, r)
+	})
+
+	timeOffset, err := s.client.NewSetServerTimeService().Do(newContext())
+	s.r().NoError(err)
+	s.r().NotZero(s.client.TimeOffset)
+	s.r().EqualValues(timeOffset, s.client.TimeOffset)
+}

--- a/v2/delivery/client.go
+++ b/v2/delivery/client.go
@@ -266,6 +266,21 @@ func (c *Client) callAPI(ctx context.Context, r *request, opts ...RequestOption)
 	return data, nil
 }
 
+// NewPingService init ping service
+func (c *Client) NewPingService() *PingService {
+	return &PingService{c: c}
+}
+
+// NewServerTimeService init server time service
+func (c *Client) NewServerTimeService() *ServerTimeService {
+	return &ServerTimeService{c: c}
+}
+
+// NewSetServerTimeService init set server time service
+func (c *Client) NewSetServerTimeService() *SetServerTimeService {
+	return &SetServerTimeService{c: c}
+}
+
 // NewKlinesService init klines service
 func (c *Client) NewKlinesService() *KlinesService {
 	return &KlinesService{c: c}

--- a/v2/delivery/server_service.go
+++ b/v2/delivery/server_service.go
@@ -1,0 +1,59 @@
+package delivery
+
+import (
+	"context"
+)
+
+// PingService ping server
+type PingService struct {
+	c *Client
+}
+
+// Do send request
+func (s *PingService) Do(ctx context.Context, opts ...RequestOption) (err error) {
+	r := &request{
+		method:   "GET",
+		endpoint: "/dapi/v1/ping",
+	}
+	_, err = s.c.callAPI(ctx, r, opts...)
+	return err
+}
+
+// ServerTimeService get server time
+type ServerTimeService struct {
+	c *Client
+}
+
+// Do send request
+func (s *ServerTimeService) Do(ctx context.Context, opts ...RequestOption) (serverTime int64, err error) {
+	r := &request{
+		method:   "GET",
+		endpoint: "/dapi/v1/time",
+	}
+	data, err := s.c.callAPI(ctx, r, opts...)
+	if err != nil {
+		return 0, err
+	}
+	j, err := newJSON(data)
+	if err != nil {
+		return 0, err
+	}
+	serverTime = j.Get("serverTime").MustInt64()
+	return serverTime, nil
+}
+
+// SetServerTimeService set server time
+type SetServerTimeService struct {
+	c *Client
+}
+
+// Do send request
+func (s *SetServerTimeService) Do(ctx context.Context, opts ...RequestOption) (timeOffset int64, err error) {
+	serverTime, err := s.c.NewServerTimeService().Do(ctx)
+	if err != nil {
+		return 0, err
+	}
+	timeOffset = currentTimestamp() - serverTime
+	s.c.TimeOffset = timeOffset
+	return timeOffset, nil
+}

--- a/v2/delivery/server_service_test.go
+++ b/v2/delivery/server_service_test.go
@@ -1,0 +1,107 @@
+package delivery
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/adshao/go-binance/v2/common"
+	"github.com/stretchr/testify/suite"
+)
+
+type serverServiceTestSuite struct {
+	baseTestSuite
+}
+
+func TestServerService(t *testing.T) {
+	suite.Run(t, new(serverServiceTestSuite))
+}
+
+func (s *serverServiceTestSuite) TestPing() {
+	data := []byte(`{}`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	s.assertReq(func(r *request) {
+		e := newRequest()
+		s.assertRequestEqual(e, r)
+	})
+
+	err := s.client.NewPingService().Do(newContext())
+	s.r().NoError(err)
+}
+
+func (s *serverServiceTestSuite) TestServerTime() {
+	data := []byte(`{
+        "serverTime": 1499827319559
+    }`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	s.assertReq(func(r *request) {
+		e := newRequest()
+		s.assertRequestEqual(e, r)
+	})
+
+	serverTime, err := s.client.NewServerTimeService().Do(newContext())
+	s.r().NoError(err)
+	s.r().EqualValues(1499827319559, serverTime)
+}
+
+func (s *serverServiceTestSuite) TestServerTimeError() {
+	s.mockDo([]byte("{}"), fmt.Errorf("dummy error"), http.StatusInternalServerError)
+	defer s.assertDo()
+
+	s.assertReq(func(r *request) {
+		e := newRequest()
+		s.assertRequestEqual(e, r)
+	})
+	_, err := s.client.NewServerTimeService().Do(newContext())
+	s.r().Error(err)
+	s.r().Contains(err.Error(), "dummy error")
+}
+
+func (s *serverServiceTestSuite) TestServerTimeBadRequest() {
+	s.mockDo([]byte(`{
+        "code": -1121,
+        "msg": "Invalid symbol."
+    }`), nil, http.StatusBadRequest)
+	defer s.assertDo()
+
+	s.assertReq(func(r *request) {
+		e := newRequest()
+		s.assertRequestEqual(e, r)
+	})
+	_, err := s.client.NewServerTimeService().Do(newContext())
+	s.r().Error(err)
+	s.r().True(common.IsAPIError(err))
+}
+
+func (s *serverServiceTestSuite) TestInvalidResponseBody() {
+	s.mockDo([]byte(``), nil)
+	defer s.assertDo()
+
+	s.assertReq(func(r *request) {
+		e := newRequest()
+		s.assertRequestEqual(e, r)
+	})
+	_, err := s.client.NewServerTimeService().Do(newContext())
+	s.r().Error(err)
+	s.r().False(common.IsAPIError(err))
+}
+
+func (s *serverServiceTestSuite) TestSetServerTime() {
+	data := []byte(`1399827319559`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	s.assertReq(func(r *request) {
+		e := newRequest()
+		s.assertRequestEqual(e, r)
+	})
+
+	timeOffset, err := s.client.NewSetServerTimeService().Do(newContext())
+	s.r().NoError(err)
+	s.r().NotZero(s.client.TimeOffset)
+	s.r().EqualValues(timeOffset, s.client.TimeOffset)
+}


### PR DESCRIPTION
# New feature
Add server services
- ping https://binance-docs.github.io/apidocs/delivery/en/#test-connectivity
- time https://binance-docs.github.io/apidocs/delivery/en/#check-server-time

# Related to...
#150 and #145 