### PR TITLE
Adding `commissionRates` into the account service response

### DIFF
--- a/v2/account_service.go
+++ b/v2/account_service.go
@@ -31,17 +31,18 @@ func (s *GetAccountService) Do(ctx context.Context, opts ...RequestOption) (res 
 
 // Account define account info
 type Account struct {
-	MakerCommission  int64     `json:"makerCommission"`
-	TakerCommission  int64     `json:"takerCommission"`
-	BuyerCommission  int64     `json:"buyerCommission"`
-	SellerCommission int64     `json:"sellerCommission"`
-	CanTrade         bool      `json:"canTrade"`
-	CanWithdraw      bool      `json:"canWithdraw"`
-	CanDeposit       bool      `json:"canDeposit"`
-	UpdateTime       uint64    `json:"updateTime"`
-	AccountType      string    `json:"accountType"`
-	Balances         []Balance `json:"balances"`
-	Permissions      []string  `json:"permissions"`
+	MakerCommission  int64           `json:"makerCommission"`
+	TakerCommission  int64           `json:"takerCommission"`
+	BuyerCommission  int64           `json:"buyerCommission"`
+	SellerCommission int64           `json:"sellerCommission"`
+	CommissionRates  CommissionRates `json:"commissionRates"`
+	CanTrade         bool            `json:"canTrade"`
+	CanWithdraw      bool            `json:"canWithdraw"`
+	CanDeposit       bool            `json:"canDeposit"`
+	UpdateTime       uint64          `json:"updateTime"`
+	AccountType      string          `json:"accountType"`
+	Balances         []Balance       `json:"balances"`
+	Permissions      []string        `json:"permissions"`
 }
 
 // Balance define user balance of your account
@@ -58,6 +59,13 @@ type GetAccountSnapshotService struct {
 	startTime   *int64
 	endTime     *int64
 	limit       *int
+}
+
+type CommissionRates struct {
+	Maker  string `json:"maker"`
+	Taker  string `json:"taker"`
+	Buyer  string `json:"buyer"`
+	Seller string `json:"seller"`
 }
 
 // Type set account type ("SPOT", "MARGIN", "FUTURES")

--- a/v2/account_service_test.go
+++ b/v2/account_service_test.go
@@ -20,6 +20,12 @@ func (s *accountServiceTestSuite) TestGetAccount() {
 			"takerCommission": 15,
 			"buyerCommission": 0,
 			"sellerCommission": 0,
+			"commissionRates": {
+				"maker": "0.00150000",
+				"taker": "0.00150000",
+				"buyer": "0.00000000",
+				"seller": "0.00000000"
+			},
 			"canTrade": true,
 			"canWithdraw": true,
 			"canDeposit": true,
@@ -55,11 +61,17 @@ func (s *accountServiceTestSuite) TestGetAccount() {
 		TakerCommission:  15,
 		BuyerCommission:  0,
 		SellerCommission: 0,
-		CanTrade:         true,
-		CanWithdraw:      true,
-		CanDeposit:       true,
-		UpdateTime:       123456789,
-		AccountType:      "SPOT",
+		CommissionRates: CommissionRates{
+			Maker:  "0.00150000",
+			Taker:  "0.00150000",
+			Buyer:  "0.00000000",
+			Seller: "0.00000000",
+		},
+		CanTrade:    true,
+		CanWithdraw: true,
+		CanDeposit:  true,
+		UpdateTime:  123456789,
+		AccountType: "SPOT",
 		Balances: []Balance{
 			{
 				Asset:  "BTC",
@@ -83,6 +95,10 @@ func (s *accountServiceTestSuite) assertAccountEqual(e, a *Account) {
 	r.Equal(e.TakerCommission, a.TakerCommission, "TakerCommission")
 	r.Equal(e.BuyerCommission, a.BuyerCommission, "BuyerCommission")
 	r.Equal(e.SellerCommission, a.SellerCommission, "SellerCommission")
+	r.Equal(e.CommissionRates.Maker, a.CommissionRates.Maker, "CommissionRates.Maker")
+	r.Equal(e.CommissionRates.Taker, a.CommissionRates.Taker, "CommissionRates.Taker")
+	r.Equal(e.CommissionRates.Buyer, a.CommissionRates.Buyer, "CommissionRates.Buyer")
+	r.Equal(e.CommissionRates.Seller, a.CommissionRates.Seller, "CommissionRates.Seller")
 	r.Equal(e.CanTrade, a.CanTrade, "CanTrade")
 	r.Equal(e.CanWithdraw, a.CanWithdraw, "CanWithdraw")
 	r.Equal(e.CanDeposit, a.CanDeposit, "CanDeposit")


### PR DESCRIPTION
Adding `commissionRates` into the account service response. Fixing open issue **#492**