### PR TITLE
set futures create order parameter quantity as optional

### DIFF
--- a/v2/futures/order_service.go
+++ b/v2/futures/order_service.go
@@ -137,8 +137,10 @@ func (s *CreateOrderService) createOrder(ctx context.Context, endpoint string, o
 		"symbol":           s.symbol,
 		"side":             s.side,
 		"type":             s.orderType,
-		"quantity":         s.quantity,
 		"newOrderRespType": s.newOrderRespType,
+	}
+	if s.quantity != "" {
+		m["quantity"] = s.quantity
 	}
 	if s.positionSide != nil {
 		m["positionSide"] = *s.positionSide


### PR DESCRIPTION
As [/fapi/v1/order api](https://binance-docs.github.io/apidocs/futures/en/#new-order-trade) says, parameter `quantity` is optional, it cannot be sent with closePosition=true(Close-All). 

So we should check its value before set it.