### PR TITLE
Changed type of asks and bids to one type. 

### DIFF
--- a/v2/common/priceLevel.go
+++ b/v2/common/priceLevel.go
@@ -1,0 +1,25 @@
+package common
+
+import "strconv"
+
+// PriceLevel is a common structure for bids and asks in the
+// order book.
+type PriceLevel struct {
+	Price    string
+	Quantity string
+}
+
+// Parse parses this PriceLevel's Price and Quantity and
+// returns them both.  It also returns an error if either
+// fails to parse.
+func (p *PriceLevel) Parse() (float64, float64, error) {
+	price, err := strconv.ParseFloat(p.Price, 64)
+	if err != nil {
+		return 0, 0, err
+	}
+	quantity, err := strconv.ParseFloat(p.Quantity, 64)
+	if err != nil {
+		return price, 0, err
+	}
+	return price, quantity, nil
+}

--- a/v2/delivery/depth_service.go
+++ b/v2/delivery/depth_service.go
@@ -1,13 +1,9 @@
 package delivery
 
-// Bid define bid info with price and quantity
-type Bid struct {
-	Price    string
-	Quantity string
-}
+import "github.com/adshao/go-binance/v2/common"
 
-// Ask define ask info with price and quantity
-type Ask struct {
-	Price    string
-	Quantity string
-}
+// Ask is a type alias for PriceLevel.
+type Ask = common.PriceLevel
+
+// Bid is a type alias for PriceLevel.
+type Bid = common.PriceLevel

--- a/v2/depth_service.go
+++ b/v2/depth_service.go
@@ -2,6 +2,8 @@ package binance
 
 import (
 	"context"
+
+	"github.com/adshao/go-binance/v2/common"
 )
 
 // DepthService show depth info
@@ -71,14 +73,8 @@ type DepthResponse struct {
 	Asks         []Ask `json:"asks"`
 }
 
-// Bid define bid info with price and quantity
-type Bid struct {
-	Price    string
-	Quantity string
-}
+// Ask is a type alias for PriceLevel.
+type Ask = common.PriceLevel
 
-// Ask define ask info with price and quantity
-type Ask struct {
-	Price    string
-	Quantity string
-}
+// Bid is a type alias for PriceLevel.
+type Bid = common.PriceLevel

--- a/v2/futures/depth_service.go
+++ b/v2/futures/depth_service.go
@@ -2,7 +2,8 @@ package futures
 
 import (
 	"context"
-	"strconv"
+
+	"github.com/adshao/go-binance/v2/common"
 )
 
 // DepthService show depth info
@@ -72,30 +73,8 @@ type DepthResponse struct {
 	Asks         []Ask `json:"asks"`
 }
 
-// PriceLevel is a common structure for bids and asks in the
-// order book.
-type PriceLevel struct {
-	Price    string
-	Quantity string
-}
-
-// Parse parses this PriceLevel's Price and Quantity and
-// returns them both.  It also returns an error if either
-// fails to parse.
-func (p *PriceLevel) Parse() (float64, float64, error) {
-	price, err := strconv.ParseFloat(p.Price, 64)
-	if err != nil {
-		return 0, 0, err
-	}
-	quantity, err := strconv.ParseFloat(p.Quantity, 64)
-	if err != nil {
-		return price, 0, err
-	}
-	return price, quantity, nil
-}
-
 // Ask is a type alias for PriceLevel.
-type Ask = PriceLevel
+type Ask = common.PriceLevel
 
-// Bid is a tpye alias for PriceLevel.
-type Bid = PriceLevel
+// Bid is a type alias for PriceLevel.
+type Bid = common.PriceLevel

--- a/v2/websocket_service.go
+++ b/v2/websocket_service.go
@@ -168,7 +168,7 @@ func wsDepthServe(endpoint string, handler WsDepthHandler, errHandler ErrHandler
 		event.Event = j.Get("e").MustString()
 		event.Time = j.Get("E").MustInt64()
 		event.Symbol = j.Get("s").MustString()
-		event.UpdateID = j.Get("u").MustInt64()
+		event.LastUpdateID = j.Get("u").MustInt64()
 		event.FirstUpdateID = j.Get("U").MustInt64()
 		bidsLen := len(j.Get("b").MustArray())
 		event.Bids = make([]Bid, bidsLen)
@@ -198,7 +198,7 @@ type WsDepthEvent struct {
 	Event         string `json:"e"`
 	Time          int64  `json:"E"`
 	Symbol        string `json:"s"`
-	UpdateID      int64  `json:"u"`
+	LastUpdateID  int64  `json:"u"`
 	FirstUpdateID int64  `json:"U"`
 	Bids          []Bid  `json:"b"`
 	Asks          []Ask  `json:"a"`

--- a/v2/websocket_service_test.go
+++ b/v2/websocket_service_test.go
@@ -261,7 +261,7 @@ func (s *websocketServiceTestSuite) TestDepthServe() {
 			Event:         "depthUpdate",
 			Time:          1499404630606,
 			Symbol:        "ETHBTC",
-			UpdateID:      7913455,
+			LastUpdateID:  7913455,
 			FirstUpdateID: 7913452,
 			Bids: []Bid{
 				{
@@ -334,7 +334,7 @@ func (s *websocketServiceTestSuite) TestDepthServe100Ms() {
 			Event:         "depthUpdate",
 			Time:          1499404630606,
 			Symbol:        "ETHBTC",
-			UpdateID:      7913455,
+			LastUpdateID:  7913455,
 			FirstUpdateID: 7913452,
 			Bids: []Bid{
 				{
@@ -371,7 +371,7 @@ func (s *websocketServiceTestSuite) assertWsDepthEventEqual(e, a *WsDepthEvent) 
 	r.Equal(e.Event, a.Event, "Event")
 	r.Equal(e.Time, a.Time, "Time")
 	r.Equal(e.Symbol, a.Symbol, "Symbol")
-	r.Equal(e.UpdateID, a.UpdateID, "UpdateID")
+	r.Equal(e.LastUpdateID, a.LastUpdateID, "UpdateID")
 	r.Equal(e.FirstUpdateID, a.FirstUpdateID, "FirstUpdateID")
 	for i := 0; i < len(e.Bids); i++ {
 		r.Equal(e.Bids[i].Price, a.Bids[i].Price, "Price")


### PR DESCRIPTION
Hi!
I've needed to work with asks\bids from spot and futures market simultaneously, that's why I think that asks and bids should be the same type (I moved them into common package).
In addition, I changed the name of update ID, because previous name wasn't clear enough (binance docs are using "lastUpdateId").