### PR TITLE
Fix the bug of multiple symbol(#267)

### DIFF
--- a/v2/exchange_info_service.go
+++ b/v2/exchange_info_service.go
@@ -3,13 +3,14 @@ package binance
 import (
 	"context"
 	"encoding/json"
+	"strings"
 )
 
 // ExchangeInfoService exchange info service
 type ExchangeInfoService struct {
 	c       *Client
 	symbol  string
-	symbols []string
+	symbols string
 }
 
 // Symbol set symbol
@@ -19,8 +20,12 @@ func (s *ExchangeInfoService) Symbol(symbol string) *ExchangeInfoService {
 }
 
 // Symbols set symbol
-func (s *ExchangeInfoService) Symbols(symbols ...string) *ExchangeInfoService {
-	s.symbols = symbols
+func (s *ExchangeInfoService) Symbols(pairs ...string) *ExchangeInfoService {
+	if len(pairs) == 0 {
+		s.symbols = "[]"
+	} else {
+		s.symbols = "[\"" + strings.Join(pairs, "\",\"") + "\"]"
+	}
 	return s
 }
 


### PR DESCRIPTION
I found a bug (#267) and tried to fix it.

Correct request format:
curl -X GET "https://api.binance.com/api/v3/exchangeInfo?symbols=%5B%22BNBBTC%22,%22BTCUSDT%22%5D" 
or 
curl -g GET 'https://api.binance.com/api/v3/exchangeInfo?symbols=["BTCUSDT","BNBBTC"]'