### PR TITLE
Add tradeFee method support

### DIFF
--- a/v2/client.go
+++ b/v2/client.go
@@ -742,3 +742,8 @@ func (c *Client) NewGetIsolatedMarginAllPairsService() *GetIsolatedMarginAllPair
 func (c *Client) NewInterestHistoryService() *InterestHistoryService {
 	return &InterestHistoryService{c: c}
 }
+
+// NewTradeFeeService init the trade fee service
+func (c *Client) NewTradeFeeService() *TradeFeeService {
+	return &TradeFeeService{c: c}
+}

--- a/v2/trade_fee_service.go
+++ b/v2/trade_fee_service.go
@@ -1,0 +1,50 @@
+package binance
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+)
+
+// TradeFeeService shows current trade fee for all symbols available
+type TradeFeeService struct {
+	c      *Client
+	symbol *string
+}
+
+// Symbol set the symbol parameter for the request
+func (s *TradeFeeService) Symbol(symbol string) *TradeFeeService {
+	s.symbol = &symbol
+	return s
+}
+
+// Do send request
+func (s *TradeFeeService) Do(ctx context.Context) (res []*TradeFeeDetails, err error) {
+	r := &request{
+		method:   http.MethodGet,
+		endpoint: "/sapi/v1/asset/tradeFee",
+		secType:  secTypeSigned,
+	}
+
+	if s.symbol != nil {
+		r.setParam("symbol", *s.symbol)
+	}
+
+	data, err := s.c.callAPI(ctx, r)
+	if err != nil {
+		return res, err
+	}
+	res = make([]*TradeFeeDetails, 0)
+	err = json.Unmarshal(data, &res)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+// TradeFeeDetails represents details about fees
+type TradeFeeDetails struct {
+	Symbol          string `json:"symbol"`
+	MakerCommission string `json:"makerCommission"`
+	TakerCommission string `json:"takerCommission"`
+}

--- a/v2/trade_fee_service_test.go
+++ b/v2/trade_fee_service_test.go
@@ -1,0 +1,86 @@
+package binance
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type assetTradeFeeServiceSuite struct {
+	baseTestSuite
+}
+
+func (a *assetTradeFeeServiceSuite) assertTradeFeeServiceEqual(expected, other *TradeFeeDetails) {
+	r := a.r()
+
+	r.Equal(expected.Symbol, other.Symbol)
+	r.Equal(expected.MakerCommission, other.MakerCommission)
+	r.Equal(expected.TakerCommission, other.TakerCommission)
+}
+
+func TestTradeFeeService(t *testing.T) {
+	suite.Run(t, new(assetTradeFeeServiceSuite))
+}
+
+func (s *assetTradeFeeServiceSuite) TestListTradeFee() {
+	data := []byte(`
+	[
+		{
+			"symbol": "ADABNB",
+			"makerCommission": "0.001",
+			"takerCommission": "0.001"
+		},
+		{
+			"symbol": "BNBBTC",
+			"makerCommission": "0.001",
+			"takerCommission": "0.001"
+		}
+	]
+	`)
+
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	fees, err := s.client.NewTradeFeeService().Do(context.Background())
+	s.r().NoError(err)
+	rows := fees
+
+	s.Len(rows, 2)
+	s.assertTradeFeeServiceEqual(&TradeFeeDetails{
+		Symbol:          "ADABNB",
+		MakerCommission: "0.001",
+		TakerCommission: "0.001"},
+		rows[0])
+	s.assertTradeFeeServiceEqual(&TradeFeeDetails{
+		Symbol:          "BNBBTC",
+		MakerCommission: "0.001",
+		TakerCommission: "0.001"},
+		rows[1])
+}
+
+func (s *assetTradeFeeServiceSuite) TestSingleSymbolTradeFee() {
+	data := []byte(`
+	[
+		{
+			"symbol": "ADABNB",
+			"makerCommission": "0.001",
+			"takerCommission": "0.001"
+		}
+	]
+	`)
+
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	fees, err := s.client.NewTradeFeeService().Symbol("ADABNB").Do(context.Background())
+	s.r().NoError(err)
+	rows := fees
+
+	s.Len(rows, 1)
+	s.assertTradeFeeServiceEqual(&TradeFeeDetails{
+		Symbol:          "ADABNB",
+		MakerCommission: "0.001",
+		TakerCommission: "0.001"},
+		rows[0])
+}


### PR DESCRIPTION
Add:
 - `trade_fee_service` with tradeFee structure representation
 - basic tests for that service
 - client `NewTradeFeeService` to allow creation of new Trade Fee service

Fix #253