### PR TITLE
Add staking positions and history services

### DIFF
--- a/v2/client.go
+++ b/v2/client.go
@@ -75,6 +75,9 @@ type LendingType string
 // StakingProduct define the staking product (locked staking, flexible defi staking, locked defi staking, ...)
 type StakingProduct string
 
+// StakingTransactionType define the staking transaction type (subscription, redemption, interest)
+type StakingTransactionType string
+
 // Endpoints
 const (
 	baseAPIMainURL    = "https://api.binance.com"
@@ -177,6 +180,10 @@ const (
 	StakingProductLockedStaking       = "STAKING"
 	StakingProductFlexibleDeFiStaking = "F_DEFI"
 	StakingProductLockedDeFiStaking   = "L_DEFI"
+
+	StakingTransactionTypeSubscription = "SUBSCRIPTION"
+	StakingTransactionTypeRedemption   = "REDEMPTION"
+	StakingTransactionTypeInterest     = "INTEREST"
 )
 
 func currentTimestamp() int64 {
@@ -804,4 +811,9 @@ func (c *Client) NewC2CTradeHistoryService() *C2CTradeHistoryService {
 // NewStakingProductPositionService init the staking product position service
 func (c *Client) NewStakingProductPositionService() *StakingProductPositionService {
 	return &StakingProductPositionService{c: c}
+}
+
+// NewStakingHistoryService init the staking history service
+func (c *Client) NewStakingHistoryService() *StakingHistoryService {
+	return &StakingHistoryService{c: c}
 }

--- a/v2/client.go
+++ b/v2/client.go
@@ -72,6 +72,9 @@ type TransactionType string
 // LendingType define the type of lending (flexible saving, activity, ...)
 type LendingType string
 
+// StakingProduct define the staking product (locked staking, flexible defi staking, locked defi staking, ...)
+type StakingProduct string
+
 // Endpoints
 const (
 	baseAPIMainURL    = "https://api.binance.com"
@@ -170,6 +173,10 @@ const (
 	timestampKey  = "timestamp"
 	signatureKey  = "signature"
 	recvWindowKey = "recvWindow"
+
+	StakingProductLockedStaking       = "STAKING"
+	StakingProductFlexibleDeFiStaking = "F_DEFI"
+	StakingProductLockedDeFiStaking   = "L_DEFI"
 )
 
 func currentTimestamp() int64 {
@@ -792,4 +799,9 @@ func (c *Client) NewTradeFeeService() *TradeFeeService {
 // NewC2CTradeHistoryService init the c2c trade history service
 func (c *Client) NewC2CTradeHistoryService() *C2CTradeHistoryService {
 	return &C2CTradeHistoryService{c: c}
+}
+
+// NewStakingProductPositionService init the staking product position service
+func (c *Client) NewStakingProductPositionService() *StakingProductPositionService {
+	return &StakingProductPositionService{c: c}
 }

--- a/v2/staking_service.go
+++ b/v2/staking_service.go
@@ -80,6 +80,7 @@ func (s *StakingProductPositionService) Do(ctx context.Context) (*StakingProduct
 // StakingProductPositions represents a list of staking product positions.
 type StakingProductPositions []StakingProductPosition
 
+// StakingProductPosition represents a staking product position.
 type StakingProductPosition struct {
 	PositionId                 int64  `json:"positionId"`
 	ProductId                  string `json:"productId"`
@@ -107,4 +108,110 @@ type StakingProductPosition struct {
 	Renewable                  bool   `json:"renewable"`
 	Type                       string `json:"type"`
 	Status                     string `json:"status"`
+}
+
+// StakingHistoryService fetches the staking history
+type StakingHistoryService struct {
+	c               *Client
+	product         StakingProduct
+	transactionType StakingTransactionType
+	asset           *string
+	startTime       *int64
+	endTime         *int64
+	current         *int32
+	size            *int32
+}
+
+// Product sets the product parameter.
+func (s *StakingHistoryService) Product(product StakingProduct) *StakingHistoryService {
+	s.product = product
+	return s
+}
+
+// TransactionType sets the txnType parameter.
+func (s *StakingHistoryService) TransactionType(transactionType StakingTransactionType) *StakingHistoryService {
+	s.transactionType = transactionType
+	return s
+}
+
+// Asset sets the asset parameter.
+func (s *StakingHistoryService) Asset(asset string) *StakingHistoryService {
+	s.asset = &asset
+	return s
+}
+
+// StartTime sets the startTime parameter.
+func (s *StakingHistoryService) StartTime(startTime int64) *StakingHistoryService {
+	s.startTime = &startTime
+	return s
+}
+
+// EndTime sets the endTime parameter.
+func (s *StakingHistoryService) EndTime(endTime int64) *StakingHistoryService {
+	s.endTime = &endTime
+	return s
+}
+
+// Current sets the current parameter.
+func (s *StakingHistoryService) Current(current int32) *StakingHistoryService {
+	s.current = &current
+	return s
+}
+
+// Size sets the size parameter.
+func (s *StakingHistoryService) Size(size int32) *StakingHistoryService {
+	s.size = &size
+	return s
+}
+
+// Do sends the request.
+func (s *StakingHistoryService) Do(ctx context.Context) (*StakingHistory, error) {
+	r := &request{
+		method:   http.MethodGet,
+		endpoint: "/sapi/v1/staking/stakingRecord",
+		secType:  secTypeSigned,
+	}
+	r.setParam("product", s.product)
+	r.setParam("txnType", s.transactionType)
+	if s.asset != nil {
+		r.setParam("asset", *s.asset)
+	}
+	if s.startTime != nil {
+		r.setParam("startTime", *s.startTime)
+	}
+	if s.endTime != nil {
+		r.setParam("endTime", *s.endTime)
+	}
+	if s.current != nil {
+		r.setParam("current", *s.current)
+	}
+	if s.size != nil {
+		r.setParam("size", *s.size)
+	}
+	data, err := s.c.callAPI(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+	res := new(StakingHistory)
+	err = json.Unmarshal(data, res)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+// StakingHistory represents a list of staking history transactions.
+type StakingHistory []StakingHistoryTransaction
+
+// StakingHistoryTransaction represents a staking history transaction.
+type StakingHistoryTransaction struct {
+	PositionId  int64  `json:"positionId"`
+	Time        int64  `json:"time"`
+	Asset       string `json:"asset"`
+	Project     string `json:"project"`
+	Amount      string `json:"amount"`
+	LockPeriod  int64  `json:"lockPeriod"`
+	DeliverDate int64  `json:"deliverDate"`
+	Type        string `json:"type"`
+	Status      string `json:"status"`
 }

--- a/v2/staking_service.go
+++ b/v2/staking_service.go
@@ -1,0 +1,110 @@
+package binance
+
+import (
+	"context"
+	"net/http"
+)
+
+// StakingProductPositionService fetches the staking product positions
+type StakingProductPositionService struct {
+	c         *Client
+	product   StakingProduct
+	productId *string
+	asset     *string
+	current   *int32
+	size      *int32
+}
+
+// Product sets the product parameter.
+func (s *StakingProductPositionService) Product(product StakingProduct) *StakingProductPositionService {
+	s.product = product
+	return s
+}
+
+// ProductId sets the productId parameter.
+func (s *StakingProductPositionService) ProductId(productId string) *StakingProductPositionService {
+	s.productId = &productId
+	return s
+}
+
+// Asset sets the asset parameter.
+func (s *StakingProductPositionService) Asset(asset string) *StakingProductPositionService {
+	s.asset = &asset
+	return s
+}
+
+// Current sets the current parameter.
+func (s *StakingProductPositionService) Current(current int32) *StakingProductPositionService {
+	s.current = &current
+	return s
+}
+
+// Size sets the size parameter.
+func (s *StakingProductPositionService) Size(size int32) *StakingProductPositionService {
+	s.size = &size
+	return s
+}
+
+// Do sends the request.
+func (s *StakingProductPositionService) Do(ctx context.Context) (*StakingProductPositions, error) {
+	r := &request{
+		method:   http.MethodGet,
+		endpoint: "/sapi/v1/staking/position",
+		secType:  secTypeSigned,
+	}
+	r.setParam("product", s.product)
+	if s.productId != nil {
+		r.setParam("productId", *s.productId)
+	}
+	if s.asset != nil {
+		r.setParam("asset", *s.asset)
+	}
+	if s.current != nil {
+		r.setParam("current", *s.current)
+	}
+	if s.size != nil {
+		r.setParam("size", *s.size)
+	}
+	data, err := s.c.callAPI(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+	res := new(StakingProductPositions)
+	err = json.Unmarshal(data, res)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+// StakingProductPositions represents a list of staking product positions.
+type StakingProductPositions []StakingProductPosition
+
+type StakingProductPosition struct {
+	PositionId                 int64  `json:"positionId"`
+	ProductId                  string `json:"productId"`
+	Asset                      string `json:"asset"`
+	Amount                     string `json:"amount"`
+	PurchaseTime               int64  `json:"purchaseTime"`
+	Duration                   int64  `json:"duration"`
+	AccrualDays                int64  `json:"accrualDays"`
+	RewardAsset                string `json:"rewardAsset"`
+	APY                        string `json:"apy"`
+	RewardAmount               string `json:"rewardAmt"`
+	ExtraRewardAsset           string `json:"extraRewardAsset"`
+	ExtraRewardAPY             string `json:"extraRewardAPY"`
+	EstimatedExtraRewardAmount string `json:"estExtraRewardAmt"`
+	NextInterestPay            string `json:"nextInterestPay"`
+	NextInterestPayDate        string `json:"nextInterestPayDate"`
+	PayInterestPeriod          int64  `json:"payInterestPeriod"`
+	RedeemAmountEarly          string `json:"redeemAmountEarly"`
+	InterestEndDate            int64  `json:"interestEndDate"`
+	DeliverDate                int64  `json:"deliverDate"`
+	RedeemPeriod               int64  `json:"redeemPeriod"`
+	RedeemingAmount            string `json:"redeemingAmt"`
+	PartialAmountDeliverDate   int64  `json:"partialAmtDeliverDate"`
+	CanRedeemEarly             bool   `json:"canRedeemEarly"`
+	Renewable                  bool   `json:"renewable"`
+	Type                       string `json:"type"`
+	Status                     string `json:"status"`
+}

--- a/v2/staking_service_test.go
+++ b/v2/staking_service_test.go
@@ -1,0 +1,130 @@
+package binance
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type stakingServiceTestSuite struct {
+	baseTestSuite
+}
+
+func TestStakingService(t *testing.T) {
+	suite.Run(t, new(stakingServiceTestSuite))
+}
+
+func (s *stakingServiceTestSuite) TestStakingProductPosition() {
+	data := []byte(`[
+	  {
+		"positionId": 123123,
+		"productId": "Axs*90",
+		"asset": "AXS",
+		"amount": "122.09202928",
+		"purchaseTime": 1646182276000,
+		"duration": 60,
+		"accrualDays": 4,
+		"rewardAsset": "AXS",
+		"APY": "0.2032",
+		"rewardAmt": "5.17181528",
+		"extraRewardAsset": "BNB",
+		"extraRewardAPY": "0.0203",
+		"estExtraRewardAmt": "5.17181528",
+		"nextInterestPay": "1.29295383",
+		"nextInterestPayDate": "1646697600000",
+		"payInterestPeriod": 1,
+		"redeemAmountEarly": "2802.24068892",
+		"interestEndDate": 1651449600000,
+		"deliverDate": 1651536000000,
+		"redeemPeriod": 1,
+		"redeemingAmt": "232.2323",
+		"partialAmtDeliverDate": 1651536000000,
+		"canRedeemEarly": true,
+		"renewable": true,
+		"type": "AUTO",
+		"status": "HOLDING"
+	  }
+	]`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	s.assertReq(func(r *request) {
+		e := newSignedRequest().setParams(params{
+			"product": StakingProductLockedStaking,
+		})
+		s.assertRequestEqual(e, r)
+	})
+
+	res, err := s.client.NewStakingProductPositionService().
+		Product(StakingProductLockedStaking).
+		Do(newContext())
+	s.r().NoError(err)
+	e := &StakingProductPositions{
+		{
+			PositionId:                 123123,
+			ProductId:                  "Axs*90",
+			Asset:                      "AXS",
+			Amount:                     "122.09202928",
+			PurchaseTime:               1646182276000,
+			Duration:                   60,
+			AccrualDays:                4,
+			RewardAsset:                "AXS",
+			APY:                        "0.2032",
+			RewardAmount:               "5.17181528",
+			ExtraRewardAsset:           "BNB",
+			ExtraRewardAPY:             "0.0203",
+			EstimatedExtraRewardAmount: "5.17181528",
+			NextInterestPay:            "1.29295383",
+			NextInterestPayDate:        "1646697600000",
+			PayInterestPeriod:          1,
+			RedeemAmountEarly:          "2802.24068892",
+			InterestEndDate:            1651449600000,
+			DeliverDate:                1651536000000,
+			RedeemPeriod:               1,
+			RedeemingAmount:            "232.2323",
+			PartialAmountDeliverDate:   1651536000000,
+			CanRedeemEarly:             true,
+			Renewable:                  true,
+			Type:                       "AUTO",
+			Status:                     "HOLDING",
+		},
+	}
+	s.assertStakingProductPositionsEqual(e, res)
+}
+
+func (s *stakingServiceTestSuite) assertStakingProductPositionsEqual(e, a *StakingProductPositions) {
+	r := s.r()
+	r.Len(*a, len(*e))
+	for i := 0; i < len(*a); i++ {
+		s.assertStakingProductPositionEqual(&(*e)[i], &(*a)[i])
+	}
+}
+
+func (s *stakingServiceTestSuite) assertStakingProductPositionEqual(e, a *StakingProductPosition) {
+	r := s.r()
+	r.Equal(e.PositionId, a.PositionId, "PositionId")
+	r.Equal(e.ProductId, a.ProductId, "ProductId")
+	r.Equal(e.Asset, a.Asset, "Asset")
+	r.Equal(e.Amount, a.Amount, "Amount")
+	r.Equal(e.PurchaseTime, a.PurchaseTime, "PurchaseTime")
+	r.Equal(e.Duration, a.Duration, "Duration")
+	r.Equal(e.AccrualDays, a.AccrualDays, "AccrualDays")
+	r.Equal(e.RewardAsset, a.RewardAsset, "RewardAsset")
+	r.Equal(e.APY, a.APY, "APY")
+	r.Equal(e.RewardAmount, a.RewardAmount, "RewardAmount")
+	r.Equal(e.ExtraRewardAsset, a.ExtraRewardAsset, "ExtraRewardAsset")
+	r.Equal(e.ExtraRewardAPY, a.ExtraRewardAPY, "ExtraRewardAPY")
+	r.Equal(e.EstimatedExtraRewardAmount, a.EstimatedExtraRewardAmount, "EstimatedExtraRewardAmount")
+	r.Equal(e.NextInterestPay, a.NextInterestPay, "NextInterestPay")
+	r.Equal(e.NextInterestPayDate, a.NextInterestPayDate, "NextInterestPayDate")
+	r.Equal(e.PayInterestPeriod, a.PayInterestPeriod, "PayInterestPeriod")
+	r.Equal(e.RedeemAmountEarly, a.RedeemAmountEarly, "RedeemAmountEarly")
+	r.Equal(e.InterestEndDate, a.InterestEndDate, "InterestEndDate")
+	r.Equal(e.DeliverDate, a.DeliverDate, "DeliverDate")
+	r.Equal(e.RedeemPeriod, a.RedeemPeriod, "RedeemPeriod")
+	r.Equal(e.RedeemingAmount, a.RedeemingAmount, "RedeemingAmount")
+	r.Equal(e.PartialAmountDeliverDate, a.PartialAmountDeliverDate, "PartialAmountDeliverDate")
+	r.Equal(e.CanRedeemEarly, a.CanRedeemEarly, "CanRedeemEarly")
+	r.Equal(e.Renewable, a.Renewable, "Renewable")
+	r.Equal(e.Type, a.Type, "Type")
+	r.Equal(e.Status, a.Status, "Status")
+}

--- a/v2/staking_service_test.go
+++ b/v2/staking_service_test.go
@@ -128,3 +128,70 @@ func (s *stakingServiceTestSuite) assertStakingProductPositionEqual(e, a *Stakin
 	r.Equal(e.Type, a.Type, "Type")
 	r.Equal(e.Status, a.Status, "Status")
 }
+
+func (s *stakingServiceTestSuite) TestStakingHistory() {
+	data := []byte(`[
+	  {
+		"positionId": 123123,
+		"time": 1575018510000,
+		"asset": "BNB",
+		"project": "BSC",
+		"amount": "21312.23223",
+		"lockPeriod": 30,
+		"deliverDate": 1575018510000,
+		"type": "AUTO",
+		"status": "success"
+	  }
+	]`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	s.assertReq(func(r *request) {
+		e := newSignedRequest().setParams(params{
+			"product": StakingProductLockedStaking,
+			"txnType": StakingTransactionTypeSubscription,
+		})
+		s.assertRequestEqual(e, r)
+	})
+
+	res, err := s.client.NewStakingHistoryService().
+		Product(StakingProductLockedStaking).
+		TransactionType(StakingTransactionTypeSubscription).
+		Do(newContext())
+	s.r().NoError(err)
+	e := &StakingHistory{
+		{
+			PositionId:  123123,
+			Time:        1575018510000,
+			Asset:       "BNB",
+			Project:     "BSC",
+			Amount:      "21312.23223",
+			LockPeriod:  30,
+			DeliverDate: 1575018510000,
+			Type:        "AUTO",
+			Status:      "success",
+		},
+	}
+	s.assertStakingHistoryEqual(e, res)
+}
+
+func (s *stakingServiceTestSuite) assertStakingHistoryEqual(e, a *StakingHistory) {
+	r := s.r()
+	r.Len(*a, len(*e))
+	for i := 0; i < len(*a); i++ {
+		s.assertStakingHistoryTransactionEqual(&(*e)[i], &(*a)[i])
+	}
+}
+
+func (s *stakingServiceTestSuite) assertStakingHistoryTransactionEqual(e, a *StakingHistoryTransaction) {
+	r := s.r()
+	r.Equal(e.PositionId, a.PositionId, "PositionId")
+	r.Equal(e.Time, a.Time, "Time")
+	r.Equal(e.Asset, a.Asset, "Asset")
+	r.Equal(e.Project, a.Project, "Project")
+	r.Equal(e.Amount, a.Amount, "Amount")
+	r.Equal(e.LockPeriod, a.LockPeriod, "LockPeriod")
+	r.Equal(e.DeliverDate, a.DeliverDate, "DeliverDate")
+	r.Equal(e.Type, a.Type, "Type")
+	r.Equal(e.Status, a.Status, "Status")
+}


### PR DESCRIPTION
Add some services from the new [stacking](https://binance-docs.github.io/apidocs/spot/en/#staking-endpoints) endpoints:
  - Get Staking Product Position (`/sapi/v1/staking/position`)
  - Get Staking History (`/sapi/v1/staking/stakingRecord`)