### PR TITLE
Add NOTIONAL filter support

### DIFF
--- a/v2/client.go
+++ b/v2/client.go
@@ -14,11 +14,12 @@ import (
 	"os"
 	"time"
 
+	"github.com/bitly/go-simplejson"
+	jsoniter "github.com/json-iterator/go"
+
 	"github.com/adshao/go-binance/v2/common"
 	"github.com/adshao/go-binance/v2/delivery"
 	"github.com/adshao/go-binance/v2/futures"
-	"github.com/bitly/go-simplejson"
-	jsoniter "github.com/json-iterator/go"
 )
 
 // SideType define side type of order
@@ -155,7 +156,7 @@ const (
 	SymbolFilterTypePriceFilter  SymbolFilterType = "PRICE_FILTER"
 	SymbolFilterTypePercentPrice SymbolFilterType = "PERCENT_PRICE"
 	// Deprecated: use SymbolFilterTypePercentPrice instead
-	SymbolFilterTypeMinNotional      SymbolFilterType = "NOTIONAL"
+	SymbolFilterTypeMinNotional      SymbolFilterType = "MIN_NOTIONAL"
 	SymbolFilterTypeNotional         SymbolFilterType = "NOTIONAL"
 	SymbolFilterTypeIcebergParts     SymbolFilterType = "ICEBERG_PARTS"
 	SymbolFilterTypeMarketLotSize    SymbolFilterType = "MARKET_LOT_SIZE"

--- a/v2/exchange_info_service.go
+++ b/v2/exchange_info_service.go
@@ -131,11 +131,13 @@ type MinNotionalFilter struct {
 	ApplyToMarket    bool   `json:"applyToMarket"`
 }
 
-// NotionalFilter define min notional filter of symbol
+// NotionalFilter define notional filter of symbol
 type NotionalFilter struct {
 	MinNotional      string `json:"minNotional"`
-	AveragePriceMins int    `json:"avgPriceMins"`
-	ApplyToMarket    bool   `json:"applyToMarket"`
+	ApplyMinToMarket bool   `json:"applyMinToMarket"`
+	MaxNotional      string `json:"maxNotional"`
+	ApplyMaxToMarket bool   `json:"applyMaxToMarket"`
+	AvgPriceMins     int    `json:"avgPriceMins"`
 }
 
 // IcebergPartsFilter define iceberg part filter of symbol
@@ -217,10 +219,10 @@ func (s *Symbol) PercentPriceFilter() *PercentPriceFilter {
 
 // MinNotionalFilter return min notional filter of symbol
 // Deprecated: use NotionalFilter instead
-func (s *Symbol) MinNotionalFilter() *NotionalFilter {
+func (s *Symbol) MinNotionalFilter() *MinNotionalFilter {
 	for _, filter := range s.Filters {
-		if filter["filterType"].(string) == string(SymbolFilterTypeNotional) {
-			f := &NotionalFilter{}
+		if filter["filterType"].(string) == string(SymbolFilterTypeMinNotional) {
+			f := &MinNotionalFilter{}
 			if i, ok := filter["minNotional"]; ok {
 				f.MinNotional = i.(string)
 			}
@@ -236,7 +238,7 @@ func (s *Symbol) MinNotionalFilter() *NotionalFilter {
 	return nil
 }
 
-// NotionalFilter return min notional filter of symbol
+// NotionalFilter return notional filter of symbol
 func (s *Symbol) NotionalFilter() *NotionalFilter {
 	for _, filter := range s.Filters {
 		if filter["filterType"].(string) == string(SymbolFilterTypeNotional) {
@@ -244,11 +246,17 @@ func (s *Symbol) NotionalFilter() *NotionalFilter {
 			if i, ok := filter["minNotional"]; ok {
 				f.MinNotional = i.(string)
 			}
-			if i, ok := filter["avgPriceMins"]; ok {
-				f.AveragePriceMins = int(i.(float64))
+			if i, ok := filter["applyMinToMarket"]; ok {
+				f.ApplyMinToMarket = i.(bool)
 			}
-			if i, ok := filter["applyToMarket"]; ok {
-				f.ApplyToMarket = i.(bool)
+			if i, ok := filter["maxNotional"]; ok {
+				f.MaxNotional = i.(string)
+			}
+			if i, ok := filter["applyMaxToMarket"]; ok {
+				f.ApplyMaxToMarket = i.(bool)
+			}
+			if i, ok := filter["avgPriceMins"]; ok {
+				f.AvgPriceMins = int(i.(float64))
 			}
 			return f
 		}

--- a/v2/exchange_info_service_test.go
+++ b/v2/exchange_info_service_test.go
@@ -52,7 +52,7 @@ func (s *exchangeInfoServiceTestSuite) TestExchangeInfo() {
 				"ocoAllowed": true,
 				"isSpotTradingAllowed": true,
 				"isMarginTradingAllowed": false,
-				"filters":[{"filterType":"PRICE_FILTER","minPrice":"0.00000100","maxPrice":"100000.00000000","tickSize":"0.00000100"},{"filterType":"LOT_SIZE","minQty":"0.00100000","maxQty":"100000.00000000","stepSize":"0.00100000"},{"filterType":"NOTIONAL","minNotional":"0.00100000"},{"filterType": "MAX_NUM_ALGO_ORDERS", "maxNumAlgoOrders": 5}],
+				"filters":[{"filterType":"PRICE_FILTER","minPrice":"0.00000100","maxPrice":"100000.00000000","tickSize":"0.00000100"},{"filterType":"LOT_SIZE","minQty":"0.00100000","maxQty":"100000.00000000","stepSize":"0.00100000"},{"filterType":"NOTIONAL","minNotional":"5.00000000", "applyMinToMarket": true, "maxNotional": "9000000.00000000", "applyMaxToMarket": false, "avgPriceMins": 5},{"filterType": "MAX_NUM_ALGO_ORDERS", "maxNumAlgoOrders": 5}],
 				"permissions": ["SPOT","MARGIN"]
 			}
 		]
@@ -97,7 +97,7 @@ func (s *exchangeInfoServiceTestSuite) TestExchangeInfo() {
 				Filters: []map[string]interface{}{
 					{"filterType": "PRICE_FILTER", "minPrice": "0.00000100", "maxPrice": "100000.00000000", "tickSize": "0.00000100"},
 					{"filterType": "LOT_SIZE", "minQty": "0.00100000", "maxQty": "100000.00000000", "stepSize": "0.00100000"},
-					{"filterType": "NOTIONAL", "minNotional": "0.00100000"},
+					{"filterType": "NOTIONAL", "minNotional": "5.00000000", "applyMinToMarket": true, "maxNotional": "9000000.00000000", "applyMaxToMarket": false, "avgPriceMins": 5},
 					{"filterType": "MAX_NUM_ALGO_ORDERS", "maxNumAlgoOrders": 5},
 				},
 				Permissions: []string{"SPOT", "MARGIN"},
@@ -119,9 +119,11 @@ func (s *exchangeInfoServiceTestSuite) TestExchangeInfo() {
 	}
 	s.assertPriceFilterEqual(ePriceFilter, res.Symbols[0].PriceFilter())
 	eMinNotionalFilter := &NotionalFilter{
-		MinNotional:      "0.00100000",
-		AveragePriceMins: 0,
-		ApplyToMarket:    false,
+		MinNotional:      "5.00000000",
+		ApplyMinToMarket: true,
+		MaxNotional:      "9000000.00000000",
+		ApplyMaxToMarket: false,
+		AvgPriceMins:     5,
 	}
 	s.assertMinNotionalFilterEqual(eMinNotionalFilter, res.Symbols[0].NotionalFilter())
 	eMaxNumAlgoOrdersFilter := &MaxNumAlgoOrdersFilter{
@@ -206,8 +208,10 @@ func (s *exchangeInfoServiceTestSuite) assertPercentPriceFilterEqual(e, a *Perce
 func (s *exchangeInfoServiceTestSuite) assertMinNotionalFilterEqual(e, a *NotionalFilter) {
 	r := s.r()
 	r.Equal(e.MinNotional, a.MinNotional, "MinNotional")
-	r.Equal(e.AveragePriceMins, a.AveragePriceMins, "AveragePriceMins")
-	r.Equal(e.ApplyToMarket, a.ApplyToMarket, "ApplyToMarket")
+	r.Equal(e.ApplyMinToMarket, a.ApplyMinToMarket, "ApplyMinToMarket")
+	r.Equal(e.MaxNotional, a.MaxNotional, "MaxNotional")
+	r.Equal(e.ApplyMaxToMarket, a.ApplyMaxToMarket, "ApplyMaxToMarket")
+	r.Equal(e.AvgPriceMins, a.AvgPriceMins, "AvgPriceMins")
 }
 
 func (s *exchangeInfoServiceTestSuite) assertIcebergPartsFilterEqual(e, a *IcebergPartsFilter) {

--- a/v2/futures/client.go
+++ b/v2/futures/client.go
@@ -15,8 +15,9 @@ import (
 	"os"
 	"time"
 
-	"github.com/adshao/go-binance/v2/common"
 	"github.com/bitly/go-simplejson"
+
+	"github.com/adshao/go-binance/v2/common"
 )
 
 // SideType define side type of order


### PR DESCRIPTION
I found some symbols filter have changned in binance, eg. for maticusdt, the following format is returned:

```json
        {
          "filterType": "NOTIONAL",
          "minNotional": "5.00000000",
          "applyMinToMarket": true,
          "maxNotional": "9000000.00000000",
          "applyMaxToMarket": false,
          "avgPriceMins": 5
        },
```