### PR TITLE
feat(futures): include get open interest call

### DIFF
--- a/v2/futures/client.go
+++ b/v2/futures/client.go
@@ -563,3 +563,8 @@ func (c *Client) NewGetRebateNewUserService() *GetRebateNewUserService {
 func (c *Client) NewCommissionRateService() *CommissionRateService {
 	return &CommissionRateService{c: c}
 }
+
+// NewGetOpenInterestService init open interest service
+func (c *Client) NewGetOpenInterestService() *GetOpenInterestService {
+	return &GetOpenInterestService{c: c}
+}

--- a/v2/futures/client.go
+++ b/v2/futures/client.go
@@ -568,3 +568,8 @@ func (c *Client) NewCommissionRateService() *CommissionRateService {
 func (c *Client) NewGetOpenInterestService() *GetOpenInterestService {
 	return &GetOpenInterestService{c: c}
 }
+
+// NewOpenInterestStatisticsService init open interest statistics service
+func (c *Client) NewOpenInterestStatisticsService() *OpenInterestStatisticsService {
+	return &OpenInterestStatisticsService{c: c}
+}

--- a/v2/futures/openinterest_service.go
+++ b/v2/futures/openinterest_service.go
@@ -1,0 +1,46 @@
+package futures
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+)
+
+// GetOpenInterestService get present open interest of a specific symbol.
+type GetOpenInterestService struct {
+	c      *Client
+	symbol string
+}
+
+// Symbol set symbol
+func (s *GetOpenInterestService) Symbol(symbol string) *GetOpenInterestService {
+	s.symbol = symbol
+	return s
+}
+
+// Do send request
+func (s *GetOpenInterestService) Do(ctx context.Context, opts ...RequestOption) (res *OpenInterest, err error) {
+	r := &request{
+		method:   http.MethodGet,
+		endpoint: "/fapi/v1/openInterest",
+	}
+	r.setParam("symbol", s.symbol)
+	data, _, err := s.c.callAPI(ctx, r, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	res = new(OpenInterest)
+	err = json.Unmarshal(data, &res)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+type OpenInterest struct {
+	OpenInterest string `json:"openInterest"`
+	Symbol       string `json:"symbol"`
+	Time         int64  `json:"time"`
+}

--- a/v2/futures/openinterest_service.go
+++ b/v2/futures/openinterest_service.go
@@ -44,3 +44,84 @@ type OpenInterest struct {
 	Symbol       string `json:"symbol"`
 	Time         int64  `json:"time"`
 }
+
+// OpenInterestStatisticsService list open history data of a symbol.
+type OpenInterestStatisticsService struct {
+	c         *Client
+	symbol    string
+	period    string
+	limit     *int
+	startTime *int64
+	endTime   *int64
+}
+
+// Symbol set symbol
+func (s *OpenInterestStatisticsService) Symbol(symbol string) *OpenInterestStatisticsService {
+	s.symbol = symbol
+	return s
+}
+
+// Period set period interval
+func (s *OpenInterestStatisticsService) Period(period string) *OpenInterestStatisticsService {
+	s.period = period
+	return s
+}
+
+// Limit set limit
+func (s *OpenInterestStatisticsService) Limit(limit int) *OpenInterestStatisticsService {
+	s.limit = &limit
+	return s
+}
+
+// StartTime set startTime
+func (s *OpenInterestStatisticsService) StartTime(startTime int64) *OpenInterestStatisticsService {
+	s.startTime = &startTime
+	return s
+}
+
+// EndTime set endTime
+func (s *OpenInterestStatisticsService) EndTime(endTime int64) *OpenInterestStatisticsService {
+	s.endTime = &endTime
+	return s
+}
+
+// Do send request
+func (s *OpenInterestStatisticsService) Do(ctx context.Context, opts ...RequestOption) (res []*OpenInterestStatistic, err error) {
+	r := &request{
+		method:   http.MethodGet,
+		endpoint: "/futures/data/openInterestHist",
+	}
+
+	r.setParam("symbol", s.symbol)
+	r.setParam("period", s.period)
+
+	if s.limit != nil {
+		r.setParam("limit", *s.limit)
+	}
+	if s.startTime != nil {
+		r.setParam("startTime", *s.startTime)
+	}
+	if s.endTime != nil {
+		r.setParam("endTime", *s.endTime)
+	}
+
+	data, _, err := s.c.callAPI(ctx, r, opts...)
+	if err != nil {
+		return []*OpenInterestStatistic{}, err
+	}
+
+	res = make([]*OpenInterestStatistic, 0)
+	err = json.Unmarshal(data, &res)
+	if err != nil {
+		return []*OpenInterestStatistic{}, err
+	}
+
+	return res, nil
+}
+
+type OpenInterestStatistic struct {
+	Symbol               string `json:"symbol"`
+	SumOpenInterest      string `json:"sumOpenInterest"`
+	SumOpenInterestValue string `json:"sumOpenInterestValue"`
+	Timestamp            int64  `json:"timestamp"`
+}

--- a/v2/futures/openinterest_service_test.go
+++ b/v2/futures/openinterest_service_test.go
@@ -1,0 +1,46 @@
+package futures
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type openInterestServiceTestSuite struct {
+	baseTestSuite
+}
+
+func TestGetOpenInterestService(t *testing.T) {
+	suite.Run(t, new(openInterestServiceTestSuite))
+}
+
+func (s *openInterestServiceTestSuite) TestGetOpenInterest() {
+	data := []byte(`{
+		"openInterest": "10659.509", 
+		"symbol": "BTCUSDT",
+		"time": 1589437530011
+	}`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	symbol := "BTCUSDT"
+	s.assertReq(func(r *request) {
+		e := newRequest().setParams(params{
+			"symbol": symbol,
+		})
+		s.assertRequestEqual(e, r)
+	})
+
+	res, err := s.client.NewGetOpenInterestService().Symbol(symbol).Do(newContext())
+	s.r().NoError(err)
+
+	e := &OpenInterest{
+		Symbol:       symbol,
+		Time:         1589437530011,
+		OpenInterest: "10659.509",
+	}
+
+	s.r().Equal(e.Symbol, res.Symbol, "Symbol")
+	s.r().Equal(e.OpenInterest, res.OpenInterest, "OpenInterest")
+	s.r().Equal(e.Time, res.Time, "Time")
+}


### PR DESCRIPTION
Include service for:
- Open Interest data: https://binance-docs.github.io/apidocs/futures/en/#open-interest
- Open interest statistics: https://binance-docs.github.io/apidocs/futures/en/#open-interest-statistics

Example of usage:
```go
        openInterest, err := c.client.NewGetOpenInterestService().Symbol("BTCUSDT").Do(ctx)
	if err != nil {
		return err
	}

	fmt.Printf(" %+v\n", openInterest)

	statistics, err := c.client.NewOpenInterestStatisticsService().
		Symbol("BTCUSDT").Period("1h").
		Limit(24).
		Do(ctx)

	for i, statistic := range statistics {
		fmt.Printf("%d: %+v\n", i, statistic)
	}
```