### PR TITLE
Fix isIsolated in ListMarginOpenOrdersService

### DIFF
--- a/margin_order_service.go
+++ b/margin_order_service.go
@@ -307,6 +307,9 @@ func (s *ListMarginOpenOrdersService) Do(ctx context.Context, opts ...RequestOpt
 	if s.symbol != "" {
 		r.setParam("symbol", s.symbol)
 	}
+	if s.isIsolated != nil {
+		r.setParam("isIsolated", *s.isIsolated)
+	}
 	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return []*Order{}, err


### PR DESCRIPTION
Fixes #196.

#161 added the `IsIsolated()` member function to both `ListMarginOpenOrdersService` and `ListMarginOrdersService`, but in the latter it was not effective (the `isIsolated` field was never populated in the request performed by `Do`).

This change fixes that by adding the `isIsolated` property to `ListMarginOpenOrdersService`'s requests.

cc @anujm08 