### PR TITLE
feat(futures): include long short ration service

### DIFF
--- a/v2/futures/client.go
+++ b/v2/futures/client.go
@@ -211,7 +211,7 @@ func NewClient(apiKey, secretKey string) *Client {
 	}
 }
 
-//NewProxiedClient passing a proxy url
+// NewProxiedClient passing a proxy url
 func NewProxiedClient(apiKey, secretKey, proxyUrl string) *Client {
 	proxy, err := url.Parse(proxyUrl)
 	if err != nil {
@@ -572,4 +572,9 @@ func (c *Client) NewGetOpenInterestService() *GetOpenInterestService {
 // NewOpenInterestStatisticsService init open interest statistics service
 func (c *Client) NewOpenInterestStatisticsService() *OpenInterestStatisticsService {
 	return &OpenInterestStatisticsService{c: c}
+}
+
+// NewLongShortRatioService init open interest statistics service
+func (c *Client) NewLongShortRatioService() *LongShortRatioService {
+	return &LongShortRatioService{c: c}
 }

--- a/v2/futures/longshort_ratio_service.go
+++ b/v2/futures/longshort_ratio_service.go
@@ -1,0 +1,89 @@
+package futures
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+)
+
+// LongShortRatioService list open history data of a symbol.
+type LongShortRatioService struct {
+	c         *Client
+	symbol    string
+	period    string
+	limit     *int
+	startTime *int64
+	endTime   *int64
+}
+
+// Symbol set symbol
+func (s *LongShortRatioService) Symbol(symbol string) *LongShortRatioService {
+	s.symbol = symbol
+	return s
+}
+
+// Period set period interval
+func (s *LongShortRatioService) Period(period string) *LongShortRatioService {
+	s.period = period
+	return s
+}
+
+// Limit set limit
+func (s *LongShortRatioService) Limit(limit int) *LongShortRatioService {
+	s.limit = &limit
+	return s
+}
+
+// StartTime set startTime
+func (s *LongShortRatioService) StartTime(startTime int64) *LongShortRatioService {
+	s.startTime = &startTime
+	return s
+}
+
+// EndTime set endTime
+func (s *LongShortRatioService) EndTime(endTime int64) *LongShortRatioService {
+	s.endTime = &endTime
+	return s
+}
+
+// Do send request
+func (s *LongShortRatioService) Do(ctx context.Context, opts ...RequestOption) (res []*LongShortRatio, err error) {
+	r := &request{
+		method:   http.MethodGet,
+		endpoint: "/futures/data/globalLongShortAccountRatio",
+	}
+
+	r.setParam("symbol", s.symbol)
+	r.setParam("period", s.period)
+
+	if s.limit != nil {
+		r.setParam("limit", *s.limit)
+	}
+	if s.startTime != nil {
+		r.setParam("startTime", *s.startTime)
+	}
+	if s.endTime != nil {
+		r.setParam("endTime", *s.endTime)
+	}
+
+	data, _, err := s.c.callAPI(ctx, r, opts...)
+	if err != nil {
+		return []*LongShortRatio{}, err
+	}
+
+	res = make([]*LongShortRatio, 0)
+	err = json.Unmarshal(data, &res)
+	if err != nil {
+		return []*LongShortRatio{}, err
+	}
+
+	return res, nil
+}
+
+type LongShortRatio struct {
+	Symbol         string `json:"symbol"`
+	LongShortRatio string `json:"longShortRatio"`
+	LongAccount    string `json:"longAccount"`
+	ShortAccount   string `json:"shortAccount"`
+	Timestamp      int64  `json:"timestamp"`
+}

--- a/v2/futures/longshort_ratio_service_test.go
+++ b/v2/futures/longshort_ratio_service_test.go
@@ -1,0 +1,85 @@
+package futures
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type longShortRatioServiceTestSuite struct {
+	baseTestSuite
+}
+
+func TestLongShortRatioService(t *testing.T) {
+	suite.Run(t, new(longShortRatioServiceTestSuite))
+}
+
+func (s *longShortRatioServiceTestSuite) TestOpenInterestStatistics() {
+	data := []byte(`[
+		{ 
+			"symbol":"BTCUSDT",
+			"longShortRatio":"1.8105",
+			"longAccount": "0.6442", 
+			"shortAccount":"0.3558", 
+			"timestamp":1583139600000
+		},
+		{
+			"symbol":"BTCUSDT",
+			"longShortRatio":"0.5576",
+			"longAccount": "0.3580", 
+			"shortAccount":"0.6420",                  
+			"timestamp":1583139900000
+		}
+	]`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	symbol := "BTCUSDT"
+	period := "15m"
+	limit := 10
+	startTime := int64(1583139600000)
+	endTime := int64(1583139900000)
+	s.assertReq(func(r *request) {
+		e := newRequest().setParams(params{
+			"symbol":    symbol,
+			"period":    period,
+			"limit":     limit,
+			"startTime": startTime,
+			"endTime":   endTime,
+		})
+		s.assertRequestEqual(e, r)
+	})
+
+	longShortRatios, err := s.client.NewLongShortRatioService().Symbol(symbol).
+		Period(period).Limit(limit).StartTime(startTime).
+		EndTime(endTime).Do(newContext())
+
+	s.r().NoError(err)
+	s.Len(longShortRatios, 2)
+
+	longShortRatio1 := &LongShortRatio{
+		Symbol:         "BTCUSDT",
+		LongShortRatio: "1.8105",
+		ShortAccount:   "0.3558",
+		LongAccount:    "0.6442",
+		Timestamp:      1583139600000,
+	}
+	longShortRatio2 := &LongShortRatio{
+		Symbol:         "BTCUSDT",
+		LongShortRatio: "0.5576",
+		ShortAccount:   "0.6420",
+		LongAccount:    "0.3580",
+		Timestamp:      1583139900000,
+	}
+	s.assertLongShortRatioEqual(longShortRatio1, longShortRatios[0])
+	s.assertLongShortRatioEqual(longShortRatio2, longShortRatios[1])
+}
+
+func (s *longShortRatioServiceTestSuite) assertLongShortRatioEqual(e, a *LongShortRatio) {
+	r := s.r()
+	r.Equal(e.Symbol, a.Symbol, "Symbol")
+	r.Equal(e.Timestamp, a.Timestamp, "Timestamp")
+	r.Equal(e.LongShortRatio, a.LongShortRatio, "LongShortRatio")
+	r.Equal(e.LongAccount, a.LongAccount, "LongAccount")
+	r.Equal(e.ShortAccount, a.ShortAccount, "ShortAccount")
+}

--- a/v2/futures/openinterest_service_test.go
+++ b/v2/futures/openinterest_service_test.go
@@ -45,7 +45,7 @@ func (s *openInterestServiceTestSuite) TestGetOpenInterest() {
 	s.r().Equal(e.Time, res.Time, "Time")
 }
 
-func (s *klineServiceTestSuite) TestOpenInterestStatistics() {
+func (s *openInterestServiceTestSuite) TestOpenInterestStatistics() {
 	data := []byte(`[
 		{ 
 			"symbol":"BTCUSDT",
@@ -102,7 +102,7 @@ func (s *klineServiceTestSuite) TestOpenInterestStatistics() {
 	s.assertOpenInterestStatisticEqual(openInterest2, openInterests[1])
 }
 
-func (s *klineServiceTestSuite) assertOpenInterestStatisticEqual(e, a *OpenInterestStatistic) {
+func (s *openInterestServiceTestSuite) assertOpenInterestStatisticEqual(e, a *OpenInterestStatistic) {
 	r := s.r()
 	r.Equal(e.Symbol, a.Symbol, "Symbol")
 	r.Equal(e.Timestamp, a.Timestamp, "Timestamp")


### PR DESCRIPTION
Implements Long Short Ratio Statistics: https://binance-docs.github.io/apidocs/futures/en/#long-short-ratio