### PR TITLE
Add isolatedSymbol parameter to GetMaxBorrowableService

### DIFF
--- a/v2/margin_service.go
+++ b/v2/margin_service.go
@@ -733,7 +733,9 @@ func (s *GetMaxBorrowableService) Do(ctx context.Context, opts ...RequestOption)
 		secType:  secTypeSigned,
 	}
 	r.setParam("asset", s.asset)
-	r.setParam("isolatedSymbol", s.isolatedSymbol)
+	if s.isolatedSymbol != "" {
+		r.setParam("isolatedSymbol", s.isolatedSymbol)
+	}
 	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return nil, err

--- a/v2/margin_service.go
+++ b/v2/margin_service.go
@@ -708,13 +708,20 @@ func (s *ListMarginTradesService) Do(ctx context.Context, opts ...RequestOption)
 
 // GetMaxBorrowableService get max borrowable of asset
 type GetMaxBorrowableService struct {
-	c     *Client
-	asset string
+	c              *Client
+	asset          string
+	isolatedSymbol string
 }
 
 // Asset set asset
 func (s *GetMaxBorrowableService) Asset(asset string) *GetMaxBorrowableService {
 	s.asset = asset
+	return s
+}
+
+// IsolatedSymbol set isolatedSymbol
+func (s *GetMaxBorrowableService) IsolatedSymbol(isolatedSymbol string) *GetMaxBorrowableService {
+	s.isolatedSymbol = isolatedSymbol
 	return s
 }
 
@@ -726,6 +733,7 @@ func (s *GetMaxBorrowableService) Do(ctx context.Context, opts ...RequestOption)
 		secType:  secTypeSigned,
 	}
 	r.setParam("asset", s.asset)
+	r.setParam("isolatedSymbol", s.isolatedSymbol)
 	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The `isolatedSymbol` parameter is required to get the max borrow amount of an isolated margin account.  
See https://binance-docs.github.io/apidocs/spot/en/#query-max-borrow-user_data