### PR TITLE
Make AssetDetail.MinWithdrawAmount a float64.

### DIFF
--- a/v2/asset_detail_service.go
+++ b/v2/asset_detail_service.go
@@ -33,7 +33,7 @@ func (s *GetAssetDetailService) Do(ctx context.Context) (assetDetails map[string
 
 // AssetDetail represents the detail of an asset
 type AssetDetail struct {
-	MinWithdrawAmount string  `json:"minWithdrawAmount"`
+	MinWithdrawAmount float64 `json:"minWithdrawAmount"`
 	DepositStatus     bool    `json:"depositStatus"`
 	WithdrawFee       float64 `json:"withdrawFee"`
 	WithdrawStatus    bool    `json:"withdrawStatus"`

--- a/v2/asset_detail_service_test.go
+++ b/v2/asset_detail_service_test.go
@@ -20,14 +20,14 @@ func (s *withdrawServiceTestSuite) TestGetAssetDetail() {
     "success": true,
     "assetDetail": {
 			"CTR": {
-				"minWithdrawAmount": "70.00000000",
+				"minWithdrawAmount": 70.00000000,
 				"depositStatus": false,
 				"withdrawFee": 35,
 				"withdrawStatus": true,
 				"depositTip": "Delisted, Deposit Suspended"
 			},
 			"SKY": {
-				"minWithdrawAmount": "0.02000000",
+				"minWithdrawAmount": 0.02000000,
 				"depositStatus": true,
 				"withdrawFee": 0.01,
 				"withdrawStatus": true


### PR DESCRIPTION
If you run this code, which JSON marshalls your assets to STDOUT:

```go
	assets, err := client.NewGetAssetDetailService().Do(context.Background())
	if err != nil {
		log.Fatal(err)
	}
	bs, err := json.Marshal(assets)
	if err != nil {
		log.Fatal(err)
	}
	fmt.Println(string(bs))
```

You get this unmarshalling error:

```
2021/02/27 21:35:08 json: cannot unmarshal number into Go struct field AssetDetail.assetDetail.minWithdrawAmount of type string
exit status 1
```

This PR simply fixes the datatype of the `assetDetail.minWithdrawAmount` field to the correct `float64`. With the fixed datatype, the marshalling now works:

```
{"1INCH":{"minWithdrawAmount":6.14,"depositStatus":true,"withdrawFee":3.07,"withdrawStatus":true,"depositTip":""},"AAVE":{"minWithdrawAmount":0.2,"depositStatus":true,"withdrawFee":0.1,"withdrawStatus":true,"depositTip":""},"AAVEDOWN":{"minWithdrawAmount":0,"depositStatus":false,"withdrawFee":0,"withdrawStatus":false,"depositTip":"Not support deposit"},"AAVEUP":{"...
```