### PR TITLE
change /fapi/v1/ticker/price to v2 version /fapi/v2/ticker/price

### DIFF
--- a/v2/futures/ticker_service.go
+++ b/v2/futures/ticker_service.go
@@ -67,7 +67,7 @@ func (s *ListPricesService) Symbol(symbol string) *ListPricesService {
 func (s *ListPricesService) Do(ctx context.Context, opts ...RequestOption) (res []*SymbolPrice, err error) {
 	r := &request{
 		method:   http.MethodGet,
-		endpoint: "/fapi/v1/ticker/price",
+		endpoint: "/fapi/v2/ticker/price",
 	}
 	if s.symbol != nil {
 		r.setParam("symbol", *s.symbol)


### PR DESCRIPTION
GET /fapi/v2/ticker/price: this is v2 endpoint for querying latest price. It has same parameters and response as the GET /fapi/v1/ticker/price, and it offers lower latency and consume less of the IP rate limit. Please note that the GET /fapi/v1/ticker/price will be deprecated in the future, with the exact timing to be determined.

https://binance-docs.github.io/apidocs/futures/en/#change-log