### PR TITLE
fix PremiumIndex unmarshal issue when returns only one object

### DIFF
--- a/v2/futures/mark_price.go
+++ b/v2/futures/mark_price.go
@@ -30,6 +30,7 @@ func (s *PremiumIndexService) Do(ctx context.Context, opts ...RequestOption) (re
 		r.setParam("symbol", *s.symbol)
 	}
 	data, err := s.c.callAPI(ctx, r, opts...)
+	data = common.ToJSONList(data)
 	if err != nil {
 		return []*PremiumIndex{}, err
 	}


### PR DESCRIPTION
Fix unmarshal issue when there's only one object in returned result.

error message:
json: cannot unmarshal object into Go value of type []*futures.PremiumIndex
