### PR TITLE
Fix Unmarshal error on ListDeposits API response

### DIFF
--- a/v2/deposit_service.go
+++ b/v2/deposit_service.go
@@ -105,7 +105,7 @@ type Deposit struct {
 	TxID          string `json:"txId"`
 	InsertTime    int64  `json:"insertTime"`
 	TransferType  int64  `json:"transferType"`
-	UnlockConfirm string `json:"unlockConfirm"`
+	UnlockConfirm int64  `json:"unlockConfirm"`
 	ConfirmTimes  string `json:"confirmTimes"`
 }
 

--- a/v2/deposit_service_test.go
+++ b/v2/deposit_service_test.go
@@ -26,7 +26,7 @@ func (s *depositServiceTestSuite) TestListDeposits() {
         "txId":"0xaad4654a3234aa6118af9b4b335f5ae81c360b2394721c019b5d1e75328b09f3",
         "insertTime":1599621997000,
         "transferType":0,
-        "unlockConfirm":"12/12",
+        "unlockConfirm":12,
         "confirmTimes":"12/12"
     },
     {
@@ -39,7 +39,7 @@ func (s *depositServiceTestSuite) TestListDeposits() {
         "txId":"ESBFVQUTPIWQNJSPXFNHNYHSQNTGKRVKPRABQWTAXCDWOAKDKYWPTVG9BGXNVNKTLEJGESAVXIKIZ9999",
         "insertTime":1599620082000,
         "transferType":0,
-        "unlockConfirm":"1/12",
+        "unlockConfirm":1,
         "confirmTimes":"1/1"
     }
 ]`)
@@ -79,7 +79,7 @@ func (s *depositServiceTestSuite) TestListDeposits() {
 		TxID:          "0xaad4654a3234aa6118af9b4b335f5ae81c360b2394721c019b5d1e75328b09f3",
 		InsertTime:    1599621997000,
 		TransferType:  0,
-		UnlockConfirm: "12/12",
+		UnlockConfirm: 12,
 		ConfirmTimes:  "12/12",
 	}, deposits[0])
 	s.assertDepositEqual(&Deposit{
@@ -92,7 +92,7 @@ func (s *depositServiceTestSuite) TestListDeposits() {
 		TxID:          "ESBFVQUTPIWQNJSPXFNHNYHSQNTGKRVKPRABQWTAXCDWOAKDKYWPTVG9BGXNVNKTLEJGESAVXIKIZ9999",
 		InsertTime:    1599620082000,
 		TransferType:  0,
-		UnlockConfirm: "1/12",
+		UnlockConfirm: 1,
 		ConfirmTimes:  "1/1",
 	}, deposits[1])
 }


### PR DESCRIPTION
It is written in the [documentation](https://binance-docs.github.io/apidocs/spot/en/#deposit-history-supporting-network-user_data) that the field is string, but in fact it returns int, which causes an error.

However, elsewhere in the [documentation](https://binance-docs.github.io/apidocs/spot/en/#all-coins-39-information-user_data) the field is already an integer.

`"unLockConfirm": 0,  // confirmation number for balance unlock`