### PR TITLE
Added a "Symbols" parameters to ListPricesService

### DIFF
--- a/v2/ticker_service.go
+++ b/v2/ticker_service.go
@@ -2,6 +2,7 @@ package binance
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/adshao/go-binance/v2/common"
@@ -52,8 +53,9 @@ type BookTicker struct {
 
 // ListPricesService list latest price for a symbol or symbols
 type ListPricesService struct {
-	c      *Client
-	symbol *string
+	c       *Client
+	symbol  *string
+	symbols *string
 }
 
 // Symbol set symbol
@@ -70,6 +72,8 @@ func (s *ListPricesService) Do(ctx context.Context, opts ...RequestOption) (res 
 	}
 	if s.symbol != nil {
 		r.setParam("symbol", *s.symbol)
+	} else if s.symbols != nil {
+		r.setParam("symbols", *s.symbols)
 	}
 	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
@@ -99,6 +103,21 @@ type ListPriceChangeStatsService struct {
 // Symbol set symbol
 func (s *ListPriceChangeStatsService) Symbol(symbol string) *ListPriceChangeStatsService {
 	s.symbol = &symbol
+	return s
+}
+
+// Symbols set symbols
+func (s *ListPricesService) Symbols(symbols []*string) *ListPricesService {
+	symbolsParam := `[`
+	for i, symbol := range symbols {
+		symbolsParam = fmt.Sprintf("%v\"%v\"", symbolsParam, *symbol)
+		if i != len(symbols)-1 {
+			symbolsParam = fmt.Sprintf("%v,", symbolsParam)
+		}
+	}
+	symbolsParam = fmt.Sprintf("%v]", symbolsParam)
+
+	s.symbols = &symbolsParam
 	return s
 }
 

--- a/v2/ticker_service.go
+++ b/v2/ticker_service.go
@@ -2,7 +2,6 @@ package binance
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 
 	"github.com/adshao/go-binance/v2/common"
@@ -55,7 +54,7 @@ type BookTicker struct {
 type ListPricesService struct {
 	c       *Client
 	symbol  *string
-	symbols *string
+	symbols []string
 }
 
 // Symbol set symbol
@@ -73,7 +72,8 @@ func (s *ListPricesService) Do(ctx context.Context, opts ...RequestOption) (res 
 	if s.symbol != nil {
 		r.setParam("symbol", *s.symbol)
 	} else if s.symbols != nil {
-		r.setParam("symbols", *s.symbols)
+		s, _ := json.Marshal(s.symbols)
+		r.setParam("symbols", string(s))
 	}
 	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
@@ -107,17 +107,8 @@ func (s *ListPriceChangeStatsService) Symbol(symbol string) *ListPriceChangeStat
 }
 
 // Symbols set symbols
-func (s *ListPricesService) Symbols(symbols []*string) *ListPricesService {
-	symbolsParam := `[`
-	for i, symbol := range symbols {
-		symbolsParam = fmt.Sprintf("%v\"%v\"", symbolsParam, *symbol)
-		if i != len(symbols)-1 {
-			symbolsParam = fmt.Sprintf("%v,", symbolsParam)
-		}
-	}
-	symbolsParam = fmt.Sprintf("%v]", symbolsParam)
-
-	s.symbols = &symbolsParam
+func (s *ListPricesService) Symbols(symbols []string) *ListPricesService {
+	s.symbols = symbols
 	return s
 }
 

--- a/v2/ticker_service_test.go
+++ b/v2/ticker_service_test.go
@@ -157,10 +157,10 @@ func (s *tickerServiceTestSuite) TestListPricesForMultipleSymbols() {
 	})
 
 	symbol1, symbol2 := "ETHUSDT", "LTCBTC"
-	symbols := make([]*string, 2)
+	symbols := make([]string, 2)
 
-	symbols[0] = &symbol1
-	symbols[1] = &symbol2
+	symbols[0] = symbol1
+	symbols[1] = symbol2
 
 	s.assertReq(func(r *request) {
 		e := newRequest().setParam("symbols", `["ETHUSDT","LTCBTC"]`)

--- a/v2/ticker_service_test.go
+++ b/v2/ticker_service_test.go
@@ -137,6 +137,52 @@ func (s *tickerServiceTestSuite) TestListPrices() {
 	s.assertSymbolPriceEqual(e2, prices[1])
 }
 
+func (s *tickerServiceTestSuite) TestListPricesForMultipleSymbols() {
+	data := []byte(`[
+        {
+            "symbol": "LTCBTC",
+            "price": "4.00000200"
+        },
+        {
+            "symbol": "ETHUSDT",
+            "price": "2856.76"
+        }
+    ]`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	s.assertReq(func(r *request) {
+		e := newRequest()
+		s.assertRequestEqual(e, r)
+	})
+
+	symbol1, symbol2 := "ETHUSDT", "LTCBTC"
+	symbols := make([]*string, 2)
+
+	symbols[0] = &symbol1
+	symbols[1] = &symbol2
+
+	s.assertReq(func(r *request) {
+		e := newRequest().setParam("symbols", `["ETHUSDT","LTCBTC"]`)
+		s.assertRequestEqual(e, r)
+	})
+
+	prices, err := s.client.NewListPricesService().Symbols(symbols).Do(newContext())
+	r := s.r()
+	r.NoError(err)
+	r.Len(prices, 2)
+	e1 := &SymbolPrice{
+		Symbol: "LTCBTC",
+		Price:  "4.00000200",
+	}
+	e2 := &SymbolPrice{
+		Symbol: "ETHUSDT",
+		Price:  "2856.76",
+	}
+	s.assertSymbolPriceEqual(e1, prices[0])
+	s.assertSymbolPriceEqual(e2, prices[1])
+}
+
 func (s *tickerServiceTestSuite) TestListSinglePrice() {
 	data := []byte(`{
 		"symbol": "LTCBTC",


### PR DESCRIPTION
#380 
Added the "Symbols" parameters as specified in [https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#symbol-price-ticker](url)
Corresponding unit test "TestListPricesForMultipleSymbols" was added, too.