### PR TITLE
[Savings] Add services to list Flexible and Fixed products

### DIFF
--- a/v2/client.go
+++ b/v2/client.go
@@ -433,6 +433,11 @@ func (c *Client) NewPurchaseSavingsFlexibleProductService() *PurchaseSavingsFlex
 	return &PurchaseSavingsFlexibleProductService{c: c}
 }
 
+// NewRedeemSavingsFlexibleProductService redeem a flexible product (Savings)
+func (c *Client) NewRedeemSavingsFlexibleProductService() *RedeemSavingsFlexibleProductService {
+	return &RedeemSavingsFlexibleProductService{c: c}
+}
+
 // NewListSavingsFixedAndActivityProductsService get fixed and activity product list (Savings)
 func (c *Client) NewListSavingsFixedAndActivityProductsService() *ListSavingsFixedAndActivityProductsService {
 	return &ListSavingsFixedAndActivityProductsService{c: c}

--- a/v2/client.go
+++ b/v2/client.go
@@ -428,6 +428,11 @@ func (c *Client) NewListSavingsFlexibleProductsService() *ListSavingsFlexiblePro
 	return &ListSavingsFlexibleProductsService{c: c}
 }
 
+// NewPurchaseSavingsFlexibleProductService purchase a flexible product (Savings)
+func (c *Client) NewPurchaseSavingsFlexibleProductService() *PurchaseSavingsFlexibleProductService {
+	return &PurchaseSavingsFlexibleProductService{c: c}
+}
+
 // NewListSavingsFixedAndActivityProductsService get fixed and activity product list (Savings)
 func (c *Client) NewListSavingsFixedAndActivityProductsService() *ListSavingsFixedAndActivityProductsService {
 	return &ListSavingsFixedAndActivityProductsService{c: c}

--- a/v2/client.go
+++ b/v2/client.go
@@ -423,6 +423,16 @@ func (c *Client) NewGetAccountService() *GetAccountService {
 	return &GetAccountService{c: c}
 }
 
+// NewListSavingsFlexibleProductsService get flexible products list (Savings)
+func (c *Client) NewListSavingsFlexibleProductsService() *ListSavingsFlexibleProductsService {
+	return &ListSavingsFlexibleProductsService{c: c}
+}
+
+// NewListSavingsFixedAndActivityProductsService get fixed and activity product list (Savings)
+func (c *Client) NewListSavingsFixedAndActivityProductsService() *ListSavingsFixedAndActivityProductsService {
+	return &ListSavingsFixedAndActivityProductsService{c: c}
+}
+
 // NewGetAccountSnapshotService init getting account snapshot service
 func (c *Client) NewGetAccountSnapshotService() *GetAccountSnapshotService {
 	return &GetAccountSnapshotService{c: c}

--- a/v2/savings_service.go
+++ b/v2/savings_service.go
@@ -1,0 +1,192 @@
+package binance
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// ListSavingsFlexibleProductsService get
+type ListSavingsFlexibleProductsService struct {
+	c        *Client
+	status   string
+	featured string
+	current  int64
+	size     int64
+}
+
+func (s *ListSavingsFlexibleProductsService) Status(status string) *ListSavingsFlexibleProductsService {
+	s.status = status
+	return s
+}
+
+func (s *ListSavingsFlexibleProductsService) Featured(featured string) *ListSavingsFlexibleProductsService {
+	s.featured = featured
+	return s
+}
+
+func (s *ListSavingsFlexibleProductsService) Current(current int64) *ListSavingsFlexibleProductsService {
+	s.current = current
+	return s
+}
+
+func (s *ListSavingsFlexibleProductsService) Size(size int64) *ListSavingsFlexibleProductsService {
+	s.size = size
+	return s
+}
+
+// Do send request
+func (s *ListSavingsFlexibleProductsService) Do(ctx context.Context, opts ...RequestOption) ([]*SavingsFlexibleProduct, error) {
+	r := &request{
+		method:   "GET",
+		endpoint: "/sapi/v1/lending/daily/product/list",
+		secType:  secTypeSigned,
+	}
+	m := params{}
+	if s.status != "" {
+		m["status"] = s.status
+	}
+	if s.featured != "" {
+		m["featured"] = s.featured
+	}
+	if s.current != 0 {
+		m["current"] = s.current
+	}
+	if s.size != 0 {
+		m["size"] = s.size
+	}
+	r.setParams(m)
+	data, err := s.c.callAPI(ctx, r, opts...)
+	if err != nil {
+		return nil, err
+	}
+	var res []*SavingsFlexibleProduct
+	err = json.Unmarshal(data, &res)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+// SavingsFlexibleProduct define a flexible product (Savings)
+type SavingsFlexibleProduct struct {
+	Asset                    string `json:"asset"`
+	AvgAnnualInterestRate    string `json:"avgAnnualInterestRate"`
+	CanPurchase              bool   `json:"canPurchase"`
+	CanRedeem                bool   `json:"canRedeem"`
+	DailyInterestPerThousand string `json:"dailyInterestPerThousand"`
+	Featured                 bool   `json:"featured"`
+	MinPurchaseAmount        string `json:"minPurchaseAmount"`
+	ProductId                string `json:"productId"`
+	PurchasedAmount          string `json:"purchasedAmount"`
+	Status                   string `json:"status"`
+	UpLimit                  string `json:"upLimit"`
+	UpLimitPerUser           string `json:"upLimitPerUser"`
+}
+
+// ListSavingsFixedAndActivityProductsService https://binance-docs.github.io/apidocs/spot/en/#get-fixed-and-activity-project-list-user_data
+type ListSavingsFixedAndActivityProductsService struct {
+	c           *Client
+	asset       string
+	projectType string
+	status      string
+	isSortAsc   bool
+	sortBy      string
+	current     int64
+	size        int64
+}
+
+func (s *ListSavingsFixedAndActivityProductsService) Asset(asset string) *ListSavingsFixedAndActivityProductsService {
+	s.asset = asset
+	return s
+}
+
+func (s *ListSavingsFixedAndActivityProductsService) IsSortAsc(inSortAsc bool) *ListSavingsFixedAndActivityProductsService {
+	s.isSortAsc = inSortAsc
+	return s
+}
+
+func (s *ListSavingsFixedAndActivityProductsService) SortBy(sortBy string) *ListSavingsFixedAndActivityProductsService {
+	s.sortBy = sortBy
+	return s
+}
+
+func (s *ListSavingsFixedAndActivityProductsService) Current(current int64) *ListSavingsFixedAndActivityProductsService {
+	s.current = current
+	return s
+}
+
+func (s *ListSavingsFixedAndActivityProductsService) Size(size int64) *ListSavingsFixedAndActivityProductsService {
+	s.size = size
+	return s
+}
+
+func (s *ListSavingsFixedAndActivityProductsService) Status(status string) *ListSavingsFixedAndActivityProductsService {
+	s.status = status
+	return s
+}
+
+// Type set project type ("ACTIVITY", "CUSTOMIZED_FIXED")
+func (s *ListSavingsFixedAndActivityProductsService) Type(projectType string) *ListSavingsFixedAndActivityProductsService {
+	s.projectType = projectType
+	return s
+}
+
+// Do send request
+func (s *ListSavingsFixedAndActivityProductsService) Do(ctx context.Context, opts ...RequestOption) ([]*SavingsFixedProduct, error) {
+	r := &request{
+		method:   "GET",
+		endpoint: "/sapi/v1/lending/project/list",
+		secType:  secTypeSigned,
+	}
+	m := params{
+		"type": s.projectType,
+	}
+	if s.asset != "" {
+		m["asset"] = s.asset
+	}
+	if s.status != "" {
+		m["status"] = s.status
+	}
+	if s.isSortAsc != true {
+		m["isSortAsc"] = s.isSortAsc
+	}
+	if s.sortBy != "" {
+		m["sortBy"] = s.sortBy
+	}
+	if s.current != 1 {
+		m["current"] = s.current
+	}
+	if s.size != 10 {
+		m["size"] = s.size
+	}
+	r.setParams(m)
+	data, err := s.c.callAPI(ctx, r, opts...)
+	if err != nil {
+		return nil, err
+	}
+	var res []*SavingsFixedProduct
+	if err = json.Unmarshal(data, &res); err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+// SavingsFixedProduct define a fixed product (Savings)
+type SavingsFixedProduct struct {
+	Asset              string `json:"asset"`
+	DisplayPriority    int    `json:"displayPriority"`
+	Duration           int    `json:"duration"`
+	InterestPerLot     string `json:"interestPerLot"`
+	InterestRate       string `json:"interestRate"`
+	LotSize            string `json:"lotSize"`
+	LotsLowLimit       int    `json:"lotsLowLimit"`
+	LotsPurchased      int    `json:"lotsPurchased"`
+	LotsUpLimit        int    `json:"lotsUpLimit"`
+	MaxLotsPerUser     int    `json:"maxLotsPerUser"`
+	NeedKyc            bool   `json:"needKyc"`
+	ProjectId          string `json:"projectId"`
+	ProjectName        string `json:"projectName"`
+	Status             string `json:"status"`
+	Type               string `json:"type"`
+	WithAreaLimitation bool   `json:"withAreaLimitation"`
+}

--- a/v2/savings_service.go
+++ b/v2/savings_service.go
@@ -135,6 +135,52 @@ type PurchaseSavingsFlexibleProductResponse struct {
 	PurchaseId uint64 `json:"purchaseId"`
 }
 
+// RedeemSavingsFlexibleProductService https://binance-docs.github.io/apidocs/spot/en/#redeem-flexible-product-user_data
+type RedeemSavingsFlexibleProductService struct {
+	c          *Client
+	productId  string
+	amount     float64
+	redeemType string
+}
+
+// ProductId represent the id of the flexible product to redeem
+func (s *RedeemSavingsFlexibleProductService) ProductId(productId string) *RedeemSavingsFlexibleProductService {
+	s.productId = productId
+	return s
+}
+
+// Amount is the quantity of the product to redeem
+func (s *RedeemSavingsFlexibleProductService) Amount(amount float64) *RedeemSavingsFlexibleProductService {
+	s.amount = amount
+	return s
+}
+
+// Type ("FAST", "NORMAL")
+func (s *RedeemSavingsFlexibleProductService) Type(redeemType string) *RedeemSavingsFlexibleProductService {
+	s.redeemType = redeemType
+	return s
+}
+
+// Do send request
+func (s *RedeemSavingsFlexibleProductService) Do(ctx context.Context, opts ...RequestOption) error {
+	r := &request{
+		method:   "POST",
+		endpoint: "/sapi/v1/lending/daily/redeem",
+		secType:  secTypeSigned,
+	}
+	m := params{
+		"productId": s.productId,
+		"amount":    s.amount,
+	}
+	if s.redeemType != "" {
+		m["type"] = s.redeemType
+	}
+	r.setParams(m)
+	_, err := s.c.callAPI(ctx, r, opts...)
+
+	return err
+}
+
 // ListSavingsFixedAndActivityProductsService https://binance-docs.github.io/apidocs/spot/en/#get-fixed-and-activity-project-list-user_data
 type ListSavingsFixedAndActivityProductsService struct {
 	c           *Client

--- a/v2/savings_service.go
+++ b/v2/savings_service.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 )
 
-// ListSavingsFlexibleProductsService get
+// ListSavingsFlexibleProductsService https://binance-docs.github.io/apidocs/spot/en/#get-flexible-product-list-user_data
 type ListSavingsFlexibleProductsService struct {
 	c        *Client
 	status   string
@@ -14,21 +14,25 @@ type ListSavingsFlexibleProductsService struct {
 	size     int64
 }
 
+// Status represent the product status ("ALL", "SUBSCRIBABLE", "UNSUBSCRIBABLE") - Default: "ALL"
 func (s *ListSavingsFlexibleProductsService) Status(status string) *ListSavingsFlexibleProductsService {
 	s.status = status
 	return s
 }
 
+// Featured ("ALL", "TRUE") - Default: "ALL"
 func (s *ListSavingsFlexibleProductsService) Featured(featured string) *ListSavingsFlexibleProductsService {
 	s.featured = featured
 	return s
 }
 
+// Current query page. Default: 1, Min: 1
 func (s *ListSavingsFlexibleProductsService) Current(current int64) *ListSavingsFlexibleProductsService {
 	s.current = current
 	return s
 }
 
+// Size Default: 50, Max: 100
 func (s *ListSavingsFlexibleProductsService) Size(size int64) *ListSavingsFlexibleProductsService {
 	s.size = size
 	return s
@@ -95,39 +99,45 @@ type ListSavingsFixedAndActivityProductsService struct {
 	size        int64
 }
 
+// Asset desired asset
 func (s *ListSavingsFixedAndActivityProductsService) Asset(asset string) *ListSavingsFixedAndActivityProductsService {
 	s.asset = asset
-	return s
-}
-
-func (s *ListSavingsFixedAndActivityProductsService) IsSortAsc(inSortAsc bool) *ListSavingsFixedAndActivityProductsService {
-	s.isSortAsc = inSortAsc
-	return s
-}
-
-func (s *ListSavingsFixedAndActivityProductsService) SortBy(sortBy string) *ListSavingsFixedAndActivityProductsService {
-	s.sortBy = sortBy
-	return s
-}
-
-func (s *ListSavingsFixedAndActivityProductsService) Current(current int64) *ListSavingsFixedAndActivityProductsService {
-	s.current = current
-	return s
-}
-
-func (s *ListSavingsFixedAndActivityProductsService) Size(size int64) *ListSavingsFixedAndActivityProductsService {
-	s.size = size
-	return s
-}
-
-func (s *ListSavingsFixedAndActivityProductsService) Status(status string) *ListSavingsFixedAndActivityProductsService {
-	s.status = status
 	return s
 }
 
 // Type set project type ("ACTIVITY", "CUSTOMIZED_FIXED")
 func (s *ListSavingsFixedAndActivityProductsService) Type(projectType string) *ListSavingsFixedAndActivityProductsService {
 	s.projectType = projectType
+	return s
+}
+
+// IsSortAsc default "true"
+func (s *ListSavingsFixedAndActivityProductsService) IsSortAsc(isSortAsc bool) *ListSavingsFixedAndActivityProductsService {
+	s.isSortAsc = isSortAsc
+	return s
+}
+
+// Status ("ALL", "SUBSCRIBABLE", "UNSUBSCRIBABLE") - default "ALL"
+func (s *ListSavingsFixedAndActivityProductsService) Status(status string) *ListSavingsFixedAndActivityProductsService {
+	s.status = status
+	return s
+}
+
+// SortBy ("START_TIME", "LOT_SIZE", "INTEREST_RATE", "DURATION") - default "START_TIME"
+func (s *ListSavingsFixedAndActivityProductsService) SortBy(sortBy string) *ListSavingsFixedAndActivityProductsService {
+	s.sortBy = sortBy
+	return s
+}
+
+// Current Currently querying page. Start from 1. Default:1
+func (s *ListSavingsFixedAndActivityProductsService) Current(current int64) *ListSavingsFixedAndActivityProductsService {
+	s.current = current
+	return s
+}
+
+// Size Default:10, Max:100
+func (s *ListSavingsFixedAndActivityProductsService) Size(size int64) *ListSavingsFixedAndActivityProductsService {
+	s.size = size
 	return s
 }
 

--- a/v2/savings_service.go
+++ b/v2/savings_service.go
@@ -87,6 +87,54 @@ type SavingsFlexibleProduct struct {
 	UpLimitPerUser           string `json:"upLimitPerUser"`
 }
 
+// PurchaseSavingsFlexibleProductService https://binance-docs.github.io/apidocs/spot/en/#purchase-flexible-product-user_data
+type PurchaseSavingsFlexibleProductService struct {
+	c         *Client
+	productId string
+	amount    float64
+}
+
+// ProductId represent the id of the flexible product to purchase
+func (s *PurchaseSavingsFlexibleProductService) ProductId(productId string) *PurchaseSavingsFlexibleProductService {
+	s.productId = productId
+	return s
+}
+
+// Amount is the quantity of the product to purchase
+func (s *PurchaseSavingsFlexibleProductService) Amount(amount float64) *PurchaseSavingsFlexibleProductService {
+	s.amount = amount
+	return s
+}
+
+// Do send request
+func (s *PurchaseSavingsFlexibleProductService) Do(ctx context.Context, opts ...RequestOption) (uint64, error) {
+	r := &request{
+		method:   "POST",
+		endpoint: "/sapi/v1/lending/daily/purchase",
+		secType:  secTypeSigned,
+	}
+	m := params{
+		"productId": s.productId,
+		"amount":    s.amount,
+	}
+	r.setParams(m)
+	data, err := s.c.callAPI(ctx, r, opts...)
+	if err != nil {
+		return 0, err
+	}
+
+	var res *PurchaseSavingsFlexibleProductResponse
+	if err = json.Unmarshal(data, &res); err != nil {
+		return 0, err
+	}
+
+	return res.PurchaseId, nil
+}
+
+type PurchaseSavingsFlexibleProductResponse struct {
+	PurchaseId uint64 `json:"purchaseId"`
+}
+
 // ListSavingsFixedAndActivityProductsService https://binance-docs.github.io/apidocs/spot/en/#get-fixed-and-activity-project-list-user_data
 type ListSavingsFixedAndActivityProductsService struct {
 	c           *Client

--- a/v2/savings_service_test.go
+++ b/v2/savings_service_test.go
@@ -1,0 +1,203 @@
+package binance
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type savingsServiceTestSuite struct {
+	baseTestSuite
+}
+
+func TestSavingsService(t *testing.T) {
+	suite.Run(t, new(savingsServiceTestSuite))
+}
+
+func (s *savingsServiceTestSuite) TestListSavingsFlexibleProducts() {
+	data := []byte(`[
+    {
+        "asset": "BTC",
+        "avgAnnualInterestRate": "0.00250025",
+        "canPurchase": true,
+        "canRedeem": true,
+        "dailyInterestPerThousand": "0.00685000",
+        "featured": true,
+        "minPurchaseAmount": "0.01000000",
+        "productId": "BTC001",
+        "purchasedAmount": "16.32467016",
+        "status": "PURCHASING",
+        "upLimit": "200.00000000",
+        "upLimitPerUser": "5.00000000"
+    },
+    {
+        "asset": "BUSD",
+        "avgAnnualInterestRate": "0.01228590",
+        "canPurchase": true,
+        "canRedeem": true,
+        "dailyInterestPerThousand": "0.03836000",
+        "featured": true,
+        "minPurchaseAmount": "0.10000000",
+        "productId": "BUSD001",
+        "purchasedAmount": "10.38932339",
+        "status": "PURCHASING",
+        "upLimit": "100000.00000000",
+        "upLimitPerUser": "50000.00000000"
+    }
+]`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+	s.assertReq(func(r *request) {
+		e := newSignedRequest().setParams(params{
+			"status":   "ALL",
+			"featured": "ALL",
+			"current":  1,
+			"size":     50,
+		})
+		s.assertRequestEqual(e, r)
+	})
+
+	flexibleProductList, err := s.client.NewListSavingsFlexibleProductsService().
+		Status("ALL").
+		Featured("ALL").
+		Current(1).
+		Size(50).
+		Do(newContext())
+	r := s.r()
+	r.NoError(err)
+
+	r.Len(flexibleProductList, 2)
+	s.assertSavingsFlexibleProductEqual(&SavingsFlexibleProduct{
+		Asset:                    "BTC",
+		AvgAnnualInterestRate:    "0.00250025",
+		CanPurchase:              true,
+		CanRedeem:                true,
+		DailyInterestPerThousand: "0.00685000",
+		Featured:                 true,
+		MinPurchaseAmount:        "0.01000000",
+		ProductId:                "BTC001",
+		PurchasedAmount:          "16.32467016",
+		Status:                   "PURCHASING",
+		UpLimit:                  "200.00000000",
+		UpLimitPerUser:           "5.00000000",
+	}, flexibleProductList[0])
+	s.assertSavingsFlexibleProductEqual(&SavingsFlexibleProduct{
+		Asset:                    "BUSD",
+		AvgAnnualInterestRate:    "0.01228590",
+		CanPurchase:              true,
+		CanRedeem:                true,
+		DailyInterestPerThousand: "0.03836000",
+		Featured:                 true,
+		MinPurchaseAmount:        "0.10000000",
+		ProductId:                "BUSD001",
+		PurchasedAmount:          "10.38932339",
+		Status:                   "PURCHASING",
+		UpLimit:                  "100000.00000000",
+		UpLimitPerUser:           "50000.00000000",
+	}, flexibleProductList[1])
+}
+
+func (s *savingsServiceTestSuite) assertSavingsFlexibleProductEqual(e, a *SavingsFlexibleProduct) {
+	r := s.r()
+	r.Equal(e.Asset, a.Asset, "Asset")
+	r.Equal(e.AvgAnnualInterestRate, a.AvgAnnualInterestRate, "AvgAnnualInterestRate")
+	r.Equal(e.CanPurchase, a.CanPurchase, "CanPurchase")
+	r.Equal(e.CanRedeem, a.CanRedeem, "CanRedeem")
+	r.Equal(e.DailyInterestPerThousand, a.DailyInterestPerThousand, "DailyInterestPerThousand")
+	r.Equal(e.Featured, a.Featured, "Featured")
+	r.Equal(e.MinPurchaseAmount, a.MinPurchaseAmount, "MinPurchaseAmount")
+	r.Equal(e.ProductId, a.ProductId, "ProductId")
+	r.Equal(e.PurchasedAmount, a.PurchasedAmount, "PurchasedAmount")
+	r.Equal(e.Status, a.Status, "Status")
+	r.Equal(e.UpLimit, a.UpLimit, "UpLimit")
+	r.Equal(e.UpLimitPerUser, a.UpLimitPerUser, "UpLimitPerUser")
+}
+
+func (s *savingsServiceTestSuite) TestListSavingsFixedAndActivityProducts() {
+	data := []byte(`[
+    {
+        "asset": "USDT",
+        "displayPriority": 1,
+        "duration": 90,
+        "interestPerLot": "1.35810000",
+        "interestRate": "0.05510000",
+        "lotSize": "100.00000000",
+        "lotsLowLimit": 1,
+        "lotsPurchased": 74155,
+        "lotsUpLimit": 80000,
+        "maxLotsPerUser": 2000,
+        "needKyc": false,
+        "projectId": "CUSDT90DAYSS001",
+        "projectName": "USDT",
+        "status": "PURCHASING",
+        "type": "CUSTOMIZED_FIXED",
+        "withAreaLimitation": false
+    }
+]`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+	s.assertReq(func(r *request) {
+		e := newSignedRequest().setParams(params{
+			"asset":     "USDT",
+			"type":      "ACTIVITY",
+			"status":    "ALL",
+			"isSortAsc": false,
+			"sortBy":    "INTEREST_RATE",
+			"current":   5,
+			"size":      15,
+		})
+		s.assertRequestEqual(e, r)
+	})
+
+	flexibleProductList, err := s.client.NewListSavingsFixedAndActivityProductsService().
+		Asset("USDT").
+		Type("ACTIVITY").
+		Status("ALL").
+		IsSortAsc(false).
+		SortBy("INTEREST_RATE").
+		Current(5).
+		Size(15).
+		Do(newContext())
+	r := s.r()
+	r.NoError(err)
+
+	r.Len(flexibleProductList, 1)
+	s.assertSavingsFixedProductEqual(&SavingsFixedProduct{
+		Asset:              "USDT",
+		DisplayPriority:    1,
+		Duration:           90,
+		InterestPerLot:     "1.35810000",
+		InterestRate:       "0.05510000",
+		LotSize:            "100.00000000",
+		LotsLowLimit:       1,
+		LotsPurchased:      74155,
+		LotsUpLimit:        80000,
+		MaxLotsPerUser:     2000,
+		NeedKyc:            false,
+		ProjectId:          "CUSDT90DAYSS001",
+		ProjectName:        "USDT",
+		Status:             "PURCHASING",
+		Type:               "CUSTOMIZED_FIXED",
+		WithAreaLimitation: false,
+	}, flexibleProductList[0])
+}
+
+func (s *savingsServiceTestSuite) assertSavingsFixedProductEqual(e, a *SavingsFixedProduct) {
+	r := s.r()
+	r.Equal(e.Asset, a.Asset, "Asset")
+	r.Equal(e.DisplayPriority, a.DisplayPriority, "DisplayPriority")
+	r.Equal(e.Duration, a.Duration, "Duration")
+	r.Equal(e.InterestPerLot, a.InterestPerLot, "InterestPerLot")
+	r.Equal(e.InterestRate, a.InterestRate, "InterestRate")
+	r.Equal(e.LotSize, a.LotSize, "LotSize")
+	r.Equal(e.LotsLowLimit, a.LotsLowLimit, "LotsLowLimit")
+	r.Equal(e.LotsPurchased, a.LotsPurchased, "LotsPurchased")
+	r.Equal(e.LotsUpLimit, a.LotsUpLimit, "LotsUpLimit")
+	r.Equal(e.MaxLotsPerUser, a.MaxLotsPerUser, "MaxLotsPerUser")
+	r.Equal(e.NeedKyc, a.NeedKyc, "NeedKyc")
+	r.Equal(e.ProjectId, a.ProjectId, "ProjectId")
+	r.Equal(e.ProjectName, a.ProjectName, "ProjectName")
+	r.Equal(e.Status, a.Status, "Status")
+	r.Equal(e.Type, a.Type, "Type")
+	r.Equal(e.WithAreaLimitation, a.WithAreaLimitation, "WithAreaLimitation")
+}

--- a/v2/savings_service_test.go
+++ b/v2/savings_service_test.go
@@ -113,6 +113,28 @@ func (s *savingsServiceTestSuite) assertSavingsFlexibleProductEqual(e, a *Saving
 	r.Equal(e.UpLimitPerUser, a.UpLimitPerUser, "UpLimitPerUser")
 }
 
+func (s *savingsServiceTestSuite) TestPurchaseSavingsFlexibleProduct() {
+	data := []byte(`{ "purchaseId": 40607 }`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+	s.assertReq(func(r *request) {
+		e := newSignedRequest().setParams(params{
+			"productId": "BTC001",
+			"amount":    0.52,
+		})
+		s.assertRequestEqual(e, r)
+	})
+
+	purchaseId, err := s.client.NewPurchaseSavingsFlexibleProductService().
+		ProductId("BTC001").
+		Amount(0.52).
+		Do(newContext())
+
+	r := s.r()
+	r.NoError(err)
+	r.Equal(purchaseId, uint64(40607), "Purchase Id")
+}
+
 func (s *savingsServiceTestSuite) TestListSavingsFixedAndActivityProducts() {
 	data := []byte(`[
     {

--- a/v2/savings_service_test.go
+++ b/v2/savings_service_test.go
@@ -135,6 +135,29 @@ func (s *savingsServiceTestSuite) TestPurchaseSavingsFlexibleProduct() {
 	r.Equal(purchaseId, uint64(40607), "Purchase Id")
 }
 
+func (s *savingsServiceTestSuite) TestReedemSavingsFlexibleProduct() {
+	data := []byte(`{}`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+	s.assertReq(func(r *request) {
+		e := newSignedRequest().setParams(params{
+			"productId": "BTC001",
+			"amount":    0.52,
+			"type":      "FAST",
+		})
+		s.assertRequestEqual(e, r)
+	})
+
+	err := s.client.NewRedeemSavingsFlexibleProductService().
+		ProductId("BTC001").
+		Amount(0.52).
+		Type("FAST").
+		Do(newContext())
+
+	r := s.r()
+	r.NoError(err)
+}
+
 func (s *savingsServiceTestSuite) TestListSavingsFixedAndActivityProducts() {
 	data := []byte(`[
     {


### PR DESCRIPTION
Add 2 new services related to the "Savings"
- `ListSavingsFixedAndActivityProductsService` 
  - https://binance-docs.github.io/apidocs/spot/en/#get-fixed-and-activity-project-list-user_data
- `ListSavingsFlexibleProductsService` 
  - https://binance-docs.github.io/apidocs/spot/en/#get-flexible-product-list-user_data
