### PR TITLE
Added breakEvenPrice data

### DIFF
--- a/v2/futures/position_risk.go
+++ b/v2/futures/position_risk.go
@@ -43,6 +43,7 @@ func (s *GetPositionRiskService) Do(ctx context.Context, opts ...RequestOption) 
 // PositionRisk define position risk info
 type PositionRisk struct {
 	EntryPrice       string `json:"entryPrice"`
+	BreakEvenPrice   string `json:"breakEvenPrice"`
 	MarginType       string `json:"marginType"`
 	IsAutoAddMargin  string `json:"isAutoAddMargin"`
 	IsolatedMargin   string `json:"isolatedMargin"`

--- a/v2/futures/position_risk_test.go
+++ b/v2/futures/position_risk_test.go
@@ -18,6 +18,7 @@ func (s *positionRiskServiceTestSuite) TestGetPositionRisk() {
 	data := []byte(`[
 		{
 			"entryPrice": "10359.38000",
+			"breakEvenPrice": "10387.38000",
 			"marginType": "isolated",
 			"isAutoAddMargin": "false",
 			"isolatedMargin": "3.15899368",
@@ -50,6 +51,7 @@ func (s *positionRiskServiceTestSuite) TestGetPositionRisk() {
 	r.Len(res, 1)
 	e := &PositionRisk{
 		EntryPrice:       "10359.38000",
+		BreakEvenPrice:   "10387.38000",
 		MarginType:       "isolated",
 		IsAutoAddMargin:  "false",
 		IsolatedMargin:   "3.15899368",
@@ -68,6 +70,7 @@ func (s *positionRiskServiceTestSuite) TestGetPositionRisk() {
 func (s *positionRiskServiceTestSuite) assertPositionRiskEqual(e, a *PositionRisk) {
 	r := s.r()
 	r.Equal(e.EntryPrice, a.EntryPrice, "EntryPrice")
+	r.Equal(e.BreakEvenPrice, a.BreakEvenPrice, "BreakEvenPrice")
 	r.Equal(e.MarginType, a.MarginType, "MarginType")
 	r.Equal(e.IsAutoAddMargin, a.IsAutoAddMargin, "IsAutoAddMargin")
 	r.Equal(e.IsolatedMargin, a.IsolatedMargin, "IsolatedMargin")


### PR DESCRIPTION
![image](https://github.com/adshao/go-binance/assets/680980/5da5c704-2535-44ea-8f8c-2e2f63b9fd43)

`breakEvenPrice` is available in binance's production server and API doc but not applied in the source code yet.
I just added those.