### PR TITLE
[Bug]Funding Rate History response struct error

### DIFF
--- a/v2/futures/mark_price.go
+++ b/v2/futures/mark_price.go
@@ -119,7 +119,7 @@ type FundingRate struct {
 	Symbol      string `json:"symbol"`
 	FundingRate string `json:"fundingRate"`
 	FundingTime int64  `json:"fundingTime"`
-	Time        int64  `json:"time"`
+	MarkPrice   int64  `json:"markPrice"`
 }
 
 // GetLeverageBracketService get funding rate


### PR DESCRIPTION
Hi @adshao,
https://binance-docs.github.io/apidocs/futures/en/#get-funding-rate-history