### PR TITLE
Add isIsolated parameter to MarginLoanService and MarginRepayService

### DIFF
--- a/v2/margin_service.go
+++ b/v2/margin_service.go
@@ -64,9 +64,10 @@ type TransactionResponse struct {
 
 // MarginLoanService apply for a loan
 type MarginLoanService struct {
-	c      *Client
-	asset  string
-	amount string
+	c          *Client
+	asset      string
+	amount     string
+	isIsolated bool
 }
 
 // Asset set asset being transferred, e.g., BTC
@@ -78,6 +79,12 @@ func (s *MarginLoanService) Asset(asset string) *MarginLoanService {
 // Amount the amount to be transferred
 func (s *MarginLoanService) Amount(amount string) *MarginLoanService {
 	s.amount = amount
+	return s
+}
+
+// IsIsolated set isIsolated
+func (s *MarginLoanService) IsIsolated(isIsolated bool) *MarginLoanService {
+	s.isIsolated = isIsolated
 	return s
 }
 
@@ -93,6 +100,9 @@ func (s *MarginLoanService) Do(ctx context.Context, opts ...RequestOption) (res 
 		"amount": s.amount,
 	}
 	r.setFormParams(m)
+	if s.isIsolated {
+		r.setParam("isIsolated", "TRUE")
+	}
 	res = new(TransactionResponse)
 	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
@@ -107,9 +117,10 @@ func (s *MarginLoanService) Do(ctx context.Context, opts ...RequestOption) (res 
 
 // MarginRepayService repay loan for margin account
 type MarginRepayService struct {
-	c      *Client
-	asset  string
-	amount string
+	c          *Client
+	asset      string
+	amount     string
+	isIsolated bool
 }
 
 // Asset set asset being transferred, e.g., BTC
@@ -121,6 +132,12 @@ func (s *MarginRepayService) Asset(asset string) *MarginRepayService {
 // Amount the amount to be transferred
 func (s *MarginRepayService) Amount(amount string) *MarginRepayService {
 	s.amount = amount
+	return s
+}
+
+// IsIsolated set isIsolated
+func (s *MarginRepayService) IsIsolated(isIsolated bool) *MarginRepayService {
+	s.isIsolated = isIsolated
 	return s
 }
 
@@ -136,6 +153,9 @@ func (s *MarginRepayService) Do(ctx context.Context, opts ...RequestOption) (res
 		"amount": s.amount,
 	}
 	r.setFormParams(m)
+	if s.isIsolated {
+		r.setParam("isIsolated", "TRUE")
+	}
 	res = new(TransactionResponse)
 	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {

--- a/v2/margin_service.go
+++ b/v2/margin_service.go
@@ -82,7 +82,7 @@ func (s *MarginLoanService) Amount(amount string) *MarginLoanService {
 	return s
 }
 
-// IsolatedSymbol set isIsolated
+// IsolatedSymbol set IsolatedSymbol
 func (s *MarginLoanService) IsolatedSymbol(isolatedSymbol string) *MarginLoanService {
 	s.isolatedSymbol = isolatedSymbol
 	return s
@@ -135,7 +135,7 @@ func (s *MarginRepayService) Amount(amount string) *MarginRepayService {
 	return s
 }
 
-// IsolatedSymbol set isIsolated
+// IsolatedSymbol set IsolatedSymbol
 func (s *MarginRepayService) IsolatedSymbol(isolatedSymbol string) *MarginRepayService {
 	s.isolatedSymbol = isolatedSymbol
 	return s

--- a/v2/margin_service.go
+++ b/v2/margin_service.go
@@ -64,10 +64,10 @@ type TransactionResponse struct {
 
 // MarginLoanService apply for a loan
 type MarginLoanService struct {
-	c          *Client
-	asset      string
-	amount     string
-	isIsolated bool
+	c              *Client
+	asset          string
+	amount         string
+	isolatedSymbol string
 }
 
 // Asset set asset being transferred, e.g., BTC
@@ -82,9 +82,9 @@ func (s *MarginLoanService) Amount(amount string) *MarginLoanService {
 	return s
 }
 
-// IsIsolated set isIsolated
-func (s *MarginLoanService) IsIsolated(isIsolated bool) *MarginLoanService {
-	s.isIsolated = isIsolated
+// IsolatedSymbol set isIsolated
+func (s *MarginLoanService) IsolatedSymbol(isolatedSymbol string) *MarginLoanService {
+	s.isolatedSymbol = isolatedSymbol
 	return s
 }
 
@@ -100,8 +100,8 @@ func (s *MarginLoanService) Do(ctx context.Context, opts ...RequestOption) (res 
 		"amount": s.amount,
 	}
 	r.setFormParams(m)
-	if s.isIsolated {
-		r.setParam("isolatedSymbol", "TRUE")
+	if s.isolatedSymbol != "" {
+		r.setParam("isolatedSymbol", s.isolatedSymbol)
 	}
 	res = new(TransactionResponse)
 	data, err := s.c.callAPI(ctx, r, opts...)
@@ -117,10 +117,10 @@ func (s *MarginLoanService) Do(ctx context.Context, opts ...RequestOption) (res 
 
 // MarginRepayService repay loan for margin account
 type MarginRepayService struct {
-	c          *Client
-	asset      string
-	amount     string
-	isIsolated bool
+	c              *Client
+	asset          string
+	amount         string
+	isolatedSymbol string
 }
 
 // Asset set asset being transferred, e.g., BTC
@@ -135,9 +135,9 @@ func (s *MarginRepayService) Amount(amount string) *MarginRepayService {
 	return s
 }
 
-// IsIsolated set isIsolated
-func (s *MarginRepayService) IsIsolated(isIsolated bool) *MarginRepayService {
-	s.isIsolated = isIsolated
+// IsolatedSymbol set isIsolated
+func (s *MarginRepayService) IsolatedSymbol(isolatedSymbol string) *MarginRepayService {
+	s.isolatedSymbol = isolatedSymbol
 	return s
 }
 
@@ -153,8 +153,8 @@ func (s *MarginRepayService) Do(ctx context.Context, opts ...RequestOption) (res
 		"amount": s.amount,
 	}
 	r.setFormParams(m)
-	if s.isIsolated {
-		r.setParam("isolatedSymbol", "TRUE")
+	if s.isolatedSymbol != "" {
+		r.setParam("isolatedSymbol", s.isolatedSymbol)
 	}
 	res = new(TransactionResponse)
 	data, err := s.c.callAPI(ctx, r, opts...)

--- a/v2/margin_service.go
+++ b/v2/margin_service.go
@@ -101,7 +101,7 @@ func (s *MarginLoanService) Do(ctx context.Context, opts ...RequestOption) (res 
 	}
 	r.setFormParams(m)
 	if s.isIsolated {
-		r.setParam("isIsolated", "TRUE")
+		r.setParam("isolatedSymbol", "TRUE")
 	}
 	res = new(TransactionResponse)
 	data, err := s.c.callAPI(ctx, r, opts...)
@@ -154,7 +154,7 @@ func (s *MarginRepayService) Do(ctx context.Context, opts ...RequestOption) (res
 	}
 	r.setFormParams(m)
 	if s.isIsolated {
-		r.setParam("isIsolated", "TRUE")
+		r.setParam("isolatedSymbol", "TRUE")
 	}
 	res = new(TransactionResponse)
 	data, err := s.c.callAPI(ctx, r, opts...)


### PR DESCRIPTION
The isolatedSymbol parameter is required to borrow and repay loan for isolated margin account.
See https://binance-docs.github.io/apidocs/spot/en/#margin-account-repay-margin and https://binance-docs.github.io/apidocs/spot/en/#margin-account-borrow-margin