### PR TITLE
#403 - Added support for GET /api/v3/ticker

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Force CRLF for all text files.
+**/* text eol=crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-# Force CRLF for all text files.
-**/* text eol=crlf
+# Force LF for all text files.
+**/* text eol=lf

--- a/v2/client.go
+++ b/v2/client.go
@@ -458,6 +458,11 @@ func (c *Client) NewListBookTickersService() *ListBookTickersService {
 	return &ListBookTickersService{c: c}
 }
 
+// NewListSymbolTickerService init listing symbols tickers
+func (c *Client) NewListSymbolTickerService() *ListSymbolTickerService {
+	return &ListSymbolTickerService{c: c}
+}
+
 // NewCreateOrderService init creating order service
 func (c *Client) NewCreateOrderService() *CreateOrderService {
 	return &CreateOrderService{c: c}

--- a/v2/ticker_service.go
+++ b/v2/ticker_service.go
@@ -193,3 +193,61 @@ type AvgPrice struct {
 	Mins  int64  `json:"mins"`
 	Price string `json:"price"`
 }
+
+type ListSymbolTickerService struct {
+	c       *Client
+	symbol  *string
+	symbols []string
+}
+
+type SymbolTicker struct {
+	Symbol             string `json:"symbol"`
+	PriceChange        string `json:"priceChange"`
+	PriceChangePercent string `json:"priceChangePercent"`
+	WeightedAvgPrice   string `json:"weightedAvgPrice"`
+	OpenPrice          string `json:"openPrice"`
+	HighPrice          string `json:"highPrice"`
+	LowPrice           string `json:"lowPrice"`
+	LastPrice          string `json:"lastPrice"`
+	Volume             string `json:"volume"`
+	QuoteVolume        string `json:"quoteVolume"`
+	OpenTime           int64  `json:"openTime"`
+	CloseTime          int64  `json:"closeTime"`
+	FirstId            int64  `json:"firstId"`
+	LastId             int64  `json:"lastId"`
+	Count              int64  `json:"count"`
+}
+
+func (s *ListSymbolTickerService) Symbol(symbol string) *ListSymbolTickerService {
+	s.symbol = &symbol
+	return s
+}
+
+func (s *ListSymbolTickerService) Symbols(symbols []string) *ListSymbolTickerService {
+	s.symbols = symbols
+	return s
+}
+
+func (s *ListSymbolTickerService) Do(ctx context.Context, opts ...RequestOption) (res []*SymbolTicker, err error) {
+	r := &request{
+		method:   http.MethodGet,
+		endpoint: "/api/v3/ticker",
+	}
+	if s.symbol != nil {
+		r.setParam("symbol", *s.symbol)
+	} else if s.symbols != nil {
+		s, _ := json.Marshal(s.symbols)
+		r.setParam("symbols", string(s))
+	}
+	data, err := s.c.callAPI(ctx, r, opts...)
+	data = common.ToJSONList(data)
+	if err != nil {
+		return []*SymbolTicker{}, err
+	}
+	res = make([]*SymbolTicker, 0)
+	err = json.Unmarshal(data, &res)
+	if err != nil {
+		return []*SymbolTicker{}, err
+	}
+	return res, nil
+}

--- a/v2/ticker_service_test.go
+++ b/v2/ticker_service_test.go
@@ -401,3 +401,76 @@ func (s *tickerServiceTestSuite) assertAvgPrice(e, a *AvgPrice) {
 	s.r().Equal(e.Mins, a.Mins, "Mins")
 	s.r().Equal(e.Price, a.Price, "Price")
 }
+
+func (s *tickerServiceTestSuite) TestListSymbolTicker() {
+	data := []byte(`[
+		{
+			"symbol": "ETHBTC",
+			"priceChange": "0.00004700",
+			"priceChangePercent": "0.066",
+			"weightedAvgPrice": "0.07168666",
+			"openPrice": "0.07093500",
+			"highPrice": "0.07321800",
+			"lowPrice": "0.07054200",
+			"lastPrice": "0.07098200",
+			"volume": "86992.33370000",
+			"quoteVolume": "6236.18963157",
+			"openTime": 1659097380000,
+			"closeTime": 1659183780986,
+			"firstId": 359930693,
+			"lastId": 360209854,
+			"count": 279162
+		}
+	]`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	symbol := "ETHBTC"
+	s.assertReq(func(r *request) {
+		e := newRequest().setParam("symbol", symbol)
+		s.assertRequestEqual(e, r)
+	})
+
+	res, err := s.client.NewListSymbolTickerService().Symbol(symbol).Do(newContext())
+	r := s.r()
+	r.NoError(err)
+	e := make([]*SymbolTicker, 0)
+	e = append(e, &SymbolTicker{
+		Symbol:             "ETHBTC",
+		PriceChange:        "0.00004700",
+		PriceChangePercent: "0.066",
+		WeightedAvgPrice:   "0.07168666",
+		OpenPrice:          "0.07093500",
+		HighPrice:          "0.07321800",
+		LowPrice:           "0.07054200",
+		LastPrice:          "0.07098200",
+		Volume:             "86992.33370000",
+		QuoteVolume:        "6236.18963157",
+		OpenTime:           1659097380000,
+		CloseTime:          1659183780986,
+		FirstId:            359930693,
+		LastId:             360209854,
+		Count:              279162,
+	})
+	s.assertSymbolTicker(e, res)
+}
+
+func (s *tickerServiceTestSuite) assertSymbolTicker(e, st []*SymbolTicker) {
+	for i := range e {
+		s.r().Equal(e[i].Symbol, st[i].Symbol, "Symbol")
+		s.r().Equal(e[i].PriceChange, st[i].PriceChange, "PriceChange")
+		s.r().Equal(e[i].PriceChangePercent, st[i].PriceChangePercent, "PriceChangePercent")
+		s.r().Equal(e[i].WeightedAvgPrice, st[i].WeightedAvgPrice, "WeightedAvgPrice")
+		s.r().Equal(e[i].OpenPrice, st[i].OpenPrice, "OpenPrice")
+		s.r().Equal(e[i].HighPrice, st[i].HighPrice, "HighPrice")
+		s.r().Equal(e[i].LowPrice, st[i].LowPrice, "LowPrice")
+		s.r().Equal(e[i].LastPrice, st[i].LastPrice, "LastPrice")
+		s.r().Equal(e[i].Volume, st[i].Volume, "Volume")
+		s.r().Equal(e[i].QuoteVolume, st[i].QuoteVolume, "QuoteVolume")
+		s.r().Equal(e[i].OpenTime, st[i].OpenTime, "OpenTime")
+		s.r().Equal(e[i].CloseTime, st[i].CloseTime, "CloseTime")
+		s.r().Equal(e[i].FirstId, st[i].FirstId, "FirstId")
+		s.r().Equal(e[i].LastId, st[i].LastId, "LastId")
+		s.r().Equal(e[i].Count, st[i].Count, "Count")
+	}
+}


### PR DESCRIPTION
Addresses issue #403 

- Added `.gitattributes` to prevent the git of other platforms from modifying files line ending (Windows Git is known for doing that). I set it to `LF` since it's wide compatible.
- Added new service: **ListSymbolTickerService**
- Added test case for the new service
