### PR TITLE
fix!: replace `FristID` with `FirstID`

### DIFF
--- a/v2/delivery/ticker_service.go
+++ b/v2/delivery/ticker_service.go
@@ -171,7 +171,7 @@ type PriceChangeStats struct {
 	BaseVolume         string `json:"baseVolume"`
 	OpenTime           int64  `json:"openTime"`
 	CloseTime          int64  `json:"closeTime"`
-	FristID            int64  `json:"firstId"`
+	FirstID            int64  `json:"firstId"`
 	LastID             int64  `json:"lastId"`
 	Count              int64  `json:"count"`
 }

--- a/v2/delivery/ticker_service_test.go
+++ b/v2/delivery/ticker_service_test.go
@@ -345,7 +345,7 @@ func (s *tickerServiceTestSuite) TestListPriceChangeStats() {
 		BaseVolume:         "138965.76942775",
 		OpenTime:           1623748920000,
 		CloseTime:          1623835355736,
-		FristID:            172749700,
+		FirstID:            172749700,
 		LastID:             173464362,
 		Count:              714658,
 	}
@@ -364,7 +364,7 @@ func (s *tickerServiceTestSuite) TestListPriceChangeStats() {
 		BaseVolume:         "648179.55304919",
 		OpenTime:           1623748920000,
 		CloseTime:          1623835355187,
-		FristID:            138575549,
+		FirstID:            138575549,
 		LastID:             139103143,
 		Count:              527595,
 	}
@@ -423,7 +423,7 @@ func (s *tickerServiceTestSuite) TestSinglePriceChangeStats() {
 		BaseVolume:         "137750.93213717",
 		OpenTime:           1623752520000,
 		CloseTime:          1623838964257,
-		FristID:            172782522,
+		FirstID:            172782522,
 		LastID:             173490102,
 		Count:              707576,
 	}
@@ -498,7 +498,7 @@ func (s *tickerServiceTestSuite) TestPriceChangeStatsWithPair() {
 		BaseVolume:         "8300.32545198",
 		OpenTime:           1623755580000,
 		CloseTime:          1623842010140,
-		FristID:            7516015,
+		FirstID:            7516015,
 		LastID:             7591268,
 		Count:              75254,
 	}
@@ -517,7 +517,7 @@ func (s *tickerServiceTestSuite) TestPriceChangeStatsWithPair() {
 		BaseVolume:         "13637.88521626",
 		OpenTime:           1623755580000,
 		CloseTime:          1623842010656,
-		FristID:            32157829,
+		FirstID:            32157829,
 		LastID:             32307537,
 		Count:              149709,
 	}
@@ -541,7 +541,7 @@ func (s *tickerServiceTestSuite) assertPriceChangeStatsEqual(e, a *PriceChangeSt
 	r.Equal(e.BaseVolume, a.BaseVolume, "BaseVolume")
 	r.Equal(e.OpenTime, a.OpenTime, "OpenTime")
 	r.Equal(e.CloseTime, a.CloseTime, "CloseTime")
-	r.Equal(e.FristID, a.FristID, "FristID")
+	r.Equal(e.FirstID, a.FirstID, "FirstID")
 	r.Equal(e.LastID, a.LastID, "LastID")
 	r.Equal(e.Count, a.Count, "Count")
 }

--- a/v2/futures/ticker_service.go
+++ b/v2/futures/ticker_service.go
@@ -141,7 +141,7 @@ type PriceChangeStats struct {
 	QuoteVolume        string `json:"quoteVolume"`
 	OpenTime           int64  `json:"openTime"`
 	CloseTime          int64  `json:"closeTime"`
-	FristID            int64  `json:"firstId"`
+	FirstID            int64  `json:"firstId"`
 	LastID             int64  `json:"lastId"`
 	Count              int64  `json:"count"`
 }

--- a/v2/futures/ticker_service_test.go
+++ b/v2/futures/ticker_service_test.go
@@ -214,7 +214,7 @@ func (s *tickerServiceTestSuite) TestPriceChangeStats() {
 		Volume:             "8913.30000000",
 		OpenTime:           1499783499040,
 		CloseTime:          1499869899040,
-		FristID:            28385,
+		FirstID:            28385,
 		LastID:             28460,
 		Count:              76,
 	}
@@ -236,7 +236,7 @@ func (s *tickerServiceTestSuite) assertPriceChangeStatsEqual(e, a *PriceChangeSt
 	r.Equal(e.Volume, a.Volume, "Volume")
 	r.Equal(e.OpenTime, a.OpenTime, "OpenTime")
 	r.Equal(e.CloseTime, a.CloseTime, "CloseTime")
-	r.Equal(e.FristID, a.FristID, "FristID")
+	r.Equal(e.FirstID, a.FirstID, "FirstID")
 	r.Equal(e.LastID, a.LastID, "LastID")
 	r.Equal(e.Count, a.Count, "Count")
 }
@@ -289,7 +289,7 @@ func (s *tickerServiceTestSuite) TestListPriceChangeStats() {
 			QuoteVolume:        "15.30000000",
 			OpenTime:           1499783499040,
 			CloseTime:          1499869899040,
-			FristID:            28385,
+			FirstID:            28385,
 			LastID:             28460,
 			Count:              76,
 		},

--- a/v2/ticker_service.go
+++ b/v2/ticker_service.go
@@ -165,7 +165,7 @@ type PriceChangeStats struct {
 	QuoteVolume        string `json:"quoteVolume"`
 	OpenTime           int64  `json:"openTime"`
 	CloseTime          int64  `json:"closeTime"`
-	FristID            int64  `json:"firstId"`
+	FirstID            int64  `json:"firstId"`
 	LastID             int64  `json:"lastId"`
 	Count              int64  `json:"count"`
 }

--- a/v2/ticker_service_test.go
+++ b/v2/ticker_service_test.go
@@ -265,7 +265,7 @@ func (s *tickerServiceTestSuite) TestPriceChangeStats() {
 		Volume:             "8913.30000000",
 		OpenTime:           1499783499040,
 		CloseTime:          1499869899040,
-		FristID:            28385,
+		FirstID:            28385,
 		LastID:             28460,
 		Count:              76,
 		BidQty:             "300.00000000",
@@ -291,7 +291,7 @@ func (s *tickerServiceTestSuite) assertPriceChangeStatsEqual(e, a *PriceChangeSt
 	r.Equal(e.Volume, a.Volume, "Volume")
 	r.Equal(e.OpenTime, a.OpenTime, "OpenTime")
 	r.Equal(e.CloseTime, a.CloseTime, "CloseTime")
-	r.Equal(e.FristID, a.FristID, "FristID")
+	r.Equal(e.FirstID, a.FirstID, "FirstID")
 	r.Equal(e.LastID, a.LastID, "LastID")
 	r.Equal(e.Count, a.Count, "Count")
 }
@@ -365,7 +365,7 @@ func (s *tickerServiceTestSuite) TestMultiplePriceChangeStats() {
 			QuoteVolume:        "15.30000000",
 			OpenTime:           1499783499040,
 			CloseTime:          1499869899040,
-			FristID:            28385,
+			FirstID:            28385,
 			LastID:             28460,
 			Count:              76,
 		},
@@ -385,7 +385,7 @@ func (s *tickerServiceTestSuite) TestMultiplePriceChangeStats() {
 			QuoteVolume:        "115.30000000",
 			OpenTime:           1499783499041,
 			CloseTime:          1499869899041,
-			FristID:            28381,
+			FirstID:            28381,
 			LastID:             28461,
 			Count:              71,
 		},
@@ -442,7 +442,7 @@ func (s *tickerServiceTestSuite) TestListPriceChangeStats() {
 			QuoteVolume:        "15.30000000",
 			OpenTime:           1499783499040,
 			CloseTime:          1499869899040,
-			FristID:            28385,
+			FirstID:            28385,
 			LastID:             28460,
 			Count:              76,
 		},
@@ -467,11 +467,10 @@ func (s *tickerServiceTestSuite) assertListPriceChangeStatsEqual(e, a []*PriceCh
 		r.Equal(e[i].Volume, a[i].Volume, "Volume")
 		r.Equal(e[i].OpenTime, a[i].OpenTime, "OpenTime")
 		r.Equal(e[i].CloseTime, a[i].CloseTime, "CloseTime")
-		r.Equal(e[i].FristID, a[i].FristID, "FristID")
+		r.Equal(e[i].FirstID, a[i].FirstID, "FirstID")
 		r.Equal(e[i].LastID, a[i].LastID, "LastID")
 		r.Equal(e[i].Count, a[i].Count, "Count")
 	}
-
 }
 
 func (s *tickerServiceTestSuite) TestAveragePrice() {


### PR DESCRIPTION
This is a breaking change. However, I think it should be fixed because all existing users can easily fix their code (it's just a typo).