### PR TITLE
feat: Implement RateLimitService

### DIFF
--- a/v2/client.go
+++ b/v2/client.go
@@ -90,6 +90,13 @@ type LiquidityRewardType int
 // RewardClaimStatus define the status of claiming a reward
 type RewardClaimStatus int
 
+// RateLimitType define the rate limitation types
+// see https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#enum-definitions
+type RateLimitType string
+
+// RateLimitInterval define the rate limitation intervals
+type RateLimitInterval string
+
 // Endpoints
 const (
 	baseAPIMainURL    = "https://api.binance.com"
@@ -209,6 +216,14 @@ const (
 
 	RewardClaimPending RewardClaimStatus = 0
 	RewardClaimDone    RewardClaimStatus = 1
+
+	RateLimitTypeRequestWeight RateLimitType = "REQUEST_WEIGHT"
+	RateLimitTypeOrders        RateLimitType = "ORDERS"
+	RateLimitTypeRawRequests   RateLimitType = "RAW_REQUESTS"
+
+	RateLimitIntervalSecond RateLimitInterval = "SECOND"
+	RateLimitIntervalMinute RateLimitInterval = "MINUTE"
+	RateLimitIntervalDay    RateLimitInterval = "DAY"
 )
 
 func currentTimestamp() int64 {
@@ -601,6 +616,11 @@ func (c *Client) NewCloseUserStreamService() *CloseUserStreamService {
 // NewExchangeInfoService init exchange info service
 func (c *Client) NewExchangeInfoService() *ExchangeInfoService {
 	return &ExchangeInfoService{c: c}
+}
+
+// NewRateLimitService init rate limit service
+func (c *Client) NewRateLimitService() *RateLimitService {
+	return &RateLimitService{c: c}
 }
 
 // NewGetAssetDetailService init get asset detail service

--- a/v2/rate_limit_service.go
+++ b/v2/rate_limit_service.go
@@ -1,0 +1,38 @@
+package binance
+
+import (
+	"context"
+	"net/http"
+)
+
+// RateLimitService get rate limits
+type RateLimitService struct {
+	c *Client
+}
+
+// Do send request
+func (s *RateLimitService) Do(ctx context.Context, opts ...RequestOption) (res []*RateLimitFull, err error) {
+	res = make([]*RateLimitFull, 0)
+	r := &request{
+		method:   http.MethodGet,
+		endpoint: "/api/v3/rateLimit/order",
+		secType:  secTypeSigned,
+	}
+	data, err := s.c.callAPI(ctx, r, opts...)
+	if err != nil {
+		return res, err
+	}
+	err = json.Unmarshal(data, &res)
+	if err != nil {
+		return res, err
+	}
+	return res, nil
+}
+
+type RateLimitFull struct {
+	RateLimitType RateLimitType     `json:"rateLimitType"`
+	Interval      RateLimitInterval `json:"interval"`
+	IntervalNum   int               `json:"intervalNum"`
+	Limit         int               `json:"limit"`
+	Count         int               `json:"count"`
+}

--- a/v2/rate_limit_service_test.go
+++ b/v2/rate_limit_service_test.go
@@ -1,0 +1,68 @@
+package binance
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type assetRateLimitServiceSuite struct {
+	baseTestSuite
+}
+
+func (a *assetRateLimitServiceSuite) assertRateLimitServiceEqual(expected, other *RateLimitFull) {
+	r := a.r()
+
+	r.EqualValues(expected, other)
+}
+
+func TestRateLimitService(t *testing.T) {
+	suite.Run(t, new(assetRateLimitServiceSuite))
+}
+
+func (s *assetRateLimitServiceSuite) TestListRateLimit() {
+	data := []byte(`
+	[
+		{
+			"rateLimitType": "ORDERS",
+			"interval": "SECOND",
+			"intervalNum": 10,
+			"limit": 10000,
+			"count": 0
+		},
+		{
+			"rateLimitType": "RAW_REQUESTS",
+			"interval": "MINUTE",
+			"intervalNum": 5,
+			"limit": 5000,
+			"count": 100
+		}
+	]
+	`)
+
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	limits, err := s.client.NewRateLimitService().Do(context.Background())
+	s.r().NoError(err)
+	rows := limits
+
+	s.Len(rows, 2)
+	s.assertRateLimitServiceEqual(&RateLimitFull{
+		RateLimitType: "ORDERS",
+		Interval:      "SECOND",
+		IntervalNum:   10,
+		Limit:         10000,
+		Count:         0,
+	},
+		rows[0])
+	s.assertRateLimitServiceEqual(&RateLimitFull{
+		RateLimitType: "RAW_REQUESTS",
+		Interval:      "MINUTE",
+		IntervalNum:   5,
+		Limit:         5000,
+		Count:         100,
+	},
+		rows[1])
+}


### PR DESCRIPTION
Add RateLimitService to query trade limitations. Ref: https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#query-current-order-count-usage-trade 

For compatibility, I didn't alter field types in ExchangeInfoService.
https://github.com/adshao/go-binance/blob/f3bd66ee84caca1dd0e69e517d34319e145790a6/v2/delivery/exchange_info_service.go#L43-L49