### PR TITLE
Feature/better delivery websocket

### DIFF
--- a/v2/delivery/client.go
+++ b/v2/delivery/client.go
@@ -33,6 +33,9 @@ type TimeInForceType string
 // NewOrderRespType define response JSON verbosity
 type NewOrderRespType string
 
+// OrderExecutionType define order execution type
+type OrderExecutionType string
+
 // OrderStatusType define order status type
 type OrderStatusType string
 
@@ -53,6 +56,12 @@ type WorkingType string
 
 // MarginType define margin type
 type MarginType string
+
+// UserDataEventType define user data event type
+type UserDataEventType string
+
+// UserDataEventReasonType define reason type for user data event
+type UserDataEventReasonType string
 
 // Endpoints
 const (
@@ -86,6 +95,14 @@ const (
 	NewOrderRespTypeRESULT NewOrderRespType = "RESULT"
 	NewOrderRespTypeFULL   NewOrderRespType = "FULL"
 
+	OrderExecutionTypeNew         OrderExecutionType = "NEW"
+	OrderExecutionTypePartialFill OrderExecutionType = "PARTIAL_FILL"
+	OrderExecutionTypeFill        OrderExecutionType = "FILL"
+	OrderExecutionTypeCanceled    OrderExecutionType = "CANCELED"
+	OrderExecutionTypeCalculated  OrderExecutionType = "CALCULATED"
+	OrderExecutionTypeExpired     OrderExecutionType = "EXPIRED"
+	OrderExecutionTypeTrade       OrderExecutionType = "TRADE"
+
 	OrderStatusTypeNew             OrderStatusType = "NEW"
 	OrderStatusTypePartiallyFilled OrderStatusType = "PARTIALLY_FILLED"
 	OrderStatusTypeFilled          OrderStatusType = "FILLED"
@@ -118,6 +135,27 @@ const (
 
 	MarginTypeIsolated MarginType = "ISOLATED"
 	MarginTypeCrossed  MarginType = "CROSSED"
+
+	UserDataEventTypeListenKeyExpired    UserDataEventType = "listenKeyExpired"
+	UserDataEventTypeMarginCall          UserDataEventType = "MARGIN_CALL"
+	UserDataEventTypeAccountUpdate       UserDataEventType = "ACCOUNT_UPDATE"
+	UserDataEventTypeOrderTradeUpdate    UserDataEventType = "ORDER_TRADE_UPDATE"
+	UserDataEventTypeAccountConfigUpdate UserDataEventType = "ACCOUNT_CONFIG_UPDATE"
+
+	UserDataEventReasonTypeDeposit             UserDataEventReasonType = "DEPOSIT"
+	UserDataEventReasonTypeWithdraw            UserDataEventReasonType = "WITHDRAW"
+	UserDataEventReasonTypeOrder               UserDataEventReasonType = "ORDER"
+	UserDataEventReasonTypeFundingFee          UserDataEventReasonType = "FUNDING_FEE"
+	UserDataEventReasonTypeWithdrawReject      UserDataEventReasonType = "WITHDRAW_REJECT"
+	UserDataEventReasonTypeAdjustment          UserDataEventReasonType = "ADJUSTMENT"
+	UserDataEventReasonTypeInsuranceClear      UserDataEventReasonType = "INSURANCE_CLEAR"
+	UserDataEventReasonTypeAdminDeposit        UserDataEventReasonType = "ADMIN_DEPOSIT"
+	UserDataEventReasonTypeAdminWithdraw       UserDataEventReasonType = "ADMIN_WITHDRAW"
+	UserDataEventReasonTypeMarginTransfer      UserDataEventReasonType = "MARGIN_TRANSFER"
+	UserDataEventReasonTypeMarginTypeChange    UserDataEventReasonType = "MARGIN_TYPE_CHANGE"
+	UserDataEventReasonTypeAssetTransfer       UserDataEventReasonType = "ASSET_TRANSFER"
+	UserDataEventReasonTypeOptionsPremiumFee   UserDataEventReasonType = "OPTIONS_PREMIUM_FEE"
+	UserDataEventReasonTypeOptionsSettleProfit UserDataEventReasonType = "OPTIONS_SETTLE_PROFIT"
 
 	timestampKey  = "timestamp"
 	signatureKey  = "signature"

--- a/v2/delivery/websocket_service.go
+++ b/v2/delivery/websocket_service.go
@@ -639,6 +639,7 @@ type WsBalance struct {
 	Asset              string `json:"a"`
 	Balance            string `json:"wb"`
 	CrossWalletBalance string `json:"cw"`
+	BalanceChange      string `json:"bc"`
 }
 
 // WsPosition define position
@@ -672,10 +673,12 @@ type WsOrderTradeUpdate struct {
 	LastFilledQty        string             `json:"l"`
 	AccumulatedFilledQty string             `json:"z"`
 	LastFilledPrice      string             `json:"L"`
+	MarginAsset          string             `json:"ma"`
 	CommissionAsset      string             `json:"N"`
 	Commission           string             `json:"n"`
 	TradeTime            int64              `json:"T"`
 	TradeID              int64              `json:"t"`
+	RealizedPnL          string             `json:"rp"`
 	BidsNotional         string             `json:"b"`
 	AsksNotional         string             `json:"a"`
 	IsMaker              bool               `json:"m"`
@@ -686,7 +689,7 @@ type WsOrderTradeUpdate struct {
 	IsClosingPosition    bool               `json:"cp"`
 	ActivationPrice      string             `json:"AP"`
 	CallbackRate         string             `json:"cr"`
-	RealizedPnL          string             `json:"rp"`
+	IsProtected          bool               `json:"pP"`
 }
 
 // WsAccountConfigUpdate define account config update

--- a/v2/delivery/websocket_service.go
+++ b/v2/delivery/websocket_service.go
@@ -30,13 +30,6 @@ func getWsEndpoint() string {
 	return baseWsMainUrl
 }
 
-// WsUserDataServe serve user data handler with listen key
-func WsUserDataServe(listenKey string, handler WsHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
-	endpoint := fmt.Sprintf("%s/%s", getWsEndpoint(), listenKey)
-	cfg := newWsConfig(endpoint)
-	return wsServe(cfg, handler, errHandler)
-}
-
 // WsAggTradeEvent define websocket aggTrde event.
 type WsAggTradeEvent struct {
 	Event            string `json:"e"`
@@ -616,6 +609,105 @@ func wsDepthServe(cfg *WsConfig, handler WsDepthHandler, errHandler ErrHandler) 
 				Price:    item.GetIndex(0).MustString(),
 				Quantity: item.GetIndex(1).MustString(),
 			}
+		}
+		handler(event)
+	}
+	return wsServe(cfg, wsHandler, errHandler)
+}
+
+// WsUserDataEvent define user data event
+type WsUserDataEvent struct {
+	Event               UserDataEventType  `json:"e"`
+	Time                int64              `json:"E"`
+	Alias               string             `json:"i"`
+	CrossWalletBalance  string             `json:"cw"`
+	MarginCallPositions []WsPosition       `json:"p"`
+	TransactionTime     int64              `json:"T"`
+	AccountUpdate       WsAccountUpdate    `json:"a"`
+	OrderTradeUpdate    WsOrderTradeUpdate `json:"o"`
+}
+
+// WsAccountUpdate define account update
+type WsAccountUpdate struct {
+	Reason    UserDataEventReasonType `json:"m"`
+	Balances  []WsBalance             `json:"B"`
+	Positions []WsPosition            `json:"P"`
+}
+
+// WsBalance define balance
+type WsBalance struct {
+	Asset              string `json:"a"`
+	Balance            string `json:"wb"`
+	CrossWalletBalance string `json:"cw"`
+}
+
+// WsPosition define position
+type WsPosition struct {
+	Symbol                    string           `json:"s"`
+	Side                      PositionSideType `json:"ps"`
+	Amount                    string           `json:"pa"`
+	MarginType                MarginType       `json:"mt"`
+	IsolatedWallet            string           `json:"iw"`
+	EntryPrice                string           `json:"ep"`
+	MarkPrice                 string           `json:"mp"`
+	UnrealizedPnL             string           `json:"up"`
+	AccumulatedRealized       string           `json:"cr"`
+	MaintenanceMarginRequired string           `json:"mm"`
+}
+
+// WsOrderTradeUpdate define order trade update
+type WsOrderTradeUpdate struct {
+	Symbol               string             `json:"s"`
+	ClientOrderID        string             `json:"c"`
+	Side                 SideType           `json:"S"`
+	Type                 OrderType          `json:"o"`
+	TimeInForce          TimeInForceType    `json:"f"`
+	OriginalQty          string             `json:"q"`
+	OriginalPrice        string             `json:"p"`
+	AveragePrice         string             `json:"ap"`
+	StopPrice            string             `json:"sp"`
+	ExecutionType        OrderExecutionType `json:"x"`
+	Status               OrderStatusType    `json:"X"`
+	ID                   int64              `json:"i"`
+	LastFilledQty        string             `json:"l"`
+	AccumulatedFilledQty string             `json:"z"`
+	LastFilledPrice      string             `json:"L"`
+	CommissionAsset      string             `json:"N"`
+	Commission           string             `json:"n"`
+	TradeTime            int64              `json:"T"`
+	TradeID              int64              `json:"t"`
+	BidsNotional         string             `json:"b"`
+	AsksNotional         string             `json:"a"`
+	IsMaker              bool               `json:"m"`
+	IsReduceOnly         bool               `json:"R"`
+	WorkingType          WorkingType        `json:"wt"`
+	OriginalType         OrderType          `json:"ot"`
+	PositionSide         PositionSideType   `json:"ps"`
+	IsClosingPosition    bool               `json:"cp"`
+	ActivationPrice      string             `json:"AP"`
+	CallbackRate         string             `json:"cr"`
+	RealizedPnL          string             `json:"rp"`
+}
+
+// WsAccountConfigUpdate define account config update
+type WsAccountConfigUpdate struct {
+	Symbol   string `json:"s"`
+	Leverage int64  `json:"l"`
+}
+
+// WsUserDataHandler handle WsUserDataEvent
+type WsUserDataHandler func(event *WsUserDataEvent)
+
+// WsUserDataServe serve user data handler with listen key
+func WsUserDataServe(listenKey string, handler WsUserDataHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	endpoint := fmt.Sprintf("%s/%s", getWsEndpoint(), listenKey)
+	cfg := newWsConfig(endpoint)
+	wsHandler := func(message []byte) {
+		event := new(WsUserDataEvent)
+		err := json.Unmarshal(message, event)
+		if err != nil {
+			errHandler(err)
+			return
 		}
 		handler(event)
 	}

--- a/v2/delivery/websocket_service_test.go
+++ b/v2/delivery/websocket_service_test.go
@@ -1167,41 +1167,6 @@ func (s *websocketServiceTestSuite) assertDepthEvent(e, a *WsDepthEvent) {
 	}
 }
 
-// func (s *websocketServiceTestSuite) testWsUserDataServe(data []byte) {
-// 	fakeErrMsg := "fake error"
-// 	s.mockWsServe(data, errors.New(fakeErrMsg))
-// 	defer s.assertWsServe()
-
-// 	doneC, stopC, err := WsUserDataServe("listenKey", func(event *WsUserDataEvent) {
-// 		s.r().Equal(data, event)
-// 	}, func(err error) {
-// 		s.r().EqualError(err, fakeErrMsg)
-// 	})
-// 	s.r().NoError(err)
-// 	stopC <- struct{}{}
-// 	<-doneC
-// }
-
-// // https://binance-docs.github.io/apidocs/delivery/en/#event-margin-call
-// func (s *websocketServiceTestSuite) TestWsUserDataServe() {
-// 	s.testWsUserDataServe([]byte(`{
-// 	  "e":"MARGIN_CALL",
-// 	  "E":1587727187525,
-// 	  "i": "SfsR",
-// 	  "cw":"3.16812045",
-// 	  "p":[{
-// 	    "s":"BTCUSD_200925",
-// 	    "ps":"LONG",
-// 	    "pa":"132",
-// 	    "mt":"CROSSED",
-// 	    "iw":"0",
-// 	    "mp":"9187.17127000",
-// 	    "up":"-1.166074",
-// 	    "mm":"1.614445"
-// 	  }]
-//     }`))
-// }
-
 func (s *websocketServiceTestSuite) testWsUserDataServe(data []byte, expectedEvent *WsUserDataEvent) {
 	fakeErrMsg := "fake error"
 	s.mockWsServe(data, errors.New(fakeErrMsg))

--- a/v2/delivery/websocket_service_test.go
+++ b/v2/delivery/websocket_service_test.go
@@ -1308,7 +1308,7 @@ func (s *websocketServiceTestSuite) TestWsUserDataServeAccountUpdate() {
 				  "pa":"20",
 				  "ep":"6563.6",
 				  "cr":"0",
-				  "up":"2850.21200",
+				  "up":"2850.21200000",
 				  "mt":"isolated",
 				  "iw":"13200.70726908",
 				  "ps":"LONG"
@@ -1318,7 +1318,7 @@ func (s *websocketServiceTestSuite) TestWsUserDataServeAccountUpdate() {
 				  "pa":"-10",
 				  "ep":"6563.8",
 				  "cr":"-45.04000000",
-				  "up":"-1423.15600",
+				  "up":"-1423.15600000",
 				  "mt":"isolated",
 				  "iw":"6570.42511771",
 				  "ps":"SHORT"
@@ -1330,6 +1330,7 @@ func (s *websocketServiceTestSuite) TestWsUserDataServeAccountUpdate() {
 		Event:           "ACCOUNT_UPDATE",
 		Time:            1564745798939,
 		TransactionTime: 1564745798938,
+		Alias:           "SfsR",
 		AccountUpdate: WsAccountUpdate{
 			Reason: "ORDER",
 			Balances: []WsBalance{
@@ -1372,7 +1373,7 @@ func (s *websocketServiceTestSuite) TestWsUserDataServeAccountUpdate() {
 					Amount:              "-10",
 					EntryPrice:          "6563.8",
 					AccumulatedRealized: "-45.04000000",
-					UnrealizedPnL:       "-1423.15600",
+					UnrealizedPnL:       "-1423.15600000",
 					MarginType:          "isolated",
 					IsolatedWallet:      "6570.42511771",
 					Side:                "SHORT",

--- a/v2/delivery/websocket_service_test.go
+++ b/v2/delivery/websocket_service_test.go
@@ -51,41 +51,6 @@ func (s *websocketServiceTestSuite) assertWsServe(count ...int) {
 	s.r().Equal(e, s.serveCount)
 }
 
-func (s *websocketServiceTestSuite) testWsUserDataServe(data []byte) {
-	fakeErrMsg := "fake error"
-	s.mockWsServe(data, errors.New(fakeErrMsg))
-	defer s.assertWsServe()
-
-	doneC, stopC, err := WsUserDataServe("listenKey", func(event []byte) {
-		s.r().Equal(data, event)
-	}, func(err error) {
-		s.r().EqualError(err, fakeErrMsg)
-	})
-	s.r().NoError(err)
-	stopC <- struct{}{}
-	<-doneC
-}
-
-// https://binance-docs.github.io/apidocs/delivery/en/#event-margin-call
-func (s *websocketServiceTestSuite) TestWsUserDataServe() {
-	s.testWsUserDataServe([]byte(`{
-	  "e":"MARGIN_CALL",     
-	  "E":1587727187525,     
-	  "i": "SfsR",           
-	  "cw":"3.16812045",     
-	  "p":[{
-	    "s":"BTCUSD_200925",   
-	    "ps":"LONG",       
-	    "pa":"132",        
-	    "mt":"CROSSED",    
-	    "iw":"0",          
-	    "mp":"9187.17127000",  
-	    "up":"-1.166074",  
-	    "mm":"1.614445"    
-	  }]
-    }`))
-}
-
 // https://binance-docs.github.io/apidocs/delivery/en/#aggregate-trade-streams
 func (s *websocketServiceTestSuite) TestAggTradeServe() {
 	data := []byte(`{
@@ -1200,4 +1165,381 @@ func (s *websocketServiceTestSuite) assertDepthEvent(e, a *WsDepthEvent) {
 		r.Equal(b.Price, a.Asks[i].Price, "Price")
 		r.Equal(b.Quantity, a.Asks[i].Quantity, "Quantity")
 	}
+}
+
+// func (s *websocketServiceTestSuite) testWsUserDataServe(data []byte) {
+// 	fakeErrMsg := "fake error"
+// 	s.mockWsServe(data, errors.New(fakeErrMsg))
+// 	defer s.assertWsServe()
+
+// 	doneC, stopC, err := WsUserDataServe("listenKey", func(event *WsUserDataEvent) {
+// 		s.r().Equal(data, event)
+// 	}, func(err error) {
+// 		s.r().EqualError(err, fakeErrMsg)
+// 	})
+// 	s.r().NoError(err)
+// 	stopC <- struct{}{}
+// 	<-doneC
+// }
+
+// // https://binance-docs.github.io/apidocs/delivery/en/#event-margin-call
+// func (s *websocketServiceTestSuite) TestWsUserDataServe() {
+// 	s.testWsUserDataServe([]byte(`{
+// 	  "e":"MARGIN_CALL",
+// 	  "E":1587727187525,
+// 	  "i": "SfsR",
+// 	  "cw":"3.16812045",
+// 	  "p":[{
+// 	    "s":"BTCUSD_200925",
+// 	    "ps":"LONG",
+// 	    "pa":"132",
+// 	    "mt":"CROSSED",
+// 	    "iw":"0",
+// 	    "mp":"9187.17127000",
+// 	    "up":"-1.166074",
+// 	    "mm":"1.614445"
+// 	  }]
+//     }`))
+// }
+
+func (s *websocketServiceTestSuite) testWsUserDataServe(data []byte, expectedEvent *WsUserDataEvent) {
+	fakeErrMsg := "fake error"
+	s.mockWsServe(data, errors.New(fakeErrMsg))
+	defer s.assertWsServe()
+
+	doneC, stopC, err := WsUserDataServe("fakeListenKey", func(event *WsUserDataEvent) {
+		s.assertUserDataEvent(expectedEvent, event)
+	},
+		func(err error) {
+			s.r().EqualError(err, fakeErrMsg)
+		})
+
+	s.r().NoError(err)
+	stopC <- struct{}{}
+	<-doneC
+}
+
+func (s *websocketServiceTestSuite) TestWsUserDataServeStreamExpired() {
+	data := []byte(`{
+		"e": "listenKeyExpired",
+		"E": 1576653824250
+	}`)
+	expectedEvent := &WsUserDataEvent{
+		Event: "listenKeyExpired",
+		Time:  1576653824250,
+	}
+	s.testWsUserDataServe(data, expectedEvent)
+}
+
+func (s *websocketServiceTestSuite) TestWsUserDataServeMarginCall() {
+	data := []byte(`{
+	  "e":"MARGIN_CALL",
+	  "E":1587727187525,
+	  "i": "SfsR",
+	  "cw":"3.16812045",
+	  "p":[{
+	    "s":"BTCUSD_200925",
+	    "ps":"LONG",
+	    "pa":"132",
+	    "mt":"CROSSED",
+	    "iw":"0",
+	    "mp":"9187.17127000",
+	    "up":"-1.166074",
+	    "mm":"1.614445"
+	  }]
+    }`)
+	expectedEvent := &WsUserDataEvent{
+		Event:              "MARGIN_CALL",
+		Time:               1587727187525,
+		Alias:              "SfsR",
+		CrossWalletBalance: "3.16812045",
+		MarginCallPositions: []WsPosition{
+			{
+				Symbol:                    "BTCUSD_200925",
+				Side:                      "LONG",
+				Amount:                    "132",
+				MarginType:                "CROSSED",
+				IsolatedWallet:            "0",
+				MarkPrice:                 "9187.17127000",
+				UnrealizedPnL:             "-1.166074",
+				MaintenanceMarginRequired: "1.614445",
+			},
+		},
+	}
+	s.testWsUserDataServe(data, expectedEvent)
+}
+
+func (s *websocketServiceTestSuite) TestWsUserDataServeAccountUpdate() {
+	data := []byte(`{
+		"e": "ACCOUNT_UPDATE",
+		"E": 1564745798939,
+		"T": 1564745798938,
+		"i": "SfsR",
+		"a":
+		  {
+			"m":"ORDER",
+			"B":[
+			  {
+				"a":"BTC",
+				"wb":"122624.12345678",
+				"cw":"100.12345678",
+				"bc":"50.12345678"
+			  },
+			  {
+				"a":"ETH",           
+				"wb":"1.00000000",
+				"cw":"0.00000000",
+				"bc":"-49.12345678"
+			}
+			],
+			"P":[
+			  {
+				"s":"BTCUSD_200925",
+				"pa":"0",
+				"ep":"0.00000",
+				"cr":"200",
+				"up":"0",
+				"mt":"isolated",
+				"iw":"0.00000000",
+				"ps":"BOTH"
+			  },
+			  {
+				  "s":"BTCUSD_200925",
+				  "pa":"20",
+				  "ep":"6563.6",
+				  "cr":"0",
+				  "up":"2850.21200",
+				  "mt":"isolated",
+				  "iw":"13200.70726908",
+				  "ps":"LONG"
+			   },
+			  {
+				  "s":"BTCUSD_200925",
+				  "pa":"-10",
+				  "ep":"6563.8",
+				  "cr":"-45.04000000",
+				  "up":"-1423.15600",
+				  "mt":"isolated",
+				  "iw":"6570.42511771",
+				  "ps":"SHORT"
+			  }
+			]
+		  }
+	}`)
+	expectedEvent := &WsUserDataEvent{
+		Event:           "ACCOUNT_UPDATE",
+		Time:            1564745798939,
+		TransactionTime: 1564745798938,
+		AccountUpdate: WsAccountUpdate{
+			Reason: "ORDER",
+			Balances: []WsBalance{
+				{
+					Asset:              "BTC",
+					Balance:            "122624.12345678",
+					CrossWalletBalance: "100.12345678",
+					BalanceChange:      "50.12345678",
+				},
+				{
+					Asset:              "ETH",
+					Balance:            "1.00000000",
+					CrossWalletBalance: "0.00000000",
+					BalanceChange:      "-49.12345678",
+				},
+			},
+			Positions: []WsPosition{
+				{
+					Symbol:              "BTCUSD_200925",
+					Amount:              "0",
+					EntryPrice:          "0.00000",
+					AccumulatedRealized: "200",
+					UnrealizedPnL:       "0",
+					MarginType:          "isolated",
+					IsolatedWallet:      "0.00000000",
+					Side:                "BOTH",
+				},
+				{
+					Symbol:              "BTCUSD_200925",
+					Amount:              "20",
+					EntryPrice:          "6563.6",
+					AccumulatedRealized: "0",
+					UnrealizedPnL:       "2850.21200000",
+					MarginType:          "isolated",
+					IsolatedWallet:      "13200.70726908",
+					Side:                "LONG",
+				},
+				{
+					Symbol:              "BTCUSD_200925",
+					Amount:              "-10",
+					EntryPrice:          "6563.8",
+					AccumulatedRealized: "-45.04000000",
+					UnrealizedPnL:       "-1423.15600",
+					MarginType:          "isolated",
+					IsolatedWallet:      "6570.42511771",
+					Side:                "SHORT",
+				},
+			},
+		},
+	}
+	s.testWsUserDataServe(data, expectedEvent)
+}
+
+func (s *websocketServiceTestSuite) TestWsUserDataServeOrderTradeUpdate() {
+	data := []byte(`{
+		"e":"ORDER_TRADE_UPDATE",
+		"E":1568879465651,
+		"T":1568879465650,
+		"i": "SfsR",
+		"o":{
+		  "s":"BTCUSD_200925",
+		  "c":"TEST",
+		  "S":"SELL",
+		  "o":"TRAILING_STOP_MARKET",
+		  "f":"GTC",
+		  "q":"2",
+		  "p":"0",
+		  "ap":"0",
+		  "sp":"9103.1",
+		  "x":"NEW",
+		  "X":"NEW",
+		  "i":8888888,
+		  "l":"0",
+		  "z":"0",
+		  "L":"0",
+		  "ma": "BTC",
+		  "N":"BTC",
+		  "n":"0",
+		  "T":1591274595442,
+		  "t":0,
+		  "rp": "0",
+		  "b":"0",
+		  "a":"0",
+		  "m":false,
+		  "R":false,
+		  "wt":"CONTRACT_PRICE",
+		  "ot":"TRAILING_STOP_MARKET",
+		  "ps":"LONG",
+		  "cp":false,
+		  "AP":"9476.8",
+		  "cr":"5.0",
+		  "pP": false
+		}
+	}`)
+	expectedEvent := &WsUserDataEvent{
+		Event:           "ORDER_TRADE_UPDATE",
+		Time:            1568879465651,
+		TransactionTime: 1568879465650,
+		Alias:           "SfsR",
+		OrderTradeUpdate: WsOrderTradeUpdate{
+			Symbol:               "BTCUSD_200925",
+			ClientOrderID:        "TEST",
+			Side:                 "SELL",
+			Type:                 "TRAILING_STOP_MARKET",
+			TimeInForce:          "GTC",
+			OriginalQty:          "2",
+			OriginalPrice:        "0",
+			AveragePrice:         "0",
+			StopPrice:            "9103.1",
+			ExecutionType:        "NEW",
+			Status:               "NEW",
+			ID:                   8888888,
+			LastFilledQty:        "0",
+			AccumulatedFilledQty: "0",
+			LastFilledPrice:      "0",
+			MarginAsset:          "BTC",
+			CommissionAsset:      "BTC",
+			Commission:           "0",
+			TradeTime:            1591274595442,
+			TradeID:              0,
+			RealizedPnL:          "0",
+			BidsNotional:         "0",
+			AsksNotional:         "0",
+			IsMaker:              false,
+			IsReduceOnly:         false,
+			WorkingType:          "CONTRACT_PRICE",
+			OriginalType:         "TRAILING_STOP_MARKET",
+			PositionSide:         "LONG",
+			IsClosingPosition:    false,
+			ActivationPrice:      "9476.8",
+			CallbackRate:         "5.0",
+			IsProtected:          false,
+		},
+	}
+	s.testWsUserDataServe(data, expectedEvent)
+}
+
+func (s *websocketServiceTestSuite) assertUserDataEvent(e, a *WsUserDataEvent) {
+	r := s.r()
+	r.Equal(e.Event, a.Event, "Event")
+	r.Equal(e.Time, a.Time, "Time")
+	r.Equal(e.CrossWalletBalance, a.CrossWalletBalance, "CrossWalletBalance")
+	for i, e := range e.MarginCallPositions {
+		a := a.MarginCallPositions[i]
+		s.assertPosition(e, a)
+	}
+	r.Equal(e.TransactionTime, a.TransactionTime, "TransactionTime")
+	s.assertAccountUpdate(e.AccountUpdate, a.AccountUpdate)
+	s.assertOrderTradeUpdate(e.OrderTradeUpdate, a.OrderTradeUpdate)
+}
+
+func (s *websocketServiceTestSuite) assertPosition(e, a WsPosition) {
+	r := s.r()
+	r.Equal(e.Symbol, a.Symbol, "Symbol")
+	r.Equal(e.Side, a.Side, "Side")
+	r.Equal(e.Amount, a.Amount, "Amount")
+	r.Equal(e.MarginType, a.MarginType, "MarginType")
+	r.Equal(e.IsolatedWallet, a.IsolatedWallet, "IsolatedWallet")
+	r.Equal(e.EntryPrice, a.EntryPrice, "EntryPrice")
+	r.Equal(e.MarkPrice, a.MarkPrice, "MarkPrice")
+	r.Equal(e.UnrealizedPnL, a.UnrealizedPnL, "UnrealizedPnL")
+	r.Equal(e.AccumulatedRealized, a.AccumulatedRealized, "AccumulatedRealized")
+	r.Equal(e.MaintenanceMarginRequired, a.MaintenanceMarginRequired, "MaintenanceMarginRequired")
+}
+
+func (s *websocketServiceTestSuite) assertAccountUpdate(e, a WsAccountUpdate) {
+	r := s.r()
+	r.Equal(e.Reason, a.Reason, "Reason")
+	for i, e := range e.Balances {
+		a := a.Balances[i]
+		r.Equal(e.Asset, a.Asset, "Asset")
+		r.Equal(e.Balance, a.Balance, "Balance")
+		r.Equal(e.CrossWalletBalance, a.CrossWalletBalance, "CrossWalletBalance")
+	}
+	for i, e := range e.Positions {
+		a := a.Positions[i]
+		s.assertPosition(e, a)
+	}
+}
+
+func (s *websocketServiceTestSuite) assertOrderTradeUpdate(e, a WsOrderTradeUpdate) {
+	r := s.r()
+	r.Equal(e.Symbol, a.Symbol, "Symbol")
+	r.Equal(e.ClientOrderID, a.ClientOrderID, "ClientOrderID")
+	r.Equal(e.Side, a.Side, "Side")
+	r.Equal(e.Type, a.Type, "Type")
+	r.Equal(e.TimeInForce, a.TimeInForce, "TimeInForce")
+	r.Equal(e.OriginalQty, a.OriginalQty, "OriginalQty")
+	r.Equal(e.OriginalPrice, a.OriginalPrice, "OriginalPrice")
+	r.Equal(e.AveragePrice, a.AveragePrice, "AveragePrice")
+	r.Equal(e.StopPrice, a.StopPrice, "StopPrice")
+	r.Equal(e.ExecutionType, a.ExecutionType, "ExecutionType")
+	r.Equal(e.Status, a.Status, "Status")
+	r.Equal(e.ID, a.ID, "ID")
+	r.Equal(e.LastFilledQty, a.LastFilledQty, "LastFilledQty")
+	r.Equal(e.AccumulatedFilledQty, a.AccumulatedFilledQty, "AccumulatedFilledQty")
+	r.Equal(e.LastFilledPrice, a.LastFilledPrice, "LastFilledPrice")
+	r.Equal(e.CommissionAsset, a.CommissionAsset, "CommissionAsset")
+	r.Equal(e.Commission, a.Commission, "Commission")
+	r.Equal(e.TradeTime, a.TradeTime, "TradeTime")
+	r.Equal(e.TradeID, a.TradeID, "TradeID")
+	r.Equal(e.BidsNotional, a.BidsNotional, "BidsNotional")
+	r.Equal(e.AsksNotional, a.AsksNotional, "AsksNotional")
+	r.Equal(e.IsMaker, a.IsMaker, "IsMaker")
+	r.Equal(e.IsReduceOnly, a.IsReduceOnly, "IsReduceOnly")
+	r.Equal(e.WorkingType, a.WorkingType, "WorkingType")
+	r.Equal(e.OriginalType, a.OriginalType, "OriginalType")
+	r.Equal(e.PositionSide, a.PositionSide, "PositionSide")
+	r.Equal(e.IsClosingPosition, a.IsClosingPosition, "IsClosingPosition")
+	r.Equal(e.ActivationPrice, a.ActivationPrice, "ActivationPrice")
+	r.Equal(e.CallbackRate, a.CallbackRate, "CallbackRate")
+	r.Equal(e.RealizedPnL, a.RealizedPnL, "RealizedPnL")
 }


### PR DESCRIPTION
Different API for Futures and Delivery API led to dirty code in my project. This PR makes Futures and Delivery API consistent in websocket_service.go, new tests also added.