### PR TITLE
Add the Interest History service

### DIFF
--- a/v2/client.go
+++ b/v2/client.go
@@ -68,6 +68,9 @@ type FuturesTransferType int
 // TransactionType define transaction type
 type TransactionType string
 
+// LendingType define the type of lending (flexible saving, activity, ...)
+type LendingType string
+
 // Endpoints
 const (
 	baseAPIMainURL    = "https://api.binance.com"
@@ -155,6 +158,10 @@ const (
 	TransactionTypeWithdraw TransactionType = "1"
 	TransactionTypeBuy      TransactionType = "0"
 	TransactionTypeSell     TransactionType = "1"
+
+	LendingTypeFlexible LendingType = "DAILY"
+	LendingTypeFixed    LendingType = "CUSTOMIZED_FIXED"
+	LendingTypeActivity LendingType = "ACTIVITY"
 
 	timestampKey  = "timestamp"
 	signatureKey  = "signature"
@@ -724,4 +731,9 @@ func (c *Client) NewSpotRebateHistoryService() *SpotRebateHistoryService {
 // NewConvertTradeHistoryService init the convert trade history service
 func (c *Client) NewConvertTradeHistoryService() *ConvertTradeHistoryService {
 	return &ConvertTradeHistoryService{c: c}
+}
+
+// NewInterestHistoryService init the interest history service
+func (c *Client) NewInterestHistoryService() *InterestHistoryService {
+	return &InterestHistoryService{c: c}
 }

--- a/v2/interest_history_service.go
+++ b/v2/interest_history_service.go
@@ -1,0 +1,102 @@
+package binance
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+)
+
+// InterestHistoryService fetches the interest history
+type InterestHistoryService struct {
+	c           *Client
+	lendingType LendingType
+	asset       *string
+	startTime   *int64
+	endTime     *int64
+	current     *int32
+	size        *int32
+}
+
+// LendingType sets the lendingType parameter.
+func (s *InterestHistoryService) LendingType(lendingType LendingType) *InterestHistoryService {
+	s.lendingType = lendingType
+	return s
+}
+
+// Asset sets the asset parameter.
+func (s *InterestHistoryService) Asset(asset string) *InterestHistoryService {
+	s.asset = &asset
+	return s
+}
+
+// StartTime sets the startTime parameter.
+// If present, EndTime MUST be specified. The difference between EndTime - StartTime MUST be between 0-30 days.
+func (s *InterestHistoryService) StartTime(startTime int64) *InterestHistoryService {
+	s.startTime = &startTime
+	return s
+}
+
+// EndTime sets the endTime parameter.
+// If present, StartTime MUST be specified. The difference between EndTime - StartTime MUST be between 0-90 days.
+func (s *InterestHistoryService) EndTime(endTime int64) *InterestHistoryService {
+	s.endTime = &endTime
+	return s
+}
+
+// Current sets the current parameter.
+func (s *InterestHistoryService) Current(current int32) *InterestHistoryService {
+	s.current = &current
+	return s
+}
+
+// Size sets the size parameter.
+func (s *InterestHistoryService) Size(size int32) *InterestHistoryService {
+	s.size = &size
+	return s
+}
+
+// Do sends the request.
+func (s *InterestHistoryService) Do(ctx context.Context) (*InterestHistory, error) {
+	r := &request{
+		method:   http.MethodGet,
+		endpoint: "/sapi/v1/lending/union/interestHistory",
+		secType:  secTypeSigned,
+	}
+	r.setParam("lendingType", s.lendingType)
+	if s.asset != nil {
+		r.setParam("asset", *s.asset)
+	}
+	if s.startTime != nil {
+		r.setParam("startTime", *s.startTime)
+	}
+	if s.endTime != nil {
+		r.setParam("endTime", *s.endTime)
+	}
+	if s.current != nil {
+		r.setParam("current", *s.current)
+	}
+	if s.size != nil {
+		r.setParam("size", *s.size)
+	}
+	data, err := s.c.callAPI(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+	res := new(InterestHistory)
+	err = json.Unmarshal(data, res)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+// InterestHistory represents a response from InterestHistoryService.
+type InterestHistory []InterestHistoryElement
+
+type InterestHistoryElement struct {
+	Asset       string      `json:"asset"`
+	Interest    string      `json:"interest"`
+	LendingType LendingType `json:"lendingType"`
+	ProductName string      `json:"productName"`
+	Time        int64       `json:"time"`
+}

--- a/v2/interest_history_service_test.go
+++ b/v2/interest_history_service_test.go
@@ -1,0 +1,78 @@
+package binance
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type interestHistoryServiceTestSuite struct {
+	baseTestSuite
+}
+
+func TestInterestHistoryService(t *testing.T) {
+	suite.Run(t, new(interestHistoryServiceTestSuite))
+}
+
+func (s *interestHistoryServiceTestSuite) TestInterestHistory() {
+	data := []byte(`
+	[
+		{
+			"asset": "BUSD",
+			"interest": "0.00006408",
+			"lendingType": "DAILY",
+			"productName": "BUSD",
+			"time": 1577233578000
+		},
+		{
+			"asset": "USDT",
+			"interest": "0.00687654",
+			"lendingType": "DAILY",
+			"productName": "USDT",
+			"time": 1577233562000
+		}
+	]
+	`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	lendingType := LendingTypeFlexible
+	s.assertReq(func(r *request) {
+		e := newSignedRequest().setParams(params{
+			"lendingType": lendingType,
+		})
+		s.assertRequestEqual(e, r)
+	})
+
+	history, err := s.client.NewInterestHistoryService().
+		LendingType(lendingType).
+		Do(context.Background())
+	r := s.r()
+	r.NoError(err)
+
+	s.Len(*history, 2)
+	s.assertInterestHistoryElementEqual(&InterestHistoryElement{
+		Asset:       "BUSD",
+		Interest:   "0.00006408",
+		LendingType: "DAILY",
+		ProductName: "BUSD",
+		Time:        1577233578000,
+	}, &(*history)[0])
+	s.assertInterestHistoryElementEqual(&InterestHistoryElement{
+		Asset:       "USDT",
+		Interest:    "0.00687654",
+		LendingType: "DAILY",
+		ProductName: "USDT",
+		Time:        1577233562000,
+	}, &(*history)[1])
+}
+
+func (s *interestHistoryServiceTestSuite) assertInterestHistoryElementEqual(e, a *InterestHistoryElement) {
+	r := s.r()
+	r.Equal(e.Asset, a.Asset, "Asset")
+	r.Equal(e.Interest, a.Interest, "Interest")
+	r.Equal(e.LendingType, a.LendingType, "LendingType")
+	r.Equal(e.ProductName, a.ProductName, "ProductName")
+	r.Equal(e.Time, a.Time, "Time")
+}

--- a/v2/interest_history_service_test.go
+++ b/v2/interest_history_service_test.go
@@ -54,7 +54,7 @@ func (s *interestHistoryServiceTestSuite) TestInterestHistory() {
 	s.Len(*history, 2)
 	s.assertInterestHistoryElementEqual(&InterestHistoryElement{
 		Asset:       "BUSD",
-		Interest:   "0.00006408",
+		Interest:    "0.00006408",
 		LendingType: "DAILY",
 		ProductName: "BUSD",
 		Time:        1577233578000,


### PR DESCRIPTION
Add the [Interest History](https://binance-docs.github.io/apidocs/spot/en/#get-interest-history-user_data-2) service : /sapi/v1/lending/union/interestHistory