### PR TITLE
Add SubAccountFuturesTransferV1Service

### DIFF
--- a/v2/client.go
+++ b/v2/client.go
@@ -1022,3 +1022,8 @@ func (c *Client) NewSubAccountFuturesAccountService() *SubAccountFuturesAccountS
 func (c *Client) NewSubAccountFuturesSummaryV1Service() *SubAccountFuturesSummaryV1Service {
 	return &SubAccountFuturesSummaryV1Service{c: c}
 }
+
+// NewSubAccountFuturesTransferV1Service Futures Transfer for Sub-account (For Master Account)
+func (c *Client) NewSubAccountFuturesTransferV1Service() *SubAccountFuturesTransferV1Service {
+	return &SubAccountFuturesTransferV1Service{c: c}
+}

--- a/v2/subaccount_service.go
+++ b/v2/subaccount_service.go
@@ -2,6 +2,7 @@ package binance
 
 import (
 	"context"
+	"net/http"
 )
 
 // TransferToSubAccountService transfer to subaccount
@@ -646,7 +647,7 @@ func (s *SubAccountFuturesTransferV1Service) TransferType(v int) *SubAccountFutu
 
 func (s *SubAccountFuturesTransferV1Service) Do(ctx context.Context, opts ...RequestOption) (res *SubAccountFuturesTransferResponse, err error) {
 	r := &request{
-		method:   "POST",
+		method:   http.MethodPost,
 		endpoint: "/sapi/v1/sub-account/futures/transfer",
 		secType:  secTypeSigned,
 	}
@@ -656,7 +657,7 @@ func (s *SubAccountFuturesTransferV1Service) Do(ctx context.Context, opts ...Req
 		"amount": s.amount,
 		"type":   s.transferType,
 	}
-	r.setFormParams(m)
+	r.setParams(m)
 	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return nil, err

--- a/v2/subaccount_service.go
+++ b/v2/subaccount_service.go
@@ -607,3 +607,68 @@ type SubAccountFuturesSummaryV1SubAccountList struct {
 	Email string `json:"email"`
 	SubAccountFuturesSummaryCommon
 }
+
+// SubAccountFuturesTransferV1Service Futures Transfer for Sub-account (For Master Account)
+// https://binance-docs.github.io/apidocs/spot/en/#futures-transfer-for-sub-account-for-master-account
+type SubAccountFuturesTransferV1Service struct {
+	c      *Client
+	email  string
+	asset  string
+	amount float64
+	/*
+		1: transfer from subaccount's spot account to its USDT-margined futures account
+		2: transfer from subaccount's USDT-margined futures account to its spot account
+		3: transfer from subaccount's spot account to its COIN-margined futures account
+		4:transfer from subaccount's COIN-margined futures account to its spot account
+	*/
+	transferType int
+}
+
+func (s *SubAccountFuturesTransferV1Service) Email(v string) *SubAccountFuturesTransferV1Service {
+	s.email = v
+	return s
+}
+
+func (s *SubAccountFuturesTransferV1Service) Asset(v string) *SubAccountFuturesTransferV1Service {
+	s.asset = v
+	return s
+}
+
+func (s *SubAccountFuturesTransferV1Service) Amount(v float64) *SubAccountFuturesTransferV1Service {
+	s.amount = v
+	return s
+}
+
+func (s *SubAccountFuturesTransferV1Service) TransferType(v int) *SubAccountFuturesTransferV1Service {
+	s.transferType = v
+	return s
+}
+
+func (s *SubAccountFuturesTransferV1Service) Do(ctx context.Context, opts ...RequestOption) (res *SubAccountFuturesTransferResponse, err error) {
+	r := &request{
+		method:   "POST",
+		endpoint: "/sapi/v1/sub-account/futures/transfer",
+		secType:  secTypeSigned,
+	}
+	m := params{
+		"email":  s.email,
+		"asset":  s.asset,
+		"amount": s.amount,
+		"type":   s.transferType,
+	}
+	r.setFormParams(m)
+	data, err := s.c.callAPI(ctx, r, opts...)
+	if err != nil {
+		return nil, err
+	}
+	res = new(SubAccountFuturesTransferResponse)
+	err = json.Unmarshal(data, res)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+type SubAccountFuturesTransferResponse struct {
+	TxnID int64 `json:"txnId"`
+}

--- a/v2/subaccount_service_test.go
+++ b/v2/subaccount_service_test.go
@@ -301,3 +301,35 @@ func (s *subAccountServiceTestSuite) assertAccountFuturesAssetsEqual(e, a *SubAc
 	r.Equal(e.UnrealizedProfit, a.UnrealizedProfit, "UnrealizedProfit")
 	r.Equal(e.WalletBalance, a.WalletBalance, "WalletBalance")
 }
+
+func (s *subAccountServiceTestSuite) TestSubAccountFuturesTransferService() {
+	data := []byte(`
+		{
+		    "txnId": "123456789",
+		}
+	`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	email := "abc@test.com"
+	asset := "USDT"
+	amount := 1.0
+	tType := 1
+	s.assertReq(func(r *request) {
+		e := newSignedRequest().
+			setParams(params{
+				"email":  email,
+				"asset":  asset,
+				"amount": amount,
+				"type":   tType,
+			})
+		s.assertRequestEqual(e, r)
+	})
+
+	response, err := s.client.NewSubAccountFuturesTransferV1Service().Email(email).Asset(asset).Amount(amount).TransferType(tType).Do(newContext())
+
+	r := s.r()
+	r.NoError(err)
+	r.Equal("123456789", response.TxnID, "TxnID")
+
+}


### PR DESCRIPTION
implement [/sapi/v1/sub-account/futures/transfer](https://binance-docs.github.io/apidocs/spot/en/#futures-transfer-for-sub-account-for-master-account)