### PR TITLE
feat: add trade ID field to order fills

### DIFF
--- a/v2/order_service.go
+++ b/v2/order_service.go
@@ -176,6 +176,7 @@ type CreateOrderResponse struct {
 
 // Fill may be returned in an array of fills in a CreateOrderResponse.
 type Fill struct {
+	TradeID         int    `json:"tradeId"`
 	Price           string `json:"price"`
 	Quantity        string `json:"qty"`
 	Commission      string `json:"commission"`


### PR DESCRIPTION
As per [binance docs](https://binance-docs.github.io/apidocs/spot/en/#new-order-trade) (and tested empirically) fills have a field `tradeId` which is very useful to perform cross-matching in between the websocket feed and the standar API calls.