### PR TITLE
Fix fapi commission_rate_service (/fapi/v1/commissionRate) no signature param error

### DIFF
--- a/v2/futures/commission_rate_service.go
+++ b/v2/futures/commission_rate_service.go
@@ -18,22 +18,23 @@ func (service *CommissionRateService) Symbol(symbol string) *CommissionRateServi
 }
 
 // Do send request
-func (s *CommissionRateService) Do(ctx context.Context, opts ...RequestOption) (res []*CommissionRate, err error) {
+func (s *CommissionRateService) Do(ctx context.Context, opts ...RequestOption) (res *CommissionRate, err error) {
 	r := &request{
 		method:   http.MethodGet,
 		endpoint: "/fapi/v1/commissionRate",
+		secType:  secTypeSigned,
 	}
 	if s.symbol != "" {
 		r.setParam("symbol", s.symbol)
 	}
 	data, _, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
-		return []*CommissionRate{}, err
+		return nil, err
 	}
-	res = make([]*CommissionRate, 0)
+	res = new(CommissionRate)
 	err = json.Unmarshal(data, &res)
 	if err != nil {
-		return []*CommissionRate{}, err
+		return nil, err
 	}
 	return res, nil
 }

--- a/v2/futures/commission_rate_service_test.go
+++ b/v2/futures/commission_rate_service_test.go
@@ -17,20 +17,18 @@ func TestCommissionRateService(t *testing.T) {
 
 func (commissionRateService *commissionRateServiceTestSuite) TestCommissionRate() {
 	data := []byte(`
-		[
-			{
-				"symbol": "BTCUSDT",
-				"makerCommissionRate": "0.001",
-				"takerCommissionRate": "0.001"
-			}
-		]
+		{
+			"symbol": "BTCUSDT",
+			"makerCommissionRate": "0.001",
+			"takerCommissionRate": "0.001"
+		}
 	`)
 	commissionRateService.mockDo(data, nil)
 	defer commissionRateService.assertDo()
 
 	symbol := "BTCUSDT"
 	commissionRateService.assertReq(func(request *request) {
-		requestParams := newRequest().setParam("symbol", symbol)
+		requestParams := newSignedRequest().setParam("symbol", symbol)
 		commissionRateService.assertRequestEqual(requestParams, request)
 	})
 	res, err := commissionRateService.client.NewCommissionRateService().Symbol(symbol).Do(newContext())
@@ -40,7 +38,7 @@ func (commissionRateService *commissionRateServiceTestSuite) TestCommissionRate(
 		MakerCommissionRate: "0.001",
 		TakerCommissionRate: "0.001",
 	}
-	commissionRateService.assertCommissionRateResponseEqual(expectation, res[0])
+	commissionRateService.assertCommissionRateResponseEqual(expectation, res)
 }
 
 func (commissionRateServiceTestSuite *commissionRateServiceTestSuite) assertCommissionRateResponseEqual(expectation, assertedData *CommissionRate) {


### PR DESCRIPTION
Found that this api needs a signature and the response is not an array
ref: https://binance-docs.github.io/apidocs/futures/en/#user-commission-rate-user_data