### PR TITLE
Add missing StatusCode

### DIFF
--- a/v2/common/errors.go
+++ b/v2/common/errors.go
@@ -6,13 +6,14 @@ import (
 
 // APIError define API error when response status is 4xx or 5xx
 type APIError struct {
-	Code    int64  `json:"code"`
-	Message string `json:"msg"`
+	StatusCode int    `json:"-"`
+	Code       int64  `json:"code"`
+	Message    string `json:"msg"`
 }
 
 // Error return error code and message
 func (e APIError) Error() string {
-	return fmt.Sprintf("<APIError> code=%d, msg=%s", e.Code, e.Message)
+	return fmt.Sprintf("<APIError> status_code=%d, code=%d, msg=%s", e.StatusCode, e.Code, e.Message)
 }
 
 // IsAPIError check if e is an API error


### PR DESCRIPTION
Binance api return 4xx HTTP StatusCode represent client error, but the code and message not required in response body. So it would be better fill the StatusCode in APIError to provide more information.