### PR TITLE
The futures module adds the continuous contract Kline rest interface and websocket interface

### DIFF
--- a/v2/futures/client.go
+++ b/v2/futures/client.go
@@ -400,6 +400,11 @@ func (c *Client) NewKlinesService() *KlinesService {
 	return &KlinesService{c: c}
 }
 
+// NewKlinesService init klines service
+func (c *Client) NewContinuousKlinesService() *ContinuousKlinesService {
+	return &ContinuousKlinesService{c: c}
+}
+
 // NewIndexPriceKlinesService init index price klines service
 func (c *Client) NewIndexPriceKlinesService() *IndexPriceKlinesService {
 	return &IndexPriceKlinesService{c: c}

--- a/v2/futures/client.go
+++ b/v2/futures/client.go
@@ -400,7 +400,7 @@ func (c *Client) NewKlinesService() *KlinesService {
 	return &KlinesService{c: c}
 }
 
-// NewKlinesService init klines service
+// NewContinuousKlinesService init continuous klines service
 func (c *Client) NewContinuousKlinesService() *ContinuousKlinesService {
 	return &ContinuousKlinesService{c: c}
 }

--- a/v2/futures/continuous_kline_service.go
+++ b/v2/futures/continuous_kline_service.go
@@ -104,7 +104,7 @@ func (s *ContinuousKlinesService) Do(ctx context.Context, opts ...RequestOption)
 	return res, nil
 }
 
-// Kline define kline info
+// ContinuousKline define ContinuousKline info
 type ContinuousKline struct {
 	OpenTime                 int64  `json:"openTime"`
 	Open                     string `json:"open"`

--- a/v2/futures/continuous_kline_service.go
+++ b/v2/futures/continuous_kline_service.go
@@ -1,0 +1,120 @@
+package futures
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// ContinuousKlinesService list klines
+type ContinuousKlinesService struct {
+	c            *Client
+	pair         string
+	contractType string
+	interval     string
+	limit        *int
+	startTime    *int64
+	endTime      *int64
+}
+
+// pair set pair
+func (s *ContinuousKlinesService) Pair(pair string) *ContinuousKlinesService {
+	s.pair = pair
+	return s
+}
+
+// contractType set contractType
+func (s *ContinuousKlinesService) ContractType(contractType string) *ContinuousKlinesService {
+	s.contractType = contractType
+	return s
+}
+
+// Interval set interval
+func (s *ContinuousKlinesService) Interval(interval string) *ContinuousKlinesService {
+	s.interval = interval
+	return s
+}
+
+// Limit set limit
+func (s *ContinuousKlinesService) Limit(limit int) *ContinuousKlinesService {
+	s.limit = &limit
+	return s
+}
+
+// StartTime set startTime
+func (s *ContinuousKlinesService) StartTime(startTime int64) *ContinuousKlinesService {
+	s.startTime = &startTime
+	return s
+}
+
+// EndTime set endTime
+func (s *ContinuousKlinesService) EndTime(endTime int64) *ContinuousKlinesService {
+	s.endTime = &endTime
+	return s
+}
+
+// Do send request
+func (s *ContinuousKlinesService) Do(ctx context.Context, opts ...RequestOption) (res []*ContinuousKline, err error) {
+	r := &request{
+		method:   http.MethodGet,
+		endpoint: "/fapi/v1/continuousKlines",
+	}
+	r.setParam("pair", s.pair)
+	r.setParam("contractType", s.contractType)
+	r.setParam("interval", s.interval)
+	if s.limit != nil {
+		r.setParam("limit", *s.limit)
+	}
+	if s.startTime != nil {
+		r.setParam("startTime", *s.startTime)
+	}
+	if s.endTime != nil {
+		r.setParam("endTime", *s.endTime)
+	}
+	data, _, err := s.c.callAPI(ctx, r, opts...)
+	if err != nil {
+		return []*ContinuousKline{}, err
+	}
+	j, err := newJSON(data)
+	if err != nil {
+		return []*ContinuousKline{}, err
+	}
+	num := len(j.MustArray())
+	res = make([]*ContinuousKline, num)
+	for i := 0; i < num; i++ {
+		item := j.GetIndex(i)
+		if len(item.MustArray()) < 11 {
+			err = fmt.Errorf("invalid kline response")
+			return []*ContinuousKline{}, err
+		}
+		res[i] = &ContinuousKline{
+			OpenTime:                 item.GetIndex(0).MustInt64(),
+			Open:                     item.GetIndex(1).MustString(),
+			High:                     item.GetIndex(2).MustString(),
+			Low:                      item.GetIndex(3).MustString(),
+			Close:                    item.GetIndex(4).MustString(),
+			Volume:                   item.GetIndex(5).MustString(),
+			CloseTime:                item.GetIndex(6).MustInt64(),
+			QuoteAssetVolume:         item.GetIndex(7).MustString(),
+			TradeNum:                 item.GetIndex(8).MustInt64(),
+			TakerBuyBaseAssetVolume:  item.GetIndex(9).MustString(),
+			TakerBuyQuoteAssetVolume: item.GetIndex(10).MustString(),
+		}
+	}
+	return res, nil
+}
+
+// Kline define kline info
+type ContinuousKline struct {
+	OpenTime                 int64  `json:"openTime"`
+	Open                     string `json:"open"`
+	High                     string `json:"high"`
+	Low                      string `json:"low"`
+	Close                    string `json:"close"`
+	Volume                   string `json:"volume"`
+	CloseTime                int64  `json:"closeTime"`
+	QuoteAssetVolume         string `json:"quoteAssetVolume"`
+	TradeNum                 int64  `json:"tradeNum"`
+	TakerBuyBaseAssetVolume  string `json:"takerBuyBaseAssetVolume"`
+	TakerBuyQuoteAssetVolume string `json:"takerBuyQuoteAssetVolume"`
+}

--- a/v2/futures/continuous_kline_service_test.go
+++ b/v2/futures/continuous_kline_service_test.go
@@ -1,0 +1,116 @@
+package futures
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type ContinuousklineServiceTestSuite struct {
+	baseTestSuite
+}
+
+func TestContinuousKlineService(t *testing.T) {
+	suite.Run(t, new(ContinuousklineServiceTestSuite))
+}
+
+func (s *ContinuousklineServiceTestSuite) TestContinuousKlines() {
+	data := []byte(`[
+        [
+            1499040000000,
+            "0.01634790",
+            "0.80000000",
+            "0.01575800",
+            "0.01577100",
+            "148976.11427815",
+            1499644799999,
+            "2434.19055334",
+            308,
+            "1756.87402397",
+            "28.46694368",
+            "17928899.62484339"
+        ],
+        [
+            1499040000001,
+            "0.01634790",
+            "0.80000000",
+            "0.01575800",
+            "0.01577101",
+            "148976.11427815",
+            1499644799999,
+            "2434.19055334",
+            308,
+            "1756.87402397",
+            "28.46694368",
+            "17928899.62484339"
+        ]
+    ]`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	pair := "LTCBTC"
+	contractType := "PERPETUAL"
+	interval := "15m"
+	limit := 10
+	startTime := int64(1499040000000)
+	endTime := int64(1499040000001)
+	s.assertReq(func(r *request) {
+		e := newRequest().setParams(params{
+			"pair":         pair,
+			"contractType": contractType,
+			"interval":     interval,
+			"limit":        limit,
+			"startTime":    startTime,
+			"endTime":      endTime,
+		})
+		s.assertRequestEqual(e, r)
+	})
+	klines, err := s.client.NewContinuousKlinesService().Pair(pair).
+		ContractType(contractType).Interval(interval).Limit(limit).
+		StartTime(startTime).EndTime(endTime).Do(newContext())
+	s.r().NoError(err)
+	s.Len(klines, 2)
+	kline1 := &ContinuousKline{
+		OpenTime:                 1499040000000,
+		Open:                     "0.01634790",
+		High:                     "0.80000000",
+		Low:                      "0.01575800",
+		Close:                    "0.01577100",
+		Volume:                   "148976.11427815",
+		CloseTime:                1499644799999,
+		QuoteAssetVolume:         "2434.19055334",
+		TradeNum:                 308,
+		TakerBuyBaseAssetVolume:  "1756.87402397",
+		TakerBuyQuoteAssetVolume: "28.46694368",
+	}
+	kline2 := &ContinuousKline{
+		OpenTime:                 1499040000001,
+		Open:                     "0.01634790",
+		High:                     "0.80000000",
+		Low:                      "0.01575800",
+		Close:                    "0.01577101",
+		Volume:                   "148976.11427815",
+		CloseTime:                1499644799999,
+		QuoteAssetVolume:         "2434.19055334",
+		TradeNum:                 308,
+		TakerBuyBaseAssetVolume:  "1756.87402397",
+		TakerBuyQuoteAssetVolume: "28.46694368",
+	}
+	s.assertContinuousKlineEqual(kline1, klines[0])
+	s.assertContinuousKlineEqual(kline2, klines[1])
+}
+
+func (s *ContinuousklineServiceTestSuite) assertContinuousKlineEqual(e, a *ContinuousKline) {
+	r := s.r()
+	r.Equal(e.OpenTime, a.OpenTime, "OpenTime")
+	r.Equal(e.Open, a.Open, "Open")
+	r.Equal(e.High, a.High, "High")
+	r.Equal(e.Low, a.Low, "Low")
+	r.Equal(e.Close, a.Close, "Close")
+	r.Equal(e.Volume, a.Volume, "Volume")
+	r.Equal(e.CloseTime, a.CloseTime, "CloseTime")
+	r.Equal(e.QuoteAssetVolume, a.QuoteAssetVolume, "QuoteAssetVolume")
+	r.Equal(e.TradeNum, a.TradeNum, "TradeNum")
+	r.Equal(e.TakerBuyBaseAssetVolume, a.TakerBuyBaseAssetVolume, "TakerBuyBaseAssetVolume")
+	r.Equal(e.TakerBuyQuoteAssetVolume, a.TakerBuyQuoteAssetVolume, "TakerBuyQuoteAssetVolume")
+}

--- a/v2/futures/websocket_service.go
+++ b/v2/futures/websocket_service.go
@@ -282,6 +282,94 @@ func WsCombinedKlineServe(symbolIntervalPair map[string]string, handler WsKlineH
 	return wsServe(cfg, wsHandler, errHandler)
 }
 
+// WsContinuousKlineEvent define websocket continuous kline event
+type WsContinuousKlineEvent struct {
+	Event        string            `json:"e"`
+	Time         int64             `json:"E"`
+	PairSymbol   string            `json:"ps"`
+	ContractType string            `json:"ct"`
+	Kline        WsContinuousKline `json:"k"`
+}
+
+// WsContinuousKline define websocket continuous kline
+type WsContinuousKline struct {
+	StartTime            int64  `json:"t"`
+	EndTime              int64  `json:"T"`
+	Interval             string `json:"i"`
+	FirstTradeID         int64  `json:"f"`
+	LastTradeID          int64  `json:"L"`
+	Open                 string `json:"o"`
+	Close                string `json:"c"`
+	High                 string `json:"h"`
+	Low                  string `json:"l"`
+	Volume               string `json:"v"`
+	TradeNum             int64  `json:"n"`
+	IsFinal              bool   `json:"x"`
+	QuoteVolume          string `json:"q"`
+	ActiveBuyVolume      string `json:"V"`
+	ActiveBuyQuoteVolume string `json:"Q"`
+}
+
+type WsPairContractTypeIntervalPair struct {
+	Pair         string
+	ContractType string
+	Interval     string
+}
+
+// WsContinuousKlineHandler handle websocket continuous kline event
+type WsContinuousKlineHandler func(event *WsContinuousKlineEvent)
+
+// WsContinuousKlineServe serve websocket continuous kline handler with a pair and contractType and interval like 15m, 30s
+func WsContinuousKlineServe(pair string, contractType string, interval string, handler WsContinuousKlineHandler,
+	errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	endpoint := fmt.Sprintf("%s/%s_%s@continuousKline_%s", getWsEndpoint(), strings.ToLower(pair),
+		strings.ToLower(contractType), interval)
+	cfg := newWsConfig(endpoint)
+	wsHandler := func(message []byte) {
+		event := new(WsContinuousKlineEvent)
+		err := json.Unmarshal(message, event)
+		if err != nil {
+			errHandler(err)
+			return
+		}
+		handler(event)
+	}
+	return wsServe(cfg, wsHandler, errHandler)
+}
+
+// WsCombinedContinuousKlineServe is similar to WsKlineServe, but it handles multiple pairs of different contractType with it interval
+func WsCombinedContinuousKlineServe(PairContractTypeIntervalList []WsPairContractTypeIntervalPair,
+	handler WsContinuousKlineHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	endpoint := getCombinedEndpoint()
+	for _, val := range PairContractTypeIntervalList {
+		endpoint += fmt.Sprintf("%s_%s@continuousKline_%s", strings.ToLower(val.Pair),
+			strings.ToLower(val.ContractType), val.Interval) + "/"
+	}
+	endpoint = endpoint[:len(endpoint)-1]
+	cfg := newWsConfig(endpoint)
+	wsHandler := func(message []byte) {
+		j, err := newJSON(message)
+		if err != nil {
+			errHandler(err)
+			return
+		}
+
+		data := j.Get("data").MustMap()
+
+		jsonData, _ := json.Marshal(data)
+
+		event := new(WsContinuousKlineEvent)
+		err = json.Unmarshal(jsonData, event)
+		if err != nil {
+			errHandler(err)
+			return
+		}
+
+		handler(event)
+	}
+	return wsServe(cfg, wsHandler, errHandler)
+}
+
 // WsMiniMarketTickerEvent define websocket mini market ticker event.
 type WsMiniMarketTickerEvent struct {
 	Event       string `json:"e"`

--- a/v2/futures/websocket_service_test.go
+++ b/v2/futures/websocket_service_test.go
@@ -464,6 +464,162 @@ func (s *websocketServiceTestSuite) TestWsCombinedKlineServe() {
 	<-doneC
 }
 
+func (s *websocketServiceTestSuite) TestContinuousKlineServe() {
+	data := []byte(`{
+		"e": "kline",
+		"E": 123456789,
+		"ps": "BTCUSDT",
+		"ct": "PERPETUAL",
+		"k": {
+		  "t": 123400000,
+		  "T": 123460000,
+		  "i": "1m",
+		  "f": 100,
+		  "L": 200,
+		  "o": "0.0010",
+		  "c": "0.0020",
+		  "h": "0.0025",
+		  "l": "0.0015",
+		  "v": "1000",
+		  "n": 100,
+		  "x": false,
+		  "q": "1.0000",
+		  "V": "500",
+		  "Q": "0.500"
+		}
+	  }`)
+	fakeErrMsg := "fake error"
+	s.mockWsServe(data, errors.New(fakeErrMsg))
+	defer s.assertWsServe()
+
+	doneC, stopC, err := WsContinuousKlineServe("ETHBTC", "PERPETUAL", "1m", func(event *WsContinuousKlineEvent) {
+		e := &WsContinuousKlineEvent{
+			Event:        "kline",
+			Time:         123456789,
+			PairSymbol:   "BTCUSDT",
+			ContractType: "PERPETUAL",
+			Kline: WsContinuousKline{
+				StartTime:            123400000,
+				EndTime:              123460000,
+				Interval:             "1m",
+				FirstTradeID:         100,
+				LastTradeID:          200,
+				Open:                 "0.0010",
+				Close:                "0.0020",
+				High:                 "0.0025",
+				Low:                  "0.0015",
+				Volume:               "1000",
+				TradeNum:             100,
+				IsFinal:              false,
+				QuoteVolume:          "1.0000",
+				ActiveBuyVolume:      "500",
+				ActiveBuyQuoteVolume: "0.500",
+			},
+		}
+		s.assertWsContinuousKlineEventEqual(e, event)
+	}, func(err error) {
+		s.r().EqualError(err, fakeErrMsg)
+	})
+	s.r().NoError(err)
+	stopC <- struct{}{}
+	<-doneC
+}
+
+func (s *websocketServiceTestSuite) assertWsContinuousKlineEventEqual(e, a *WsContinuousKlineEvent) {
+	r := s.r()
+	r.Equal(e.Event, a.Event, "Event")
+	r.Equal(e.Time, a.Time, "Time")
+	r.Equal(e.PairSymbol, a.PairSymbol, "PairSymbol")
+	ek, ak := e.Kline, a.Kline
+	r.Equal(ek.StartTime, ak.StartTime, "StartTime")
+	r.Equal(ek.EndTime, ak.EndTime, "EndTime")
+	r.Equal(ek.Interval, ak.Interval, "Interval")
+	r.Equal(ek.FirstTradeID, ak.FirstTradeID, "FirstTradeID")
+	r.Equal(ek.LastTradeID, ak.LastTradeID, "LastTradeID")
+	r.Equal(ek.Open, ak.Open, "Open")
+	r.Equal(ek.Close, ak.Close, "Close")
+	r.Equal(ek.High, ak.High, "High")
+	r.Equal(ek.Low, ak.Low, "Low")
+	r.Equal(ek.Volume, ak.Volume, "Volume")
+	r.Equal(ek.TradeNum, ak.TradeNum, "TradeNum")
+	r.Equal(ek.IsFinal, ak.IsFinal, "IsFinal")
+	r.Equal(ek.QuoteVolume, ak.QuoteVolume, "QuoteVolume")
+	r.Equal(ek.ActiveBuyVolume, ak.ActiveBuyVolume, "ActiveBuyVolume")
+	r.Equal(ek.ActiveBuyQuoteVolume, ak.ActiveBuyQuoteVolume, "ActiveBuyQuoteVolume")
+}
+
+func (s *websocketServiceTestSuite) TestWsCombinedContinuousKlineServe() {
+	data := []byte(`{
+	"stream":"ethbtc_perpetual@continuousKline_1m",
+	"data": {
+        "e": "kline",
+        "E": 1499404907056,
+        "ps": "ETHBTC",
+		"ct": "PERPETUAL",
+        "k": {
+            "t": 1499404860000,
+            "T": 1499404919999,
+            "s": "ETHBTC",
+            "i": "1m",
+            "f": 77462,
+            "L": 77465,
+            "o": "0.10278577",
+            "c": "0.10278645",
+            "h": "0.10278712",
+            "l": "0.10278518",
+            "v": "17.47929838",
+            "n": 4,
+            "x": false,
+            "q": "1.79662878",
+            "V": "2.34879839",
+            "Q": "0.24142166",
+            "B": "13279784.01349473"
+        }
+	}}`)
+	fakeErrMsg := "fake error"
+	s.mockWsServe(data, errors.New(fakeErrMsg))
+	defer s.assertWsServe()
+
+	input := []WsPairContractTypeIntervalPair{
+		{
+			Pair:         "ETHBTC",
+			ContractType: "PERPETUAL",
+			Interval:     "1m",
+		},
+	}
+	doneC, stopC, err := WsCombinedContinuousKlineServe(input, func(event *WsContinuousKlineEvent) {
+		e := &WsContinuousKlineEvent{
+			Event:        "kline",
+			Time:         1499404907056,
+			PairSymbol:   "ETHBTC",
+			ContractType: "PERPETUAL",
+			Kline: WsContinuousKline{
+				StartTime:            1499404860000,
+				EndTime:              1499404919999,
+				Interval:             "1m",
+				FirstTradeID:         77462,
+				LastTradeID:          77465,
+				Open:                 "0.10278577",
+				Close:                "0.10278645",
+				High:                 "0.10278712",
+				Low:                  "0.10278518",
+				Volume:               "17.47929838",
+				TradeNum:             4,
+				IsFinal:              false,
+				QuoteVolume:          "1.79662878",
+				ActiveBuyVolume:      "2.34879839",
+				ActiveBuyQuoteVolume: "0.24142166",
+			},
+		}
+		s.assertWsContinuousKlineEventEqual(e, event)
+	}, func(err error) {
+		s.r().EqualError(err, fakeErrMsg)
+	})
+	s.r().NoError(err)
+	stopC <- struct{}{}
+	<-doneC
+}
+
 func (s *websocketServiceTestSuite) TestMiniMarketTickerServe() {
 	data := []byte(`{
 		"e": "24hrMiniTicker", 

--- a/v2/futures/websocket_service_test.go
+++ b/v2/futures/websocket_service_test.go
@@ -466,7 +466,7 @@ func (s *websocketServiceTestSuite) TestWsCombinedKlineServe() {
 
 func (s *websocketServiceTestSuite) TestContinuousKlineServe() {
 	data := []byte(`{
-		"e": "kline",
+		"e": "continuous_kline",
 		"E": 123456789,
 		"ps": "BTCUSDT",
 		"ct": "PERPETUAL",
@@ -492,34 +492,39 @@ func (s *websocketServiceTestSuite) TestContinuousKlineServe() {
 	s.mockWsServe(data, errors.New(fakeErrMsg))
 	defer s.assertWsServe()
 
-	doneC, stopC, err := WsContinuousKlineServe("ETHBTC", "PERPETUAL", "1m", func(event *WsContinuousKlineEvent) {
-		e := &WsContinuousKlineEvent{
-			Event:        "kline",
-			Time:         123456789,
-			PairSymbol:   "BTCUSDT",
-			ContractType: "PERPETUAL",
-			Kline: WsContinuousKline{
-				StartTime:            123400000,
-				EndTime:              123460000,
-				Interval:             "1m",
-				FirstTradeID:         100,
-				LastTradeID:          200,
-				Open:                 "0.0010",
-				Close:                "0.0020",
-				High:                 "0.0025",
-				Low:                  "0.0015",
-				Volume:               "1000",
-				TradeNum:             100,
-				IsFinal:              false,
-				QuoteVolume:          "1.0000",
-				ActiveBuyVolume:      "500",
-				ActiveBuyQuoteVolume: "0.500",
-			},
-		}
-		s.assertWsContinuousKlineEventEqual(e, event)
-	}, func(err error) {
-		s.r().EqualError(err, fakeErrMsg)
-	})
+	doneC, stopC, err := WsContinuousKlineServe(&WsContinuousKlineSubcribeArgs{
+		Pair:         "BTCUSDT",
+		ContractType: "PERPETUAL",
+		Interval:     "1m",
+	},
+		func(event *WsContinuousKlineEvent) {
+			e := &WsContinuousKlineEvent{
+				Event:        "continuous_kline",
+				Time:         123456789,
+				PairSymbol:   "BTCUSDT",
+				ContractType: "PERPETUAL",
+				Kline: WsContinuousKline{
+					StartTime:            123400000,
+					EndTime:              123460000,
+					Interval:             "1m",
+					FirstTradeID:         100,
+					LastTradeID:          200,
+					Open:                 "0.0010",
+					Close:                "0.0020",
+					High:                 "0.0025",
+					Low:                  "0.0015",
+					Volume:               "1000",
+					TradeNum:             100,
+					IsFinal:              false,
+					QuoteVolume:          "1.0000",
+					ActiveBuyVolume:      "500",
+					ActiveBuyQuoteVolume: "0.500",
+				},
+			}
+			s.assertWsContinuousKlineEventEqual(e, event)
+		}, func(err error) {
+			s.r().EqualError(err, fakeErrMsg)
+		})
 	s.r().NoError(err)
 	stopC <- struct{}{}
 	<-doneC
@@ -552,7 +557,7 @@ func (s *websocketServiceTestSuite) TestWsCombinedContinuousKlineServe() {
 	data := []byte(`{
 	"stream":"ethbtc_perpetual@continuousKline_1m",
 	"data": {
-        "e": "kline",
+        "e": "continuous_kline",
         "E": 1499404907056,
         "ps": "ETHBTC",
 		"ct": "PERPETUAL",
@@ -580,7 +585,7 @@ func (s *websocketServiceTestSuite) TestWsCombinedContinuousKlineServe() {
 	s.mockWsServe(data, errors.New(fakeErrMsg))
 	defer s.assertWsServe()
 
-	input := []WsPairContractTypeIntervalPair{
+	input := []*WsContinuousKlineSubcribeArgs{
 		{
 			Pair:         "ETHBTC",
 			ContractType: "PERPETUAL",
@@ -589,7 +594,7 @@ func (s *websocketServiceTestSuite) TestWsCombinedContinuousKlineServe() {
 	}
 	doneC, stopC, err := WsCombinedContinuousKlineServe(input, func(event *WsContinuousKlineEvent) {
 		e := &WsContinuousKlineEvent{
-			Event:        "kline",
+			Event:        "continuous_kline",
 			Time:         1499404907056,
 			PairSymbol:   "ETHBTC",
 			ContractType: "PERPETUAL",


### PR DESCRIPTION
Hello, I used this module and found that the relevant interfaces of the future part of the continuous contract kline were not implemented. So I implemented a copy and hope that the author can incorporate it.

rest api:
![image](https://user-images.githubusercontent.com/56678483/222072873-1763bdfb-0110-484b-ab80-e07871d03bce.png)

websocket:
![image](https://user-images.githubusercontent.com/56678483/222073004-e1d21561-dd19-4608-9be3-1986dbbe7e3b.png)
