### PR TITLE
add missing fields for futures leverageBracket and account

### DIFF
--- a/v2/futures/account_service.go
+++ b/v2/futures/account_service.go
@@ -110,4 +110,7 @@ type AccountPosition struct {
 	MaxNotional            string           `json:"maxNotional"`
 	PositionSide           PositionSideType `json:"positionSide"`
 	PositionAmt            string           `json:"positionAmt"`
+	Notional               string           `json:"notional"`
+	IsolatedWallet         string           `json:"isolatedWallet"`
+	UpdateTime             int64            `json:"updateTime"`
 }

--- a/v2/futures/account_service_test.go
+++ b/v2/futures/account_service_test.go
@@ -92,7 +92,10 @@ func (s *accountServiceTestSuite) TestGetAccount() {
 				"entryPrice": "8950.5",
 				"maxNotional": "250000",
 				"positionSide": "BOTH",
-				"positionAmt": "0.436"
+				"positionAmt": "0.436",
+				"notional":"0.1234",
+				"isolatedWallet":"0.5678",
+				"updateTime":1618646402359
 			 }
 		 ],
 		 "totalInitialMargin": "0.33683000",
@@ -146,6 +149,9 @@ func (s *accountServiceTestSuite) TestGetAccount() {
 				MaxNotional:            "250000",
 				PositionSide:           "BOTH",
 				PositionAmt:            "0.436",
+				Notional:               "0.1234",
+				IsolatedWallet:         "0.5678",
+				UpdateTime:             1618646402359,
 			},
 		},
 		TotalInitialMargin:          "0.33683000",
@@ -203,5 +209,8 @@ func (s *accountServiceTestSuite) assertAccountEqual(e, a *Account) {
 		r.Equal(e.Positions[i].MaxNotional, a.Positions[i].MaxNotional, "MaxNotional")
 		r.Equal(e.Positions[i].PositionSide, a.Positions[i].PositionSide, "PositionSide")
 		r.Equal(e.Positions[i].PositionAmt, a.Positions[i].PositionAmt, "PositionAmt")
+		r.Equal(e.Positions[i].Notional, a.Positions[i].Notional, "Notional")
+		r.Equal(e.Positions[i].IsolatedWallet, a.Positions[i].IsolatedWallet, "IsolatedWallet")
+		r.Equal(e.Positions[i].UpdateTime, a.Positions[i].UpdateTime, "UpdateTime")
 	}
 }

--- a/v2/futures/mark_price.go
+++ b/v2/futures/mark_price.go
@@ -175,4 +175,5 @@ type Bracket struct {
 	NotionalCap      float64 `json:"notionalCap"`
 	NotionalFloor    float64 `json:"notionalFloor"`
 	MaintMarginRatio float64 `json:"maintMarginRatio"`
+	Cum              float64 `json:"cum"`
 }

--- a/v2/futures/mark_price_test.go
+++ b/v2/futures/mark_price_test.go
@@ -143,7 +143,8 @@ func (s *getLeverageBracketServiceTestSuite) TestGetLeverageBracket() {
 				"initialLeverage": 75,
 				"notionalCap": 10000,
 				"notionalFloor": 0,
-				"maintMarginRatio": 0.0065
+				"maintMarginRatio": 0.0065,
+				"cum": 1.2345
 			}
 		]
 	}`)
@@ -173,6 +174,7 @@ func (s *getLeverageBracketServiceTestSuite) TestGetLeverageBracket() {
 					NotionalCap:      10000,
 					NotionalFloor:    0,
 					MaintMarginRatio: 0.0065,
+					Cum:              1.2345,
 				},
 			},
 		},
@@ -191,4 +193,5 @@ func (s *getLeverageBracketServiceTestSuite) assertLeverageBracketEqual(e, a *Le
 	r.Equal(e.Brackets[0].NotionalCap, a.Brackets[0].NotionalCap, "NotionalCap")
 	r.Equal(e.Brackets[0].NotionalFloor, a.Brackets[0].NotionalFloor, "NotionalFloor")
 	r.Equal(e.Brackets[0].MaintMarginRatio, a.Brackets[0].MaintMarginRatio, "MaintMarginRatio")
+	r.Equal(e.Brackets[0].Cum, a.Brackets[0].Cum, "Cum")
 }


### PR DESCRIPTION
Add missing fields for following APIs.
fapi/v1/account
/fapi/v1/leverageBracket