### PR TITLE
Add fiat endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 pkg/
 .idea
+*.iml

--- a/v2/client.go
+++ b/v2/client.go
@@ -65,6 +65,9 @@ type SideEffectType string
 // FuturesTransferType define futures transfer type
 type FuturesTransferType int
 
+// TransactionType define transaction type
+type TransactionType string
+
 // Endpoints
 const (
 	baseAPIMainURL    = "https://api.binance.com"
@@ -147,6 +150,11 @@ const (
 	SideEffectTypeNoSideEffect SideEffectType = "NO_SIDE_EFFECT"
 	SideEffectTypeMarginBuy    SideEffectType = "MARGIN_BUY"
 	SideEffectTypeAutoRepay    SideEffectType = "AUTO_REPAY"
+
+	TransactionTypeDeposit  TransactionType = "0"
+	TransactionTypeWithdraw TransactionType = "1"
+	TransactionTypeBuy      TransactionType = "0"
+	TransactionTypeSell     TransactionType = "1"
 
 	timestampKey  = "timestamp"
 	signatureKey  = "signature"
@@ -676,4 +684,9 @@ func (c *Client) NewUserUniversalTransferService() *CreateUserUniversalTransferS
 // NewDustTransferService init Get All Margin Assets service
 func (c *Client) NewGetAllMarginAssetsService() *GetAllMarginAssetsService {
 	return &GetAllMarginAssetsService{c: c}
+}
+
+// NewFiatDepositWithdrawHistoryService init get the fiat deposit/withdraw history service
+func (c *Client) NewFiatDepositWithdrawHistoryService() *FiatDepositWithdrawHistoryService {
+	return &FiatDepositWithdrawHistoryService{c: c}
 }

--- a/v2/client.go
+++ b/v2/client.go
@@ -686,7 +686,12 @@ func (c *Client) NewGetAllMarginAssetsService() *GetAllMarginAssetsService {
 	return &GetAllMarginAssetsService{c: c}
 }
 
-// NewFiatDepositWithdrawHistoryService init get the fiat deposit/withdraw history service
+// NewFiatDepositWithdrawHistoryService init the fiat deposit/withdraw history service
 func (c *Client) NewFiatDepositWithdrawHistoryService() *FiatDepositWithdrawHistoryService {
 	return &FiatDepositWithdrawHistoryService{c: c}
+}
+
+// NewFiatPaymentsHistoryService init the fiat payments history service
+func (c *Client) NewFiatPaymentsHistoryService() *FiatPaymentsHistoryService {
+	return &FiatPaymentsHistoryService{c: c}
 }

--- a/v2/fiat_service.go
+++ b/v2/fiat_service.go
@@ -98,3 +98,97 @@ type FiatDepositWithdrawHistoryItem struct {
 	CreateTime      int64  `json:"createTime"`
 	UpdateTime      int64  `json:"updateTime"`
 }
+
+// FiatPaymentsHistoryService retrieve the fiat payments history
+type FiatPaymentsHistoryService struct {
+	c               *Client
+	transactionType TransactionType
+	beginTime       *int64
+	endTime         *int64
+	page            *int32
+	rows            *int32
+}
+
+// TransactionType set transactionType
+func (s *FiatPaymentsHistoryService) TransactionType(transactionType TransactionType) *FiatPaymentsHistoryService {
+	s.transactionType = transactionType
+	return s
+}
+
+// BeginTime set beginTime
+func (s *FiatPaymentsHistoryService) BeginTime(beginTime int64) *FiatPaymentsHistoryService {
+	s.beginTime = &beginTime
+	return s
+}
+
+// EndTime set endTime
+func (s *FiatPaymentsHistoryService) EndTime(endTime int64) *FiatPaymentsHistoryService {
+	s.endTime = &endTime
+	return s
+}
+
+// Page set page
+func (s *FiatPaymentsHistoryService) Page(page int32) *FiatPaymentsHistoryService {
+	s.page = &page
+	return s
+}
+
+// Rows set rows
+func (s *FiatPaymentsHistoryService) Rows(rows int32) *FiatPaymentsHistoryService {
+	s.rows = &rows
+	return s
+}
+
+// Do send request
+func (s *FiatPaymentsHistoryService) Do(ctx context.Context, opts ...RequestOption) (*FiatPaymentsHistory, error) {
+	r := &request{
+		method:   http.MethodGet,
+		endpoint: "/sapi/v1/fiat/payments",
+		secType:  secTypeSigned,
+	}
+	r.setParam("transactionType", s.transactionType)
+	if s.beginTime != nil {
+		r.setParam("beginTime", *s.beginTime)
+	}
+	if s.endTime != nil {
+		r.setParam("endTime", *s.endTime)
+	}
+	if s.page != nil {
+		r.setParam("page", *s.page)
+	}
+	if s.rows != nil {
+		r.setParam("rows", *s.rows)
+	}
+	data, err := s.c.callAPI(ctx, r, opts...)
+	if err != nil {
+		return nil, err
+	}
+	res := FiatPaymentsHistory{}
+	if err = json.Unmarshal(data, &res); err != nil {
+		return nil, err
+	}
+	return &res, nil
+}
+
+// FiatPaymentsHistory define the fiat payments history
+type FiatPaymentsHistory struct {
+	Code    string                    `json:"code"`
+	Message string                    `json:"message"`
+	Data    []FiatPaymentsHistoryItem `json:"data"`
+	Total   int32                     `json:"total"`
+	Success bool                      `json:"success"`
+}
+
+// FiatPaymentsHistoryItem define a fiat payments history item
+type FiatPaymentsHistoryItem struct {
+	OrderNo        string `json:"orderNo"`
+	SourceAmount   string `json:"sourceAmount"`
+	FiatCurrency   string `json:"fiatCurrency"`
+	ObtainAmount   string `json:"obtainAmount"`
+	CryptoCurrency string `json:"cryptoCurrency"`
+	TotalFee       string `json:"totalFee"`
+	Price          string `json:"price"`
+	Status         string `json:"status"`
+	CreateTime     int64  `json:"createTime"`
+	UpdateTime     int64  `json:"updateTime"`
+}

--- a/v2/fiat_service.go
+++ b/v2/fiat_service.go
@@ -1,0 +1,100 @@
+package binance
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+)
+
+// FiatDepositWithdrawHistoryService retrieve the fiat deposit/withdraw history
+type FiatDepositWithdrawHistoryService struct {
+	c               *Client
+	transactionType TransactionType
+	beginTime       *int64
+	endTime         *int64
+	page            *int32
+	rows            *int32
+}
+
+// TransactionType set transactionType
+func (s *FiatDepositWithdrawHistoryService) TransactionType(transactionType TransactionType) *FiatDepositWithdrawHistoryService {
+	s.transactionType = transactionType
+	return s
+}
+
+// BeginTime set beginTime
+func (s *FiatDepositWithdrawHistoryService) BeginTime(beginTime int64) *FiatDepositWithdrawHistoryService {
+	s.beginTime = &beginTime
+	return s
+}
+
+// EndTime set endTime
+func (s *FiatDepositWithdrawHistoryService) EndTime(endTime int64) *FiatDepositWithdrawHistoryService {
+	s.endTime = &endTime
+	return s
+}
+
+// Page set page
+func (s *FiatDepositWithdrawHistoryService) Page(page int32) *FiatDepositWithdrawHistoryService {
+	s.page = &page
+	return s
+}
+
+// Rows set rows
+func (s *FiatDepositWithdrawHistoryService) Rows(rows int32) *FiatDepositWithdrawHistoryService {
+	s.rows = &rows
+	return s
+}
+
+// Do send request
+func (s *FiatDepositWithdrawHistoryService) Do(ctx context.Context, opts ...RequestOption) (*FiatDepositWithdrawHistory, error) {
+	r := &request{
+		method:   http.MethodGet,
+		endpoint: "/sapi/v1/fiat/orders",
+		secType:  secTypeSigned,
+	}
+	r.setParam("transactionType", s.transactionType)
+	if s.beginTime != nil {
+		r.setParam("beginTime", *s.beginTime)
+	}
+	if s.endTime != nil {
+		r.setParam("endTime", *s.endTime)
+	}
+	if s.page != nil {
+		r.setParam("page", *s.page)
+	}
+	if s.rows != nil {
+		r.setParam("rows", *s.rows)
+	}
+	data, err := s.c.callAPI(ctx, r, opts...)
+	if err != nil {
+		return nil, err
+	}
+	res := FiatDepositWithdrawHistory{}
+	if err = json.Unmarshal(data, &res); err != nil {
+		return nil, err
+	}
+	return &res, nil
+}
+
+// FiatDepositWithdrawHistory define the fiat deposit/withdraw history
+type FiatDepositWithdrawHistory struct {
+	Code    string                           `json:"code"`
+	Message string                           `json:"message"`
+	Data    []FiatDepositWithdrawHistoryItem `json:"data"`
+	Total   int32                            `json:"total"`
+	Success bool                             `json:"success"`
+}
+
+// FiatDepositWithdrawHistoryItem define a fiat deposit/withdraw history item
+type FiatDepositWithdrawHistoryItem struct {
+	OrderNo         string `json:"orderNo"`
+	FiatCurrency    string `json:"fiatCurrency"`
+	IndicatedAmount string `json:"indicatedAmount"`
+	Amount          string `json:"amount"`
+	TotalFee        string `json:"totalFee"`
+	Method          string `json:"method"`
+	Status          string `json:"status"`
+	CreateTime      int64  `json:"createTime"`
+	UpdateTime      int64  `json:"updateTime"`
+}

--- a/v2/fiat_service_test.go
+++ b/v2/fiat_service_test.go
@@ -1,0 +1,97 @@
+package binance
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type fiatServiceTestSuite struct {
+	baseTestSuite
+}
+
+func TestFiatService(t *testing.T) {
+	suite.Run(t, new(fiatServiceTestSuite))
+}
+
+func (s *fiatServiceTestSuite) TestFiatDepositWithdrawHistory() {
+	data := []byte(`{
+	   "code": "000000",
+	   "message": "success",
+	   "data": [
+	   {
+		  "orderNo":"7d76d611-0568-4f43-afb6-24cac7767365",
+		  "fiatCurrency": "BRL",
+		  "indicatedAmount": "10.00",
+		  "amount": "10.00",
+		  "totalFee": "0.00",
+		  "method": "BankAccount",
+		  "status": "Expired",
+		  "createTime": 1626144956000,
+		  "updateTime": 1626400907000
+	   }
+	   ],
+	   "total": 1,
+	   "success": true
+	}`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	transactionType := TransactionTypeDeposit
+	s.assertReq(func(r *request) {
+		e := newSignedRequest().setParams(params{
+			"transactionType": transactionType,
+		})
+		s.assertRequestEqual(e, r)
+	})
+
+	res, err := s.client.NewFiatDepositWithdrawHistoryService().
+		TransactionType(transactionType).
+		Do(newContext())
+	s.r().NoError(err)
+	e := &FiatDepositWithdrawHistory{
+		Code:    "000000",
+		Message: "success",
+		Data: []FiatDepositWithdrawHistoryItem{
+			{
+				OrderNo:         "7d76d611-0568-4f43-afb6-24cac7767365",
+				FiatCurrency:    "BRL",
+				IndicatedAmount: "10.00",
+				Amount:          "10.00",
+				TotalFee:        "0.00",
+				Method:          "BankAccount",
+				Status:          "Expired",
+				CreateTime:      1626144956000,
+				UpdateTime:      1626400907000,
+			},
+		},
+		Total:   1,
+		Success: true,
+	}
+	s.assertFiatDepositWithdrawHistoryEqual(e, res)
+}
+
+func (s *fiatServiceTestSuite) assertFiatDepositWithdrawHistoryEqual(e, a *FiatDepositWithdrawHistory) {
+	r := s.r()
+	r.Equal(e.Code, a.Code, "Code")
+	r.Equal(e.Message, a.Message, "Message")
+	r.Equal(e.Total, a.Total, "Total")
+	r.Equal(e.Success, a.Success, "Success")
+
+	r.Len(a.Data, len(e.Data))
+	for i := 0; i < len(a.Data); i++ {
+		s.assertFiatDepositWithdrawHistoryItemEqual(&e.Data[i], &a.Data[i])
+	}
+}
+
+func (s *fiatServiceTestSuite) assertFiatDepositWithdrawHistoryItemEqual(e, a *FiatDepositWithdrawHistoryItem) {
+	r := s.r()
+	r.Equal(e.OrderNo, a.OrderNo, "OrderNo")
+	r.Equal(e.FiatCurrency, a.FiatCurrency, "FiatCurrency")
+	r.Equal(e.IndicatedAmount, a.IndicatedAmount, "IndicatedAmount")
+	r.Equal(e.Amount, a.Amount, "Amount")
+	r.Equal(e.TotalFee, a.TotalFee, "TotalFee")
+	r.Equal(e.Method, a.Method, "Method")
+	r.Equal(e.Status, a.Status, "Status")
+	r.Equal(e.CreateTime, a.CreateTime, "CreateTime")
+	r.Equal(e.UpdateTime, a.UpdateTime, "UpdateTime")
+}

--- a/v2/fiat_service_test.go
+++ b/v2/fiat_service_test.go
@@ -95,3 +95,89 @@ func (s *fiatServiceTestSuite) assertFiatDepositWithdrawHistoryItemEqual(e, a *F
 	r.Equal(e.CreateTime, a.CreateTime, "CreateTime")
 	r.Equal(e.UpdateTime, a.UpdateTime, "UpdateTime")
 }
+
+func (s *fiatServiceTestSuite) TestFiatPaymentsHistory() {
+	data := []byte(`{
+	   "code": "000000",
+	   "message": "success",
+	   "data": [
+	   {
+		  "orderNo": "353fca443f06466db0c4dc89f94f027a",
+		  "sourceAmount": "20.0",
+		  "fiatCurrency": "EUR",
+		  "obtainAmount": "4.462",
+		  "cryptoCurrency": "LUNA",
+		  "totalFee": "0.2",
+		  "price": "4.437472",
+		  "status": "Failed",
+		  "createTime": 1624529919000,
+		  "updateTime": 1624529919000
+	   }
+	   ],
+	   "total": 1,
+	   "success": true
+	}`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	transactionType := TransactionTypeBuy
+	s.assertReq(func(r *request) {
+		e := newSignedRequest().setParams(params{
+			"transactionType": transactionType,
+		})
+		s.assertRequestEqual(e, r)
+	})
+
+	res, err := s.client.NewFiatPaymentsHistoryService().
+		TransactionType(transactionType).
+		Do(newContext())
+	s.r().NoError(err)
+	e := &FiatPaymentsHistory{
+		Code:    "000000",
+		Message: "success",
+		Data: []FiatPaymentsHistoryItem{
+			{
+				OrderNo:        "353fca443f06466db0c4dc89f94f027a",
+				SourceAmount:   "20.0",
+				FiatCurrency:   "EUR",
+				ObtainAmount:   "4.462",
+				CryptoCurrency: "LUNA",
+				TotalFee:       "0.2",
+				Price:          "4.437472",
+				Status:         "Failed",
+				CreateTime:     1624529919000,
+				UpdateTime:     1624529919000,
+			},
+		},
+		Total:   1,
+		Success: true,
+	}
+	s.assertFiatPaymentsHistoryEqual(e, res)
+}
+
+func (s *fiatServiceTestSuite) assertFiatPaymentsHistoryEqual(e, a *FiatPaymentsHistory) {
+	r := s.r()
+	r.Equal(e.Code, a.Code, "Code")
+	r.Equal(e.Message, a.Message, "Message")
+	r.Equal(e.Total, a.Total, "Total")
+	r.Equal(e.Success, a.Success, "Success")
+
+	r.Len(a.Data, len(e.Data))
+	for i := 0; i < len(a.Data); i++ {
+		s.assertFiatPaymentsHistoryItemEqual(&e.Data[i], &a.Data[i])
+	}
+}
+
+func (s *fiatServiceTestSuite) assertFiatPaymentsHistoryItemEqual(e, a *FiatPaymentsHistoryItem) {
+	r := s.r()
+	r.Equal(e.OrderNo, a.OrderNo, "OrderNo")
+	r.Equal(e.SourceAmount, a.SourceAmount, "SourceAmount")
+	r.Equal(e.FiatCurrency, a.FiatCurrency, "FiatCurrency")
+	r.Equal(e.ObtainAmount, a.ObtainAmount, "ObtainAmount")
+	r.Equal(e.CryptoCurrency, a.CryptoCurrency, "CryptoCurrency")
+	r.Equal(e.TotalFee, a.TotalFee, "TotalFee")
+	r.Equal(e.Price, a.Price, "Price")
+	r.Equal(e.Status, a.Status, "Status")
+	r.Equal(e.CreateTime, a.CreateTime, "CreateTime")
+	r.Equal(e.UpdateTime, a.UpdateTime, "UpdateTime")
+}


### PR DESCRIPTION
Add the [fiat endpoints](https://binance-docs.github.io/apidocs/spot/en/#fiat-endpoints):
  - [Fiat Deposit/Withdraw History](https://binance-docs.github.io/apidocs/spot/en/#get-fiat-deposit-withdraw-history-user_data) : `/sapi/v1/fiat/orders`
  - [Fiat Payments History](https://binance-docs.github.io/apidocs/spot/en/#get-fiat-payments-history-user_data) : `/sapi/v1/fiat/payments`