### PR TITLE
Unify futures.Bid and futures.Ask

### DIFF
--- a/v2/futures/depth_service.go
+++ b/v2/futures/depth_service.go
@@ -2,6 +2,7 @@ package futures
 
 import (
 	"context"
+	"strconv"
 )
 
 // DepthService show depth info
@@ -71,14 +72,30 @@ type DepthResponse struct {
 	Asks         []Ask `json:"asks"`
 }
 
-// Bid define bid info with price and quantity
-type Bid struct {
+// PriceLevel is a common structure for bids and asks in the
+// order book.
+type PriceLevel struct {
 	Price    string
 	Quantity string
 }
 
-// Ask define ask info with price and quantity
-type Ask struct {
-	Price    string
-	Quantity string
+// Parse parses this PriceLevel's Price and Quantity and
+// returns them both.  It also returns an error if either
+// fails to parse.
+func (p *PriceLevel) Parse() (float64, float64, error) {
+	price, err := strconv.ParseFloat(p.Price, 64)
+	if err != nil {
+		return 0, 0, err
+	}
+	quantity, err := strconv.ParseFloat(p.Quantity, 64)
+	if err != nil {
+		return price, 0, err
+	}
+	return price, quantity, nil
 }
+
+// Ask is a type alias for PriceLevel.
+type Ask = PriceLevel
+
+// Bid is a tpye alias for PriceLevel.
+type Bid = PriceLevel


### PR DESCRIPTION
Now they get replaced by a unified type called PriceLevel.  Bid and
Ask remain available as type aliases, which is backward compatible,
but also allows code to treat both bids and asks the same.