### PR TITLE
Symbol.symbols.settlePlan should be int64

### DIFF
--- a/v2/futures/exchange_info_service.go
+++ b/v2/futures/exchange_info_service.go
@@ -63,7 +63,7 @@ type Symbol struct {
 	QuotePrecision        int                      `json:"quotePrecision"`
 	UnderlyingType        string                   `json:"underlyingType"`
 	UnderlyingSubType     []string                 `json:"underlyingSubType"`
-	SettlePlan            int                      `json:"settlePlan"`
+	SettlePlan            int64                    `json:"settlePlan"`
 	TriggerProtect        string                   `json:"triggerProtect"`
 	OrderType             []OrderType              `json:"OrderType"`
 	TimeInForce           []TimeInForceType        `json:"timeInForce"`


### PR DESCRIPTION
Fixes `json: cannot unmarshal number 1624608000000 into Go struct field Symbol.symbols.settlePlan of type int`