### PR TITLE
Add MultiAssetModeService for Future

### DIFF
--- a/v2/futures/client.go
+++ b/v2/futures/client.go
@@ -581,6 +581,16 @@ func (c *Client) NewGetPositionModeService() *GetPositionModeService {
 	return &GetPositionModeService{c: c}
 }
 
+// NewChangeMultiAssetModeService init change multi-asset mode service
+func (c *Client) NewChangeMultiAssetModeService() *ChangeMultiAssetModeService {
+	return &ChangeMultiAssetModeService{c: c}
+}
+
+// NewGetMultiAssetModeService init get multi-asset mode service
+func (c *Client) NewGetMultiAssetModeService() *GetMultiAssetModeService {
+	return &GetMultiAssetModeService{c: c}
+}
+
 // NewGetRebateNewUserService init get rebate_newuser service
 func (c *Client) NewGetRebateNewUserService() *GetRebateNewUserService {
 	return &GetRebateNewUserService{c: c}

--- a/v2/futures/position_service.go
+++ b/v2/futures/position_service.go
@@ -152,16 +152,12 @@ func (s *UpdatePositionMarginService) Do(ctx context.Context, opts ...RequestOpt
 // ChangePositionModeService change user's position mode
 type ChangePositionModeService struct {
 	c        *Client
-	dualSide string
+	dualSide bool
 }
 
 // Change user's position mode: true - Hedge Mode, false - One-way Mode
 func (s *ChangePositionModeService) DualSide(dualSide bool) *ChangePositionModeService {
-	if dualSide {
-		s.dualSide = "true"
-	} else {
-		s.dualSide = "false"
-	}
+	s.dualSide = dualSide
 	return s
 }
 
@@ -215,16 +211,12 @@ func (s *GetPositionModeService) Do(ctx context.Context, opts ...RequestOption) 
 // ChangeMultiAssetModeService change user's multi-asset mode
 type ChangeMultiAssetModeService struct {
 	c                 *Client
-	multiAssetsMargin string
+	multiAssetsMargin bool
 }
 
 // MultiAssetsMargin set multiAssetsMargin
 func (s *ChangeMultiAssetModeService) MultiAssetsMargin(multiAssetsMargin bool) *ChangeMultiAssetModeService {
-	if multiAssetsMargin {
-		s.multiAssetsMargin = "true"
-	} else {
-		s.multiAssetsMargin = "false"
-	}
+	s.multiAssetsMargin = multiAssetsMargin
 	return s
 }
 

--- a/v2/futures/position_service.go
+++ b/v2/futures/position_service.go
@@ -211,3 +211,66 @@ func (s *GetPositionModeService) Do(ctx context.Context, opts ...RequestOption) 
 	}
 	return res, nil
 }
+
+// ChangeMultiAssetModeService change user's multi-asset mode
+type ChangeMultiAssetModeService struct {
+	c                 *Client
+	multiAssetsMargin string
+}
+
+// MultiAssetsMargin set multiAssetsMargin
+func (s *ChangeMultiAssetModeService) MultiAssetsMargin(multiAssetsMargin bool) *ChangeMultiAssetModeService {
+	if multiAssetsMargin {
+		s.multiAssetsMargin = "true"
+	} else {
+		s.multiAssetsMargin = "false"
+	}
+	return s
+}
+
+// Do send request
+func (s *ChangeMultiAssetModeService) Do(ctx context.Context, opts ...RequestOption) (err error) {
+	r := &request{
+		method:   http.MethodPost,
+		endpoint: "/fapi/v1/multiAssetsMargin",
+		secType:  secTypeSigned,
+	}
+	r.setFormParams(params{
+		"multiAssetsMargin": s.multiAssetsMargin,
+	})
+	_, _, err = s.c.callAPI(ctx, r, opts...)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetMultiAssetModeService get user's multi-asset mode
+type GetMultiAssetModeService struct {
+	c *Client
+}
+
+// Response of user's multi-asset mode
+type MultiAssetMode struct {
+	MultiAssetsMargin bool `json:"multiAssetsMargin"`
+}
+
+// Do send request
+func (s *GetMultiAssetModeService) Do(ctx context.Context, opts ...RequestOption) (res *MultiAssetMode, err error) {
+	r := &request{
+		method:   http.MethodGet,
+		endpoint: "/fapi/v1/multiAssetsMargin",
+		secType:  secTypeSigned,
+	}
+	r.setFormParams(params{})
+	data, _, err := s.c.callAPI(ctx, r, opts...)
+	if err != nil {
+		return nil, err
+	}
+	res = &MultiAssetMode{}
+	err = json.Unmarshal(data, &res)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}

--- a/v2/futures/position_service_test.go
+++ b/v2/futures/position_service_test.go
@@ -122,3 +122,35 @@ func (s *positionServiceTestSuite) TestGetPositionMode() {
 	s.r().NoError(err)
 	s.r().Equal(res.DualSidePosition, true)
 }
+
+func (s *positionServiceTestSuite) TestChangeMultiAssetMode() {
+	data := []byte(`{
+		"code": 200,
+		"msg": "success"
+	}`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+	s.assertReq(func(r *request) {
+		e := newSignedRequest().setFormParams(params{
+			"multiAssetsMargin": "true",
+		})
+		s.assertRequestEqual(e, r)
+	})
+	err := s.client.NewChangeMultiAssetModeService().MultiAssetsMargin(true).Do(newContext())
+	s.r().NoError(err)
+}
+
+func (s *positionServiceTestSuite) TestGetMultiAssetMode() {
+	data := []byte(`{
+		"multiAssetsMargin": true
+	}`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+	s.assertReq(func(r *request) {
+		e := newSignedRequest().setFormParams(params{})
+		s.assertRequestEqual(e, r)
+	})
+	res, err := s.client.NewGetMultiAssetModeService().Do(newContext())
+	s.r().NoError(err)
+	s.r().Equal(res.MultiAssetsMargin, true)
+}


### PR DESCRIPTION
I found the endpoint `/fapi/v1/multiAssetsMargin` is not supported yet to get or change the multi-asset mode of a user.
I added the related services accordingly in the following files in `v2/futures`.
- client.go
- position_service.go
- position_service_test.go