### PR TITLE
feat(futures): add premium index klines service

### DIFF
--- a/v2/futures/client.go
+++ b/v2/futures/client.go
@@ -536,6 +536,11 @@ func (c *Client) NewPremiumIndexService() *PremiumIndexService {
 	return &PremiumIndexService{c: c}
 }
 
+// NewPremiumIndexKlinesService init premium index klines service
+func (c *Client) NewPremiumIndexKlinesService() *PremiumIndexKlinesService {
+	return &PremiumIndexKlinesService{c: c}
+}
+
 // NewFundingRateService init funding rate service
 func (c *Client) NewFundingRateService() *FundingRateService {
 	return &FundingRateService{c: c}

--- a/v2/futures/index_price_kline_service_test.go
+++ b/v2/futures/index_price_kline_service_test.go
@@ -55,7 +55,7 @@ func (s *indexPriceKlineServiceTestSuite) TestKlines() {
 	endTime := int64(1499040000001)
 	s.assertReq(func(r *request) {
 		e := newRequest().setParams(params{
-			"symbol":    symbol,
+			"pair":      symbol,
 			"interval":  interval,
 			"limit":     limit,
 			"startTime": startTime,
@@ -63,9 +63,13 @@ func (s *indexPriceKlineServiceTestSuite) TestKlines() {
 		})
 		s.assertRequestEqual(e, r)
 	})
-	klines, err := s.client.NewKlinesService().Symbol(symbol).
-		Interval(interval).Limit(limit).StartTime(startTime).
-		EndTime(endTime).Do(newContext())
+	klines, err := s.client.NewIndexPriceKlinesService().
+		Pair(symbol).
+		Interval(interval).
+		Limit(limit).
+		StartTime(startTime).
+		EndTime(endTime).
+		Do(newContext())
 	s.r().NoError(err)
 	s.Len(klines, 2)
 	kline1 := &Kline{

--- a/v2/futures/premium_index_kline_service.go
+++ b/v2/futures/premium_index_kline_service.go
@@ -1,0 +1,92 @@
+package futures
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// PremiumIndexKlinesService list klines
+type PremiumIndexKlinesService struct {
+	c         *Client
+	symbol    string
+	interval  string
+	limit     *int
+	startTime *int64
+	endTime   *int64
+}
+
+// Symbol sets symbol
+func (piks *PremiumIndexKlinesService) Symbol(symbol string) *PremiumIndexKlinesService {
+	piks.symbol = symbol
+	return piks
+}
+
+// Interval set interval
+func (piks *PremiumIndexKlinesService) Interval(interval string) *PremiumIndexKlinesService {
+	piks.interval = interval
+	return piks
+}
+
+// Limit set limit
+func (piks *PremiumIndexKlinesService) Limit(limit int) *PremiumIndexKlinesService {
+	piks.limit = &limit
+	return piks
+}
+
+// StartTime set startTime
+func (piks *PremiumIndexKlinesService) StartTime(startTime int64) *PremiumIndexKlinesService {
+	piks.startTime = &startTime
+	return piks
+}
+
+// EndTime set endTime
+func (piks *PremiumIndexKlinesService) EndTime(endTime int64) *PremiumIndexKlinesService {
+	piks.endTime = &endTime
+	return piks
+}
+
+// Do send request
+func (piks *PremiumIndexKlinesService) Do(ctx context.Context, opts ...RequestOption) (res []*Kline, err error) {
+	r := &request{
+		method:   http.MethodGet,
+		endpoint: "/fapi/v1/premiumIndexKlines",
+	}
+	r.setParam("symbol", piks.symbol)
+	r.setParam("interval", piks.interval)
+	if piks.limit != nil {
+		r.setParam("limit", *piks.limit)
+	}
+	if piks.startTime != nil {
+		r.setParam("startTime", *piks.startTime)
+	}
+	if piks.endTime != nil {
+		r.setParam("endTime", *piks.endTime)
+	}
+	data, _, err := piks.c.callAPI(ctx, r, opts...)
+	if err != nil {
+		return []*Kline{}, err
+	}
+	j, err := newJSON(data)
+	if err != nil {
+		return []*Kline{}, err
+	}
+	num := len(j.MustArray())
+	res = make([]*Kline, num)
+	for i := 0; i < num; i++ {
+		item := j.GetIndex(i)
+		if len(item.MustArray()) < 11 {
+			err = fmt.Errorf("invalid kline response")
+			return []*Kline{}, err
+		}
+		res[i] = &Kline{
+			OpenTime:  item.GetIndex(0).MustInt64(),
+			Open:      item.GetIndex(1).MustString(),
+			High:      item.GetIndex(2).MustString(),
+			Low:       item.GetIndex(3).MustString(),
+			Close:     item.GetIndex(4).MustString(),
+			CloseTime: item.GetIndex(6).MustInt64(),
+		}
+	}
+	return res, nil
+}

--- a/v2/futures/premium_index_kline_service_test.go
+++ b/v2/futures/premium_index_kline_service_test.go
@@ -1,0 +1,103 @@
+package futures
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type premiumIndexKlinesServiceTestSuite struct {
+	baseTestSuite
+}
+
+func TestPremiumIndexKlinesService(t *testing.T) {
+	suite.Run(t, new(premiumIndexKlinesServiceTestSuite))
+}
+
+func (s *premiumIndexKlinesServiceTestSuite) TestKlines() {
+	data := []byte(`[
+        [
+            1499040000000,
+            "0.01634790",
+            "0.80000000",
+            "0.01575800",
+            "0.01577100",
+            "148976.11427815",
+            1499644799999,
+            "2434.19055334",
+            308,
+            "1756.87402397",
+            "28.46694368",
+            "17928899.62484339"
+        ],
+        [
+            1499040000001,
+            "0.01634790",
+            "0.80000000",
+            "0.01575800",
+            "0.01577101",
+            "148976.11427815",
+            1499644799999,
+            "2434.19055334",
+            308,
+            "1756.87402397",
+            "28.46694368",
+            "17928899.62484339"
+        ]
+    ]`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	symbol := "LTCBTC"
+	interval := "15m"
+	limit := 10
+	startTime := int64(1499040000000)
+	endTime := int64(1499040000001)
+	s.assertReq(func(r *request) {
+		e := newRequest().setParams(params{
+			"symbol":    symbol,
+			"interval":  interval,
+			"limit":     limit,
+			"startTime": startTime,
+			"endTime":   endTime,
+		})
+		s.assertRequestEqual(e, r)
+	})
+	klines, err := s.client.NewPremiumIndexKlinesService().
+		Symbol(symbol).
+		Interval(interval).
+		Limit(limit).
+		StartTime(startTime).
+		EndTime(endTime).
+		Do(newContext())
+	s.r().NoError(err)
+	s.Len(klines, 2)
+	kline1 := &Kline{
+		OpenTime:  1499040000000,
+		Open:      "0.01634790",
+		High:      "0.80000000",
+		Low:       "0.01575800",
+		Close:     "0.01577100",
+		CloseTime: 1499644799999,
+	}
+	kline2 := &Kline{
+		OpenTime:  1499040000001,
+		Open:      "0.01634790",
+		High:      "0.80000000",
+		Low:       "0.01575800",
+		Close:     "0.01577101",
+		CloseTime: 1499644799999,
+	}
+	s.assertKlineEqual(kline1, klines[0])
+	s.assertKlineEqual(kline2, klines[1])
+}
+
+func (s *premiumIndexKlinesServiceTestSuite) assertKlineEqual(e, a *Kline) {
+	r := s.r()
+	r.Equal(e.OpenTime, a.OpenTime, "OpenTime")
+	r.Equal(e.Open, a.Open, "Open")
+	r.Equal(e.High, a.High, "High")
+	r.Equal(e.Low, a.Low, "Low")
+	r.Equal(e.Close, a.Close, "Close")
+	r.Equal(e.CloseTime, a.CloseTime, "CloseTime")
+}


### PR DESCRIPTION
The library currently doesn't support fetching premium index klines. I added a new service that implements this functionality.

Also, I discovered `v2/futures/index_price_kline_service_test.go` doesn't call method for fetching index price klines (despite its name). I replaced `NewKlinesService()` with `NewIndexPriceKlinesService()` and made a couple of other changes to make tests pass.

Sorry for making two almost unrelated changes in one PR. I believe it won't be a big problem apart from being a bad practice.