### PR TITLE
Fix mark price issue of futures websocket

### DIFF
--- a/v2/futures/websocket_service.go
+++ b/v2/futures/websocket_service.go
@@ -66,13 +66,14 @@ func WsAggTradeServe(symbol string, handler WsAggTradeHandler, errHandler ErrHan
 
 // WsMarkPriceEvent define websocket markPriceUpdate event.
 type WsMarkPriceEvent struct {
-	Event           string `json:"e"`
-	Time            int64  `json:"E"`
-	Symbol          string `json:"s"`
-	MarkPrice       string `json:"p"`
-	IndexPrice      string `json:"i"`
-	FundingRate     string `json:"r"`
-	NextFundingTime int64  `json:"T"`
+	Event                string `json:"e"`
+	Time                 int64  `json:"E"`
+	Symbol               string `json:"s"`
+	MarkPrice            string `json:"p"`
+	IndexPrice           string `json:"i"`
+	EstimatedSettlePrice string `json:"P"`
+	FundingRate          string `json:"r"`
+	NextFundingTime      int64  `json:"T"`
 }
 
 // WsMarkPriceHandler handle websocket that pushes price and funding rate for a single symbol.


### PR DESCRIPTION
EstimatedSettlePrice is missing which caused wrong markprice
after parsed JSON.