### PR TITLE
feat: add single symbol and multiple symbol support for exchange info…

### DIFF
--- a/v2/exchange_info_service.go
+++ b/v2/exchange_info_service.go
@@ -7,7 +7,21 @@ import (
 
 // ExchangeInfoService exchange info service
 type ExchangeInfoService struct {
-	c *Client
+	c       *Client
+	symbol  string
+	symbols []string
+}
+
+// Symbol set symbol
+func (s *ExchangeInfoService) Symbol(symbol string) *ExchangeInfoService {
+	s.symbol = symbol
+	return s
+}
+
+// Symbols set symbol
+func (s *ExchangeInfoService) Symbols(symbols ...string) *ExchangeInfoService {
+	s.symbols = symbols
+	return s
 }
 
 // Do send request
@@ -17,6 +31,14 @@ func (s *ExchangeInfoService) Do(ctx context.Context, opts ...RequestOption) (re
 		endpoint: "/api/v3/exchangeInfo",
 		secType:  secTypeNone,
 	}
+	m := params{}
+	if s.symbol != "" {
+		m["symbol"] = s.symbol
+	}
+	if len(s.symbols) != 0 {
+		m["symbols"] = s.symbols
+	}
+	r.setParams(m)
 	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return nil, err

--- a/v2/exchange_info_service_test.go
+++ b/v2/exchange_info_service_test.go
@@ -58,11 +58,16 @@ func (s *exchangeInfoServiceTestSuite) TestExchangeInfo() {
 	}`)
 	s.mockDo(data, nil)
 	defer s.assertDo()
+	symbol := "ETHBTC"
+	symbols := []string{"ETHBTC", "LTCBTC"}
 	s.assertReq(func(r *request) {
-		e := newRequest()
+		e := newRequest().setParams(map[string]interface{}{
+			"symbol":  symbol,
+			"symbols": symbols,
+		})
 		s.assertRequestEqual(e, r)
 	})
-	res, err := s.client.NewExchangeInfoService().Do(newContext())
+	res, err := s.client.NewExchangeInfoService().Symbol(symbol).Symbols(symbols...).Do(newContext())
 	s.r().NoError(err)
 	ei := &ExchangeInfo{
 		Timezone:   "UTC",


### PR DESCRIPTION

support `symbol` and `symbols` args for exchange info api: `GET /api/v3/exchangeInfo`

plz read:  [https://binance-docs.github.io/apidocs/spot/cn/#3f1907847c](https://binance-docs.github.io/apidocs/spot/cn/#3f1907847c)