### PR TITLE
Add QuoteAssetPrecision field to the Symbol struct

### DIFF
--- a/v2/exchange_info_service.go
+++ b/v2/exchange_info_service.go
@@ -77,6 +77,7 @@ type Symbol struct {
 	BaseAssetPrecision     int                      `json:"baseAssetPrecision"`
 	QuoteAsset             string                   `json:"quoteAsset"`
 	QuotePrecision         int                      `json:"quotePrecision"`
+	QuoteAssetPrecision    int                      `json:"quoteAssetPrecision"`
 	OrderTypes             []string                 `json:"orderTypes"`
 	IcebergAllowed         bool                     `json:"icebergAllowed"`
 	OcoAllowed             bool                     `json:"ocoAllowed"`


### PR DESCRIPTION
As mentioned in the [Binance changelog](https://binance-docs.github.io/apidocs/spot/en/#change-log) from 2020-04-25, a new field `quoteAssetPrecision` was added; a duplicate of the `quotePrecision` field. `quotePrecision` will be removed in future API versions (v4+).