### PR TITLE
Delivery API (CoinM futures) - Add Ticker Service

### DIFF
--- a/v2/delivery/client.go
+++ b/v2/delivery/client.go
@@ -304,6 +304,21 @@ func (c *Client) NewKlinesService() *KlinesService {
 	return &KlinesService{c: c}
 }
 
+// NewListPriceChangeStatsService init list prices change stats service
+func (c *Client) NewListPriceChangeStatsService() *ListPriceChangeStatsService {
+	return &ListPriceChangeStatsService{c: c}
+}
+
+// NewListPricesService init listing prices service
+func (c *Client) NewListPricesService() *ListPricesService {
+	return &ListPricesService{c: c}
+}
+
+// NewListBookTickersService init listing booking tickers service
+func (c *Client) NewListBookTickersService() *ListBookTickersService {
+	return &ListBookTickersService{c: c}
+}
+
 // NewStartUserStreamService init starting user stream service
 func (c *Client) NewStartUserStreamService() *StartUserStreamService {
 	return &StartUserStreamService{c: c}

--- a/v2/delivery/ticker_service.go
+++ b/v2/delivery/ticker_service.go
@@ -5,26 +5,26 @@ import (
 	"encoding/json"
 )
 
-// ListBookTickersService list best price/qty on the order book for a symbol or symbols
+// ListBookTickersService list best price/qty on the order book for a symbol or symbols.
 type ListBookTickersService struct {
 	c      *Client
 	symbol *string
 	pair   *string
 }
 
-// Symbol set symbol
+// Symbol set symbol.
 func (s *ListBookTickersService) Symbol(symbol string) *ListBookTickersService {
 	s.symbol = &symbol
 	return s
 }
 
-// Pair set pair
+// Pair set pair.
 func (s *ListBookTickersService) Pair(pair string) *ListBookTickersService {
 	s.pair = &pair
 	return s
 }
 
-// Do send request
+// Do send request.
 func (s *ListBookTickersService) Do(ctx context.Context, opts ...RequestOption) (res []*BookTicker, err error) {
 	r := &request{
 		method:   "GET",
@@ -49,7 +49,7 @@ func (s *ListBookTickersService) Do(ctx context.Context, opts ...RequestOption) 
 	return res, nil
 }
 
-// BookTicker define book ticker info
+// BookTicker define book ticker info.
 type BookTicker struct {
 	Symbol      string `json:"symbol"`
 	Pair        string `json:"pair"`
@@ -59,26 +59,26 @@ type BookTicker struct {
 	AskQuantity string `json:"askQty"`
 }
 
-// ListPricesService list latest price for a symbol or symbols
+// ListPricesService list latest price for a symbol or symbols.
 type ListPricesService struct {
 	c      *Client
 	symbol *string
 	pair   *string
 }
 
-// Symbol set symbol
+// Symbol set symbol.
 func (s *ListPricesService) Symbol(symbol string) *ListPricesService {
 	s.symbol = &symbol
 	return s
 }
 
-// Pair set pair
+// Pair set pair.
 func (s *ListPricesService) Pair(pair string) *ListPricesService {
 	s.pair = &pair
 	return s
 }
 
-// Do send request
+// Do send request.
 func (s *ListPricesService) Do(ctx context.Context, opts ...RequestOption) (res []*SymbolPrice, err error) {
 	r := &request{
 		method:   "GET",
@@ -103,33 +103,33 @@ func (s *ListPricesService) Do(ctx context.Context, opts ...RequestOption) (res 
 	return res, nil
 }
 
-// SymbolPrice define symbol, price and pair
+// SymbolPrice define symbol, price and pair.
 type SymbolPrice struct {
 	Symbol string `json:"symbol"`
 	Pair   string `json:"ps"`
 	Price  string `json:"price"`
 }
 
-// ListPriceChangeStatsService show stats of price change in last 24 hours for single symbol, all symbols or pairs of symbols
+// ListPriceChangeStatsService show stats of price change in last 24 hours for single symbol, all symbols or pairs of symbols.
 type ListPriceChangeStatsService struct {
 	c      *Client
 	symbol *string
 	pair   *string
 }
 
-// Symbol set symbol
+// Symbol set symbol.
 func (s *ListPriceChangeStatsService) Symbol(symbol string) *ListPriceChangeStatsService {
 	s.symbol = &symbol
 	return s
 }
 
-// Pair set pair
+// Pair set pair.
 func (s *ListPriceChangeStatsService) Pair(pair string) *ListPriceChangeStatsService {
 	s.pair = &pair
 	return s
 }
 
-// Do send request
+// Do send request.
 func (s *ListPriceChangeStatsService) Do(ctx context.Context, opts ...RequestOption) (res []*PriceChangeStats, err error) {
 	r := &request{
 		method:   "GET",
@@ -154,7 +154,7 @@ func (s *ListPriceChangeStatsService) Do(ctx context.Context, opts ...RequestOpt
 	return res, nil
 }
 
-// PriceChangeStats define price change stats
+// PriceChangeStats define price change stats.
 type PriceChangeStats struct {
 	Symbol             string `json:"symbol"`
 	Pair               string `json:"pair"`

--- a/v2/delivery/ticker_service.go
+++ b/v2/delivery/ticker_service.go
@@ -1,0 +1,181 @@
+package delivery
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/adshao/go-binance/v2/common"
+)
+
+// ListBookTickersService list best price/qty on the order book for a symbol or symbols
+type ListBookTickersService struct {
+	c      *Client
+	symbol *string
+	pair   *string
+}
+
+// Symbol set symbol
+func (s *ListBookTickersService) Symbol(symbol string) *ListBookTickersService {
+	s.symbol = &symbol
+	return s
+}
+
+// Pair set pair
+func (s *ListBookTickersService) Pair(pair string) *ListBookTickersService {
+	s.pair = &pair
+	return s
+}
+
+// Do send request
+func (s *ListBookTickersService) Do(ctx context.Context, opts ...RequestOption) (res []*BookTicker, err error) {
+	r := &request{
+		method:   "GET",
+		endpoint: "/dapi/v1/ticker/bookTicker",
+	}
+	if s.symbol != nil {
+		r.setParam("symbol", *s.symbol)
+	}
+	if s.pair != nil {
+		r.setParam("pair", *s.pair)
+	}
+
+	data, err := s.c.callAPI(ctx, r, opts...)
+	data = common.ToJSONList(data)
+	if err != nil {
+		return []*BookTicker{}, err
+	}
+	res = make([]*BookTicker, 0)
+	err = json.Unmarshal(data, &res)
+	if err != nil {
+		return []*BookTicker{}, err
+	}
+	return res, nil
+}
+
+// BookTicker define book ticker info
+type BookTicker struct {
+	Symbol      string `json:"symbol"`
+	Pair        string `json:"pair"`
+	BidPrice    string `json:"bidPrice"`
+	BidQuantity string `json:"bidQty"`
+	AskPrice    string `json:"askPrice"`
+	AskQuantity string `json:"askQty"`
+}
+
+// ListPricesService list latest price for a symbol or symbols
+type ListPricesService struct {
+	c      *Client
+	symbol *string
+	pair   *string
+}
+
+// Symbol set symbol
+func (s *ListPricesService) Symbol(symbol string) *ListPricesService {
+	s.symbol = &symbol
+	return s
+}
+
+// Pair set pair
+func (s *ListPricesService) Pair(pair string) *ListPricesService {
+	s.pair = &pair
+	return s
+}
+
+// Do send request
+func (s *ListPricesService) Do(ctx context.Context, opts ...RequestOption) (res []*SymbolPrice, err error) {
+	r := &request{
+		method:   "GET",
+		endpoint: "/dapi/v1/ticker/price",
+	}
+	if s.symbol != nil {
+		r.setParam("symbol", *s.symbol)
+	}
+	if s.pair != nil {
+		r.setParam("pair", *s.pair)
+	}
+
+	data, err := s.c.callAPI(ctx, r, opts...)
+	if err != nil {
+		return []*SymbolPrice{}, err
+	}
+	data = common.ToJSONList(data)
+	res = make([]*SymbolPrice, 0)
+	err = json.Unmarshal(data, &res)
+	if err != nil {
+		return []*SymbolPrice{}, err
+	}
+	return res, nil
+}
+
+// SymbolPrice define symbol and price pair
+type SymbolPrice struct {
+	Symbol string `json:"symbol"`
+	Pair   string `json:"ps"`
+	Price  string `json:"price"`
+}
+
+// ListPriceChangeStatsService show stats of price change in last 24 hours for all symbols
+type ListPriceChangeStatsService struct {
+	c      *Client
+	symbol *string
+	pair   *string
+}
+
+// Symbol set symbol
+func (s *ListPriceChangeStatsService) Symbol(symbol string) *ListPriceChangeStatsService {
+	s.symbol = &symbol
+	return s
+}
+
+// Pair set pair
+func (s *ListPriceChangeStatsService) Pair(pair string) *ListPriceChangeStatsService {
+	s.pair = &pair
+	return s
+}
+
+// Do send request
+func (s *ListPriceChangeStatsService) Do(ctx context.Context, opts ...RequestOption) (res []*PriceChangeStats, err error) {
+	r := &request{
+		method:   "GET",
+		endpoint: "/dapi/v1/ticker/24hr",
+	}
+	if s.symbol != nil {
+		r.setParam("symbol", *s.symbol)
+	}
+	if s.pair != nil {
+		r.setParam("pair", *s.pair)
+	}
+
+	data, err := s.c.callAPI(ctx, r, opts...)
+	if err != nil {
+		return res, err
+	}
+	data = common.ToJSONList(data)
+	res = make([]*PriceChangeStats, 0)
+	err = json.Unmarshal(data, &res)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+// PriceChangeStats define price change stats
+type PriceChangeStats struct {
+	Symbol             string `json:"symbol"`
+	Pair               string `json:"pair"`
+	PriceChange        string `json:"priceChange"`
+	PriceChangePercent string `json:"priceChangePercent"`
+	WeightedAvgPrice   string `json:"weightedAvgPrice"`
+	LastPrice          string `json:"lastPrice"`
+	LastQuantity       string `json:"lastQty"`
+	OpenPrice          string `json:"openPrice"`
+	HighPrice          string `json:"highPrice"`
+	LowPrice           string `json:"lowPrice"`
+	Volume             string `json:"volume"`
+	BaseVolume         string `json:"baseVolume"`
+	OpenTime           int64  `json:"openTime"`
+	CloseTime          int64  `json:"closeTime"`
+	FristID            int64  `json:"firstId"`
+	LastID             int64  `json:"lastId"`
+	Count              int64  `json:"count"`
+}

--- a/v2/delivery/ticker_service.go
+++ b/v2/delivery/ticker_service.go
@@ -3,8 +3,6 @@ package delivery
 import (
 	"context"
 	"encoding/json"
-
-	"github.com/adshao/go-binance/v2/common"
 )
 
 // ListBookTickersService list best price/qty on the order book for a symbol or symbols
@@ -40,7 +38,6 @@ func (s *ListBookTickersService) Do(ctx context.Context, opts ...RequestOption) 
 	}
 
 	data, err := s.c.callAPI(ctx, r, opts...)
-	data = common.ToJSONList(data)
 	if err != nil {
 		return []*BookTicker{}, err
 	}
@@ -98,7 +95,6 @@ func (s *ListPricesService) Do(ctx context.Context, opts ...RequestOption) (res 
 	if err != nil {
 		return []*SymbolPrice{}, err
 	}
-	data = common.ToJSONList(data)
 	res = make([]*SymbolPrice, 0)
 	err = json.Unmarshal(data, &res)
 	if err != nil {
@@ -150,7 +146,6 @@ func (s *ListPriceChangeStatsService) Do(ctx context.Context, opts ...RequestOpt
 	if err != nil {
 		return res, err
 	}
-	data = common.ToJSONList(data)
 	res = make([]*PriceChangeStats, 0)
 	err = json.Unmarshal(data, &res)
 	if err != nil {

--- a/v2/delivery/ticker_service.go
+++ b/v2/delivery/ticker_service.go
@@ -107,14 +107,14 @@ func (s *ListPricesService) Do(ctx context.Context, opts ...RequestOption) (res 
 	return res, nil
 }
 
-// SymbolPrice define symbol and price pair
+// SymbolPrice define symbol, price and pair
 type SymbolPrice struct {
 	Symbol string `json:"symbol"`
 	Pair   string `json:"ps"`
 	Price  string `json:"price"`
 }
 
-// ListPriceChangeStatsService show stats of price change in last 24 hours for all symbols
+// ListPriceChangeStatsService show stats of price change in last 24 hours for single symbol, all symbols or pairs of symbols
 type ListPriceChangeStatsService struct {
 	c      *Client
 	symbol *string

--- a/v2/delivery/ticker_service_test.go
+++ b/v2/delivery/ticker_service_test.go
@@ -1,0 +1,547 @@
+package delivery
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type tickerServiceTestSuite struct {
+	baseTestSuite
+}
+
+func TestTickerService(t *testing.T) {
+	suite.Run(t, new(tickerServiceTestSuite))
+}
+
+func (s *tickerServiceTestSuite) TestListBookTickers() {
+	data := []byte(`[
+        {
+            "symbol": "BTCUSD_PERP",
+			"pair": "BTCUSD",
+            "bidPrice": "40041.9",
+            "bidQty": "3074",
+            "askPrice": "40042.0",
+            "askQty": "5286"
+        },
+        {
+            "symbol": "ETHUSD_PERP",
+			"pair": "ETHUSD",
+            "bidPrice": "2525.41",
+            "bidQty": "17054",
+            "askPrice": "2525.42",
+            "askQty": "7112"
+        }
+    ]`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	s.assertReq(func(r *request) {
+		e := newRequest()
+		s.assertRequestEqual(e, r)
+	})
+
+	tickers, err := s.client.NewListBookTickersService().Do(newContext())
+	r := s.r()
+	r.NoError(err)
+	r.Len(tickers, 2)
+	e1 := &BookTicker{
+		Symbol:      "BTCUSD_PERP",
+		Pair:        "BTCUSD",
+		BidPrice:    "40041.9",
+		BidQuantity: "3074",
+		AskPrice:    "40042.0",
+		AskQuantity: "5286",
+	}
+	e2 := &BookTicker{
+		Symbol:      "ETHUSD_PERP",
+		Pair:        "ETHUSD",
+		BidPrice:    "2525.41",
+		BidQuantity: "17054",
+		AskPrice:    "2525.42",
+		AskQuantity: "7112",
+	}
+	s.assertBookTickerEqual(e1, tickers[0])
+	s.assertBookTickerEqual(e2, tickers[1])
+}
+
+func (s *tickerServiceTestSuite) TestSingleBookTicker() {
+	data := []byte(`[
+		{
+			"symbol": "BTCUSD_210625",
+			"pair": "BTCUSD",
+			"bidPrice": "40078.9",
+			"bidQty": "761",
+			"askPrice": "40079.0",
+			"askQty": "280"
+		}
+	]`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	symbol := "BTCUSD_210625"
+
+	s.assertReq(func(r *request) {
+		e := newRequest().setParam("symbol", symbol)
+		s.assertRequestEqual(e, r)
+	})
+
+	tickers, err := s.client.NewListBookTickersService().Symbol("BTCUSD_210625").Do(newContext())
+	r := s.r()
+	r.NoError(err)
+	r.Len(tickers, 1)
+	e := &BookTicker{
+		Symbol:      "BTCUSD_210625",
+		Pair:        "BTCUSD",
+		BidPrice:    "40078.9",
+		BidQuantity: "761",
+		AskPrice:    "40079.0",
+		AskQuantity: "280",
+	}
+	s.assertBookTickerEqual(e, tickers[0])
+}
+
+func (s *tickerServiceTestSuite) TestListBookTickersWithPair() {
+	data := []byte(`[
+		{
+			"symbol": "ETHUSD_210625",
+			"pair": "ETHUSD",
+			"bidPrice": "2524.22",
+			"bidQty": "5820",
+			"askPrice": "2524.23",
+			"askQty": "3575"
+		},
+		{
+			"symbol": "ETHUSD_PERP",
+			"pair": "ETHUSD",
+			"bidPrice": "2518.08",
+			"bidQty": "7137",
+			"askPrice": "2518.09",
+			"askQty": "42967"
+		}
+	]`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	pair := "ETHUSD"
+
+	s.assertReq(func(r *request) {
+		e := newRequest().setParam("pair", pair)
+		s.assertRequestEqual(e, r)
+	})
+	tickers, err := s.client.NewListBookTickersService().Pair("ETHUSD").Do(newContext())
+	r := s.r()
+	r.NoError(err)
+	r.Len(tickers, 2)
+	e1 := &BookTicker{
+		Symbol:      "ETHUSD_210625",
+		Pair:        "ETHUSD",
+		BidPrice:    "2524.22",
+		BidQuantity: "5820",
+		AskPrice:    "2524.23",
+		AskQuantity: "3575",
+	}
+	e2 := &BookTicker{
+		Symbol:      "ETHUSD_PERP",
+		Pair:        "ETHUSD",
+		BidPrice:    "2518.08",
+		BidQuantity: "7137",
+		AskPrice:    "2518.09",
+		AskQuantity: "42967",
+	}
+	s.assertBookTickerEqual(e1, tickers[0])
+	s.assertBookTickerEqual(e2, tickers[1])
+}
+
+func (s *tickerServiceTestSuite) assertBookTickerEqual(e, a *BookTicker) {
+	r := s.r()
+	r.Equal(e.Symbol, a.Symbol, "Symbol")
+	r.Equal(e.Pair, a.Pair, "Pair")
+	r.Equal(e.BidPrice, a.BidPrice, "BidPrice")
+	r.Equal(e.BidQuantity, a.BidQuantity, "BidQuantity")
+	r.Equal(e.AskPrice, a.AskPrice, "AskPrice")
+	r.Equal(e.AskQuantity, a.AskQuantity, "AskQuantity")
+}
+
+func (s *tickerServiceTestSuite) TestListPrices() {
+	data := []byte(`[
+        {
+            "symbol": "BTCUSD_PERP",
+			"ps": "BTCUSD",
+            "price": "40016.1"
+        },
+        {
+            "symbol": "ETHUSD_PERP",
+			"ps": "ETHUSD",
+            "price": "2519.13"
+        }
+    ]`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	s.assertReq(func(r *request) {
+		e := newRequest()
+		s.assertRequestEqual(e, r)
+	})
+
+	prices, err := s.client.NewListPricesService().Do(newContext())
+	r := s.r()
+	r.NoError(err)
+	r.Len(prices, 2)
+	e1 := &SymbolPrice{
+		Symbol: "BTCUSD_PERP",
+		Pair:   "BTCUSD",
+		Price:  "40016.1",
+	}
+	e2 := &SymbolPrice{
+		Symbol: "ETHUSD_PERP",
+		Pair:   "ETHUSD",
+		Price:  "2519.13",
+	}
+	s.assertSymbolPriceEqual(e1, prices[0])
+	s.assertSymbolPriceEqual(e2, prices[1])
+}
+
+func (s *tickerServiceTestSuite) TestListSinglePrice() {
+	data := []byte(`[
+		{
+			"symbol": "BTCUSD_PERP",
+			"ps": "BTCUSD",
+			"price": "39984.3"
+		}
+	]`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	symbol := "BTCUSD_PERP"
+	s.assertReq(func(r *request) {
+		e := newRequest().setParam("symbol", symbol)
+		s.assertRequestEqual(e, r)
+	})
+
+	prices, err := s.client.NewListPricesService().Symbol(symbol).Do(newContext())
+	r := s.r()
+	r.NoError(err)
+	r.Len(prices, 1)
+	e := &SymbolPrice{
+		Symbol: "BTCUSD_PERP",
+		Pair:   "BTCUSD",
+		Price:  "39984.3",
+	}
+	s.assertSymbolPriceEqual(e, prices[0])
+}
+
+func (s *tickerServiceTestSuite) TestListPricesWithPair() {
+	data := []byte(`[
+		{
+		"symbol": "BTCUSD_210924",
+		"ps": "BTCUSD",
+		"price": "40998.5"
+		},
+		{
+		"symbol": "BTCUSD_210625",
+		"ps": "BTCUSD",
+		"price": "40049.3"
+		}
+	]`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	pair := "BTCUSD"
+	s.assertReq(func(r *request) {
+		e := newRequest().setParam("pair", pair)
+		s.assertRequestEqual(e, r)
+	})
+
+	prices, err := s.client.NewListPricesService().Pair(pair).Do(newContext())
+	r := s.r()
+	r.NoError(err)
+	r.Len(prices, 2)
+	e1 := &SymbolPrice{
+		Symbol: "BTCUSD_210924",
+		Pair:   "BTCUSD",
+		Price:  "40998.5",
+	}
+	e2 := &SymbolPrice{
+		Symbol: "BTCUSD_210625",
+		Pair:   "BTCUSD",
+		Price:  "40049.3",
+	}
+	s.assertSymbolPriceEqual(e1, prices[0])
+	s.assertSymbolPriceEqual(e2, prices[1])
+}
+
+func (s *tickerServiceTestSuite) assertSymbolPriceEqual(e, a *SymbolPrice) {
+	r := s.r()
+	r.Equal(e.Price, a.Price, "Price")
+	r.Equal(e.Pair, a.Pair, "Pair")
+	r.Equal(e.Symbol, a.Symbol, "Symbol")
+}
+
+func (s *tickerServiceTestSuite) TestListPriceChangeStats() {
+	data := []byte(`[
+		{
+			"symbol": "BTCUSD_PERP",
+			"pair": "BTCUSD",
+			"priceChange": "208.5",
+			"priceChangePercent": "0.524",
+			"weightedAvgPrice": "40186.36908209",
+			"lastPrice": "40011.9",
+			"lastQty": "2",
+			"openPrice": "39803.4",
+			"highPrice": "41327.2",
+			"lowPrice": "39455.9",
+			"volume": "55845297",
+			"baseVolume": "138965.76942775",
+			"openTime": 1623748920000,
+			"closeTime": 1623835355736,
+			"firstId": 172749700,
+			"lastId": 173464362,
+			"count": 714658
+		},
+		{
+			"symbol": "ETHUSD_PERP",
+			"pair": "ETHUSD",
+			"priceChange": "-59.74",
+			"priceChangePercent": "-2.316",
+			"weightedAvgPrice": "2549.94814666",
+			"lastPrice": "2519.36",
+			"lastQty": "15",
+			"openPrice": "2579.10",
+			"highPrice": "2615.85",
+			"lowPrice": "2498.62",
+			"volume": "165282425",
+			"baseVolume": "648179.55304919",
+			"openTime": 1623748920000,
+			"closeTime": 1623835355187,
+			"firstId": 138575549,
+			"lastId": 139103143,
+			"count": 527595
+		}
+	]`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	s.assertReq(func(r *request) {
+		e := newRequest()
+		s.assertRequestEqual(e, r)
+	})
+	res, err := s.client.NewListPriceChangeStatsService().Do(newContext())
+	r := s.r()
+	r.NoError(err)
+
+	e1 := &PriceChangeStats{
+		Symbol:             "BTCUSD_PERP",
+		Pair:               "BTCUSD",
+		PriceChange:        "208.5",
+		PriceChangePercent: "0.524",
+		WeightedAvgPrice:   "40186.36908209",
+		LastPrice:          "40011.9",
+		LastQuantity:       "2",
+		OpenPrice:          "39803.4",
+		HighPrice:          "41327.2",
+		LowPrice:           "39455.9",
+		Volume:             "55845297",
+		BaseVolume:         "138965.76942775",
+		OpenTime:           1623748920000,
+		CloseTime:          1623835355736,
+		FristID:            172749700,
+		LastID:             173464362,
+		Count:              714658,
+	}
+	e2 := &PriceChangeStats{
+		Symbol:             "ETHUSD_PERP",
+		Pair:               "ETHUSD",
+		PriceChange:        "-59.74",
+		PriceChangePercent: "-2.316",
+		WeightedAvgPrice:   "2549.94814666",
+		LastPrice:          "2519.36",
+		LastQuantity:       "15",
+		OpenPrice:          "2579.10",
+		HighPrice:          "2615.85",
+		LowPrice:           "2498.62",
+		Volume:             "165282425",
+		BaseVolume:         "648179.55304919",
+		OpenTime:           1623748920000,
+		CloseTime:          1623835355187,
+		FristID:            138575549,
+		LastID:             139103143,
+		Count:              527595,
+	}
+
+	s.r().Len(res, 2)
+	s.assertPriceChangeStatsEqual(e1, res[0])
+	s.assertPriceChangeStatsEqual(e2, res[1])
+}
+
+func (s *tickerServiceTestSuite) TestSinglePriceChangeStats() {
+	data := []byte(`[
+		{
+		"symbol": "BTCUSD_PERP",
+		"pair": "BTCUSD",
+		"priceChange": "-15.2",
+		"priceChangePercent": "-0.038",
+		"weightedAvgPrice": "40185.26563935",
+		"lastPrice": "39955.9",
+		"lastQty": "50",
+		"openPrice": "39971.1",
+		"highPrice": "41327.2",
+		"lowPrice": "39455.9",
+		"volume": "55355578",
+		"baseVolume": "137750.93213717",
+		"openTime": 1623752520000,
+		"closeTime": 1623838964257,
+		"firstId": 172782522,
+		"lastId": 173490102,
+		"count": 707576
+		}
+	]`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	symbol := "BTCUSD_PERP"
+	s.assertReq(func(r *request) {
+		e := newRequest().setParam("symbol", symbol)
+		s.assertRequestEqual(e, r)
+	})
+	stats, err := s.client.NewListPriceChangeStatsService().Symbol(symbol).Do(newContext())
+	r := s.r()
+	r.NoError(err)
+	r.Len(stats, 1)
+	e := &PriceChangeStats{
+		Symbol:             "BTCUSD_PERP",
+		Pair:               "BTCUSD",
+		PriceChange:        "-15.2",
+		PriceChangePercent: "-0.038",
+		WeightedAvgPrice:   "40185.26563935",
+		LastPrice:          "39955.9",
+		LastQuantity:       "50",
+		OpenPrice:          "39971.1",
+		HighPrice:          "41327.2",
+		LowPrice:           "39455.9",
+		Volume:             "55355578",
+		BaseVolume:         "137750.93213717",
+		OpenTime:           1623752520000,
+		CloseTime:          1623838964257,
+		FristID:            172782522,
+		LastID:             173490102,
+		Count:              707576,
+	}
+	s.assertPriceChangeStatsEqual(e, stats[0])
+}
+
+func (s *tickerServiceTestSuite) TestPriceChangeStatsWithPair() {
+	data := []byte(`[
+		{
+			"symbol": "BTCUSD_210924",
+			"pair": "BTCUSD",
+			"priceChange": "-906.4",
+			"priceChangePercent": "-2.204",
+			"weightedAvgPrice": "41226.29913486",
+			"lastPrice": "40221.8",
+			"lastQty": "125",
+			"openPrice": "41128.2",
+			"highPrice": "42532.8",
+			"lowPrice": "40052.0",
+			"volume": "3421917",
+			"baseVolume": "8300.32545198",
+			"openTime": 1623755580000,
+			"closeTime": 1623842010140,
+			"firstId": 7516015,
+			"lastId": 7591268,
+			"count": 75254
+		},
+		{
+			"symbol": "BTCUSD_210625",
+			"pair": "BTCUSD",
+			"priceChange": "-781.7",
+			"priceChangePercent": "-1.948",
+			"weightedAvgPrice": "40179.25736363",
+			"lastPrice": "39337.4",
+			"lastQty": "1",
+			"openPrice": "40119.1",
+			"highPrice": "41405.7",
+			"lowPrice": "39153.8",
+			"volume": "5479601",
+			"baseVolume": "13637.88521626",
+			"openTime": 1623755580000,
+			"closeTime": 1623842010656,
+			"firstId": 32157829,
+			"lastId": 32307537,
+			"count": 149709
+		}
+	]`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	pair := "BTCUSD"
+	s.assertReq(func(r *request) {
+		e := newRequest().setParam("pair", pair)
+		s.assertRequestEqual(e, r)
+	})
+	stats, err := s.client.NewListPriceChangeStatsService().Pair(pair).Do(newContext())
+	r := s.r()
+	r.NoError(err)
+	r.Len(stats, 2)
+	e1 := &PriceChangeStats{
+		Symbol:             "BTCUSD_210924",
+		Pair:               "BTCUSD",
+		PriceChange:        "-906.4",
+		PriceChangePercent: "-2.204",
+		WeightedAvgPrice:   "41226.29913486",
+		LastPrice:          "40221.8",
+		LastQuantity:       "125",
+		OpenPrice:          "41128.2",
+		HighPrice:          "42532.8",
+		LowPrice:           "40052.0",
+		Volume:             "3421917",
+		BaseVolume:         "8300.32545198",
+		OpenTime:           1623755580000,
+		CloseTime:          1623842010140,
+		FristID:            7516015,
+		LastID:             7591268,
+		Count:              75254,
+	}
+	e2 := &PriceChangeStats{
+		Symbol:             "BTCUSD_210625",
+		Pair:               "BTCUSD",
+		PriceChange:        "-781.7",
+		PriceChangePercent: "-1.948",
+		WeightedAvgPrice:   "40179.25736363",
+		LastPrice:          "39337.4",
+		LastQuantity:       "1",
+		OpenPrice:          "40119.1",
+		HighPrice:          "41405.7",
+		LowPrice:           "39153.8",
+		Volume:             "5479601",
+		BaseVolume:         "13637.88521626",
+		OpenTime:           1623755580000,
+		CloseTime:          1623842010656,
+		FristID:            32157829,
+		LastID:             32307537,
+		Count:              149709,
+	}
+	s.assertPriceChangeStatsEqual(e1, stats[0])
+	s.assertPriceChangeStatsEqual(e2, stats[1])
+}
+
+func (s *tickerServiceTestSuite) assertPriceChangeStatsEqual(e, a *PriceChangeStats) {
+	r := s.r()
+	r.Equal(e.Symbol, a.Symbol, "Symbol")
+	r.Equal(e.Pair, a.Pair, "Pair")
+	r.Equal(e.PriceChange, a.PriceChange, "PriceChange")
+	r.Equal(e.PriceChangePercent, a.PriceChangePercent, "PriceChangePercent")
+	r.Equal(e.WeightedAvgPrice, a.WeightedAvgPrice, "WeightedAvgPrice")
+	r.Equal(e.LastPrice, a.LastPrice, "LastPrice")
+	r.Equal(e.LastQuantity, a.LastQuantity, "LastQuantity")
+	r.Equal(e.OpenPrice, a.OpenPrice, "OpenPrice")
+	r.Equal(e.HighPrice, a.HighPrice, "HighPrice")
+	r.Equal(e.LowPrice, a.LowPrice, "LowPrice")
+	r.Equal(e.Volume, a.Volume, "Volume")
+	r.Equal(e.BaseVolume, a.BaseVolume, "BaseVolume")
+	r.Equal(e.OpenTime, a.OpenTime, "OpenTime")
+	r.Equal(e.CloseTime, a.CloseTime, "CloseTime")
+	r.Equal(e.FristID, a.FristID, "FristID")
+	r.Equal(e.LastID, a.LastID, "LastID")
+	r.Equal(e.Count, a.Count, "Count")
+}


### PR DESCRIPTION
Add support for endpoints:
- `/dapi/v1/ticker/24hr`
- `/dapi/v1/ticker/price`
- `/dapi/v1/ticker/bookTicker`

Binance Delivery API forbits `pair` and `symbol` parameter to be sent together. So I am not sure if this should be handled at the SDK level or just let the API return an error.