### PR TITLE
changed bool types to string in reduceOnly, closePosition, priceProtect.

### DIFF
--- a/v2/delivery/order_service.go
+++ b/v2/delivery/order_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strconv"
 )
 
 // CreateOrderService create order
@@ -15,15 +16,15 @@ type CreateOrderService struct {
 	orderType        OrderType
 	timeInForce      *TimeInForceType
 	quantity         string
-	reduceOnly       *bool
+	reduceOnly       *string
 	price            *string
 	newClientOrderID *string
 	stopPrice        *string
-	closePosition    *bool
+	closePosition    *string
 	activationPrice  *string
 	callbackRate     *string
 	workingType      *WorkingType
-	priceProtect     *bool
+	priceProtect     *string
 	newOrderRespType NewOrderRespType
 }
 
@@ -65,7 +66,8 @@ func (s *CreateOrderService) Quantity(quantity string) *CreateOrderService {
 
 // ReduceOnly set reduceOnly
 func (s *CreateOrderService) ReduceOnly(reduceOnly bool) *CreateOrderService {
-	s.reduceOnly = &reduceOnly
+	reduceOnlyStr := strconv.FormatBool(reduceOnly)
+	s.reduceOnly = &reduceOnlyStr
 	return s
 }
 
@@ -107,7 +109,8 @@ func (s *CreateOrderService) CallbackRate(callbackRate string) *CreateOrderServi
 
 // PriceProtect set priceProtect
 func (s *CreateOrderService) PriceProtect(priceProtect bool) *CreateOrderService {
-	s.priceProtect = &priceProtect
+	priceProtectStr := strconv.FormatBool(priceProtect)
+	s.priceProtect = &priceProtectStr
 	return s
 }
 
@@ -119,7 +122,8 @@ func (s *CreateOrderService) NewOrderResponseType(newOrderResponseType NewOrderR
 
 // ClosePosition set closePosition
 func (s *CreateOrderService) ClosePosition(closePosition bool) *CreateOrderService {
-	s.closePosition = &closePosition
+	closePositionStr := strconv.FormatBool(closePosition)
+	s.closePosition = &closePositionStr
 	return s
 }
 

--- a/v2/delivery/order_service_test.go
+++ b/v2/delivery/order_service_test.go
@@ -1,6 +1,7 @@
 package delivery
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -71,15 +72,15 @@ func (s *orderServiceTestSuite) TestCreateOrder() {
 			"type":             orderType,
 			"timeInForce":      timeInForce,
 			"quantity":         quantity,
-			"reduceOnly":       reduceOnly,
+			"reduceOnly":       strconv.FormatBool(reduceOnly),
 			"price":            price,
 			"newClientOrderId": newClientOrderID,
 			"stopPrice":        stopPrice,
-			"closePosition":    closePosition,
+			"closePosition":    strconv.FormatBool(closePosition),
 			"activationPrice":  activationPrice,
 			"callbackRate":     callbackRate,
 			"workingType":      workingType,
-			"priceProtect":     priceProtect,
+			"priceProtect":     strconv.FormatBool(priceProtect),
 			"newOrderRespType": newOrderResponseType,
 		})
 		s.assertRequestEqual(e, r)

--- a/v2/futures/order_service.go
+++ b/v2/futures/order_service.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 )
 
@@ -18,16 +19,16 @@ type CreateOrderService struct {
 	orderType        OrderType
 	timeInForce      *TimeInForceType
 	quantity         string
-	reduceOnly       *bool
+	reduceOnly       *string
 	price            *string
 	newClientOrderID *string
 	stopPrice        *string
 	workingType      *WorkingType
 	activationPrice  *string
 	callbackRate     *string
-	priceProtect     *bool
+	priceProtect     *string
 	newOrderRespType NewOrderRespType
-	closePosition    *bool
+	closePosition    *string
 }
 
 // Symbol set symbol
@@ -68,7 +69,8 @@ func (s *CreateOrderService) Quantity(quantity string) *CreateOrderService {
 
 // ReduceOnly set reduceOnly
 func (s *CreateOrderService) ReduceOnly(reduceOnly bool) *CreateOrderService {
-	s.reduceOnly = &reduceOnly
+	reduceOnlyStr := strconv.FormatBool(reduceOnly)
+	s.reduceOnly = &reduceOnlyStr
 	return s
 }
 
@@ -110,7 +112,8 @@ func (s *CreateOrderService) CallbackRate(callbackRate string) *CreateOrderServi
 
 // PriceProtect set priceProtect
 func (s *CreateOrderService) PriceProtect(priceProtect bool) *CreateOrderService {
-	s.priceProtect = &priceProtect
+	priceProtectStr := strconv.FormatBool(priceProtect)
+	s.priceProtect = &priceProtectStr
 	return s
 }
 
@@ -122,7 +125,8 @@ func (s *CreateOrderService) NewOrderResponseType(newOrderResponseType NewOrderR
 
 // ClosePosition set closePosition
 func (s *CreateOrderService) ClosePosition(closePosition bool) *CreateOrderService {
-	s.closePosition = &closePosition
+	closePositionStr := strconv.FormatBool(closePosition)
+	s.closePosition = &closePositionStr
 	return s
 }
 

--- a/v2/futures/order_service_test.go
+++ b/v2/futures/order_service_test.go
@@ -2,6 +2,7 @@ package futures
 
 import (
 	"context"
+	"strconv"
 	"testing"
 
 	"github.com/adshao/go-binance/v2/common"
@@ -69,16 +70,16 @@ func (s *orderServiceTestSuite) TestCreateOrder() {
 			"timeInForce":      timeInForce,
 			"positionSide":     positionSide,
 			"quantity":         quantity,
-			"reduceOnly":       reduceOnly,
+			"reduceOnly":       strconv.FormatBool(reduceOnly),
 			"price":            price,
 			"newClientOrderId": newClientOrderID,
 			"stopPrice":        stopPrice,
 			"workingType":      workingType,
 			"activationPrice":  activationPrice,
 			"callbackRate":     callbackRate,
-			"priceProtect":     priceProtect,
+			"priceProtect":     strconv.FormatBool(priceProtect),
 			"newOrderRespType": newOrderResponseType,
-			"closePosition":    closePosition,
+			"closePosition":    strconv.FormatBool(closePosition),
 		})
 		s.assertRequestEqual(e, r)
 	})


### PR DESCRIPTION
There are should be STRING types in this fields. 
<img width="551" alt="image" src="https://github.com/adshao/go-binance/assets/54941444/f1cda6dc-7d5f-4e96-8956-aa2cf8e68efa">

BOOL type is still working in single order requests, but not is batch ones.