### PR TITLE
Add "pu" final update Id in last stream(ie `u` in last stream)

### DIFF
--- a/v2/websocket_service.go
+++ b/v2/websocket_service.go
@@ -2,7 +2,6 @@ package binance
 
 import (
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
@@ -232,7 +231,6 @@ func wsCombinedDepthServe(endpoint string, handler WsDepthHandler, errHandler Er
 	wsHandler := func(message []byte) {
 		j, err := newJSON(message)
 
-		log.Println(j)
 		if err != nil {
 			errHandler(err)
 			return

--- a/v2/websocket_service.go
+++ b/v2/websocket_service.go
@@ -248,7 +248,7 @@ func wsCombinedDepthServe(endpoint string, handler WsDepthHandler, errHandler Er
 		event.Time, _ = data["E"].(stdjson.Number).Int64()
 		event.LastUpdateID, _ = data["u"].(stdjson.Number).Int64()
 		event.FirstUpdateID, _ = data["U"].(stdjson.Number).Int64()
-		// event.LastUpdateIDInLastStream, _ = data["pu"].(stdjson.Number).Int64()
+		event.LastUpdateIDInLastStream, _ = data["pu"].(stdjson.Number).Int64()
 		bidsLen := len(data["b"].([]interface{}))
 		event.Bids = make([]Bid, bidsLen)
 		for i := 0; i < bidsLen; i++ {


### PR DESCRIPTION
As per Binance specs we should be using "pu" (Final update Id in last stream(ie `u` in last stream) to detect that our local order book is out of order. This PR adds pu to the `WsDepthEvent `

https://binance-docs.github.io/apidocs/futures/en/#how-to-manage-a-local-order-book-correctly

