### PR TITLE
Implement subaccount transfer history and refactor user universal transfer

### DIFF
--- a/v2/client.go
+++ b/v2/client.go
@@ -102,6 +102,9 @@ type RateLimitInterval string
 // AccountType define the account types
 type AccountType string
 
+// SubAccountTransferType define the sub account transfer types
+type SubAccountTransferType int
+
 // Endpoints
 var (
 	BaseAPIMainURL    = "https://api.binance.com"
@@ -239,6 +242,9 @@ const (
 	AccountTypeIsolatedMargin AccountType = "ISOLATED_MARGIN"
 	AccountTypeUSDTFuture     AccountType = "USDT_FUTURE"
 	AccountTypeCoinFuture     AccountType = "COIN_FUTURE"
+
+	SubAccountTransferTypeTransferIn  SubAccountTransferType = 1
+	SubAccountTransferTypeTransferOut SubAccountTransferType = 2
 )
 
 func currentTimestamp() int64 {
@@ -1026,4 +1032,9 @@ func (c *Client) NewSubAccountFuturesSummaryV1Service() *SubAccountFuturesSummar
 // NewSubAccountFuturesTransferV1Service Futures Transfer for Sub-account (For Master Account)
 func (c *Client) NewSubAccountFuturesTransferV1Service() *SubAccountFuturesTransferV1Service {
 	return &SubAccountFuturesTransferV1Service{c: c}
+}
+
+// NewSubAccountTransferHistoryService Transfer History for Sub-account (For Sub-account)
+func (c *Client) NewSubAccountTransferHistoryService() *SubAccountTransferHistoryService {
+	return &SubAccountTransferHistoryService{c: c}
 }

--- a/v2/client.go
+++ b/v2/client.go
@@ -105,6 +105,12 @@ type AccountType string
 // SubAccountTransferType define the sub account transfer types
 type SubAccountTransferType int
 
+// UserUniversalTransferType define the user universal transfer types
+type UserUniversalTransferType string
+
+// UserUniversalTransferStatus define the user universal transfer status
+type UserUniversalTransferStatusType string
+
 // Endpoints
 var (
 	BaseAPIMainURL    = "https://api.binance.com"
@@ -245,6 +251,44 @@ const (
 
 	SubAccountTransferTypeTransferIn  SubAccountTransferType = 1
 	SubAccountTransferTypeTransferOut SubAccountTransferType = 2
+
+	UserUniversalTransferTypeMainToUmFutures                UserUniversalTransferType = "MAIN_UMFUTURE"
+	UserUniversalTransferTypeMainToCmFutures                UserUniversalTransferType = "MAIN_CMFUTURE"
+	UserUniversalTransferTypeMainToMargin                   UserUniversalTransferType = "MAIN_MARGIN"
+	UserUniversalTransferTypeUmFuturesToMain                UserUniversalTransferType = "UMFUTURE_MAIN"
+	UserUniversalTransferTypeUmFuturesToMargin              UserUniversalTransferType = "UMFUTURE_MARGIN"
+	UserUniversalTransferTypeCmFuturesToMain                UserUniversalTransferType = "CMFUTURE_MAIN"
+	UserUniversalTransferTypeMarginToMain                   UserUniversalTransferType = "MARGIN_MAIN"
+	UserUniversalTransferTypeMarginToUmFutures              UserUniversalTransferType = "MARGIN_UMFUTURE"
+	UserUniversalTransferTypeMarginToCmFutures              UserUniversalTransferType = "MARGIN_CMFUTURE"
+	UserUniversalTransferTypeCmFuturesToMargin              UserUniversalTransferType = "CMFUTURE_MARGIN"
+	UserUniversalTransferTypeIsolatedMarginToMargin         UserUniversalTransferType = "ISOLATEDMARGIN_MARGIN"
+	UserUniversalTransferTypeMarginToIsolatedMargin         UserUniversalTransferType = "MARGIN_ISOLATEDMARGIN"
+	UserUniversalTransferTypeIsolatedMarginToIsolatedMargin UserUniversalTransferType = "ISOLATEDMARGIN_ISOLATEDMARGIN"
+	UserUniversalTransferTypeMainToFunding                  UserUniversalTransferType = "MAIN_FUNDING"
+	UserUniversalTransferTypeFundingToMain                  UserUniversalTransferType = "FUNDING_MAIN"
+	UserUniversalTransferTypeFundingToUmFutures             UserUniversalTransferType = "FUNDING_UMFUTURE"
+	UserUniversalTransferTypeUmFuturesToFunding             UserUniversalTransferType = "UMFUTURE_FUNDING"
+	UserUniversalTransferTypeMarginToFunding                UserUniversalTransferType = "MARGIN_FUNDING"
+	UserUniversalTransferTypeFundingToMargin                UserUniversalTransferType = "FUNDING_MARGIN"
+	UserUniversalTransferTypeFundingToCmFutures             UserUniversalTransferType = "FUNDING_CMFUTURE"
+	UserUniversalTransferTypeCmFuturesToFunding             UserUniversalTransferType = "CMFUTURE_FUNDING"
+	UserUniversalTransferTypeMainToOption                   UserUniversalTransferType = "MAIN_OPTION"
+	UserUniversalTransferTypeOptionToMain                   UserUniversalTransferType = "OPTION_MAIN"
+	UserUniversalTransferTypeUmFuturesToOption              UserUniversalTransferType = "UMFUTURE_OPTION"
+	UserUniversalTransferTypeOptionToUmFutures              UserUniversalTransferType = "OPTION_UMFUTURE"
+	UserUniversalTransferTypeMarginToOption                 UserUniversalTransferType = "MARGIN_OPTION"
+	UserUniversalTransferTypeOptionToMargin                 UserUniversalTransferType = "OPTION_MARGIN"
+	UserUniversalTransferTypeFundingToOption                UserUniversalTransferType = "FUNDING_OPTION"
+	UserUniversalTransferTypeOptionToFunding                UserUniversalTransferType = "OPTION_FUNDING"
+	UserUniversalTransferTypeMainToPortfolioMargin          UserUniversalTransferType = "MAIN_PORTFOLIO_MARGIN"
+	UserUniversalTransferTypePortfolioMarginToMain          UserUniversalTransferType = "PORTFOLIO_MARGIN_MAIN"
+	UserUniversalTransferTypeMainToIsolatedMargin           UserUniversalTransferType = "MAIN_ISOLATED_MARGIN"
+	UserUniversalTransferTypeIsolatedMarginToMain           UserUniversalTransferType = "ISOLATED_MARGIN_MAIN"
+
+	UserUniversalTransferStatusTypePending   UserUniversalTransferStatusType = "PENDING"
+	UserUniversalTransferStatusTypeConfirmed UserUniversalTransferStatusType = "CONFIRMED"
+	UserUniversalTransferStatusTypeFailed    UserUniversalTransferStatusType = "FAILED"
 )
 
 func currentTimestamp() int64 {
@@ -1037,4 +1081,9 @@ func (c *Client) NewSubAccountFuturesTransferV1Service() *SubAccountFuturesTrans
 // NewSubAccountTransferHistoryService Transfer History for Sub-account (For Sub-account)
 func (c *Client) NewSubAccountTransferHistoryService() *SubAccountTransferHistoryService {
 	return &SubAccountTransferHistoryService{c: c}
+}
+
+// NewListUserUniversalTransferService Query User Universal Transfer History
+func (c *Client) NewListUserUniversalTransferService() *ListUserUniversalTransferService {
+	return &ListUserUniversalTransferService{c: c}
 }

--- a/v2/subaccount_service.go
+++ b/v2/subaccount_service.go
@@ -3,7 +3,6 @@ package binance
 import (
 	"context"
 	"net/http"
-	"time"
 )
 
 // TransferToSubAccountService transfer to subaccount
@@ -698,15 +697,13 @@ func (s *SubAccountTransferHistoryService) TransferType(v SubAccountTransferType
 	return s
 }
 
-func (s *SubAccountTransferHistoryService) StartTime(t time.Time) *SubAccountTransferHistoryService {
-	startTimestamp := t.UnixMilli()
-	s.startTime = &startTimestamp
+func (s *SubAccountTransferHistoryService) StartTime(v int64) *SubAccountTransferHistoryService {
+	s.startTime = &v
 	return s
 }
 
-func (s *SubAccountTransferHistoryService) EndTime(t time.Time) *SubAccountTransferHistoryService {
-	endTimestamp := t.UnixMilli()
-	s.endTime = &endTimestamp
+func (s *SubAccountTransferHistoryService) EndTime(v int64) *SubAccountTransferHistoryService {
+	s.endTime = &v
 	return s
 }
 

--- a/v2/subaccount_service.go
+++ b/v2/subaccount_service.go
@@ -3,6 +3,7 @@ package binance
 import (
 	"context"
 	"net/http"
+	"time"
 )
 
 // TransferToSubAccountService transfer to subaccount
@@ -673,4 +674,97 @@ func (s *SubAccountFuturesTransferV1Service) Do(ctx context.Context, opts ...Req
 type SubAccountFuturesTransferResponse struct {
 	// seems api doc bug, return `tranId` as int64 actually in production environment
 	TranID int64 `json:"tranId"`
+}
+
+// Sub-account Transfer History (For Sub-account)
+// https://binance-docs.github.io/apidocs/spot/en/#sub-account-transfer-history-for-sub-account
+type SubAccountTransferHistoryService struct {
+	c                 *Client
+	asset             *string
+	transferType      *SubAccountTransferType
+	startTime         *int64
+	endTime           *int64
+	limit             *int
+	returnFailHistory *bool
+}
+
+func (s *SubAccountTransferHistoryService) Asset(v string) *SubAccountTransferHistoryService {
+	s.asset = &v
+	return s
+}
+
+func (s *SubAccountTransferHistoryService) TransferType(v SubAccountTransferType) *SubAccountTransferHistoryService {
+	s.transferType = &v
+	return s
+}
+
+func (s *SubAccountTransferHistoryService) StartTime(t time.Time) *SubAccountTransferHistoryService {
+	startTimestamp := t.UnixMilli()
+	s.startTime = &startTimestamp
+	return s
+}
+
+func (s *SubAccountTransferHistoryService) EndTime(t time.Time) *SubAccountTransferHistoryService {
+	endTimestamp := t.UnixMilli()
+	s.endTime = &endTimestamp
+	return s
+}
+
+func (s *SubAccountTransferHistoryService) Limit(v int) *SubAccountTransferHistoryService {
+	s.limit = &v
+	return s
+}
+
+func (s *SubAccountTransferHistoryService) ReturnFailHistory(v bool) *SubAccountTransferHistoryService {
+	s.returnFailHistory = &v
+	return s
+}
+
+func (s *SubAccountTransferHistoryService) Do(ctx context.Context, opts ...RequestOption) (res []*SubAccountTransferHistory, err error) {
+	r := &request{
+		method:   http.MethodGet,
+		endpoint: "/sapi/v1/sub-account/transfer/subUserHistory",
+		secType:  secTypeSigned,
+	}
+	if s.asset != nil {
+		r.setParam("asset", *s.asset)
+	}
+	if s.transferType != nil {
+		r.setParam("type", *s.transferType)
+	}
+	if s.startTime != nil {
+		r.setParam("startTime", *s.startTime)
+	}
+	if s.endTime != nil {
+		r.setParam("endTime", *s.endTime)
+	}
+	if s.limit != nil {
+		r.setParam("limit", *s.limit)
+	}
+	if s.returnFailHistory != nil {
+		r.setParam("returnFailHistory", *s.returnFailHistory)
+	}
+	data, err := s.c.callAPI(ctx, r, opts...)
+	if err != nil {
+		return nil, err
+	}
+	res = make([]*SubAccountTransferHistory, 0)
+	err = json.Unmarshal(data, &res)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+type SubAccountTransferHistory struct {
+	CounterParty    string                 `json:"counterParty"`
+	Email           string                 `json:"email"`
+	Type            SubAccountTransferType `json:"type"`
+	Asset           string                 `json:"asset"`
+	Qty             string                 `json:"qty"`
+	FromAccountType AccountType            `json:"fromAccountType"`
+	ToAccountType   AccountType            `json:"toAccountType"`
+	Status          string                 `json:"status"`
+	TranID          int64                  `json:"tranId"`
+	Time            int64                  `json:"time"`
 }

--- a/v2/subaccount_service_test.go
+++ b/v2/subaccount_service_test.go
@@ -2,6 +2,7 @@ package binance
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 )
@@ -332,4 +333,85 @@ func (s *subAccountServiceTestSuite) TestSubAccountFuturesTransferService() {
 	r.NoError(err)
 	r.Equal(int64(123456789), response.TranID, "TranID")
 
+}
+
+func (s *subAccountServiceTestSuite) TestSubAccountTransferHistoryService() {
+	data := []byte(`
+		[
+			{
+				"counterParty":"master",
+				"email":"master@test.com",
+				"type":1,
+				"asset":"BTC",
+				"qty":"1",
+				"fromAccountType":"SPOT",
+				"toAccountType":"SPOT",
+				"status":"SUCCESS",
+				"tranId":11798835829,
+				"time":1544433325000
+			},
+			{
+				"counterParty": "subAccount",
+				"email": "sub2@test.com",
+				"type":  2,                                 
+				"asset":"ETH",
+				"qty":"2",
+				"fromAccountType":"SPOT",
+				"toAccountType":"COIN_FUTURE",
+				"status":"SUCCESS",
+				"tranId":11798829519,
+				"time":1544433326000
+			}
+		]
+	`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	transferType := SubAccountTransferTypeTransferIn
+	startTime := time.Date(2018, 9, 15, 0, 0, 0, 0, time.UTC)
+	endTime := time.Date(2018, 9, 16, 0, 0, 0, 0, time.UTC)
+
+	s.assertReq(func(r *request) {
+		e := newSignedRequest().setParams(params{
+			"type":      int(transferType),
+			"startTime": startTime.UnixMilli(),
+			"endTime":   endTime.UnixMilli(),
+		})
+		s.assertRequestEqual(e, r)
+	})
+
+	response, err := s.client.NewSubAccountTransferHistoryService().
+		TransferType(transferType).
+		StartTime(startTime).
+		EndTime(endTime).
+		Do(newContext())
+
+	r := s.r()
+	r.NoError(err)
+	s.assertSubAccountTransferHistoryEqual(&SubAccountTransferHistory{
+		CounterParty:    "master",
+		Email:           "master@test.com",
+		Type:            1,
+		Asset:           "BTC",
+		Qty:             "1",
+		FromAccountType: "SPOT",
+		ToAccountType:   "SPOT",
+		Status:          "SUCCESS",
+		TranID:          11798835829,
+		Time:            1544433325000,
+	}, response[0])
+}
+
+func (s *subAccountServiceTestSuite) assertSubAccountTransferHistoryEqual(e, a *SubAccountTransferHistory) {
+	r := s.r()
+	r.Equal(e.CounterParty, a.CounterParty, "CounterParty")
+	r.Equal(e.Email, a.Email, "Email")
+	r.Equal(e.Type, a.Type, "Type")
+	r.Equal(e.Asset, a.Asset, "Asset")
+	r.Equal(e.Qty, a.Qty, "Qty")
+	r.Equal(e.FromAccountType, a.FromAccountType, "FromAccountType")
+	r.Equal(e.ToAccountType, a.ToAccountType, "ToAccountType")
+	r.Equal(e.Status, a.Status, "Status")
+	r.Equal(e.TranID, a.TranID, "TranId")
+	r.Equal(e.Time, a.Time, "Time")
 }

--- a/v2/subaccount_service_test.go
+++ b/v2/subaccount_service_test.go
@@ -368,14 +368,14 @@ func (s *subAccountServiceTestSuite) TestSubAccountTransferHistoryService() {
 	defer s.assertDo()
 
 	transferType := SubAccountTransferTypeTransferIn
-	startTime := time.Date(2018, 9, 15, 0, 0, 0, 0, time.UTC)
-	endTime := time.Date(2018, 9, 16, 0, 0, 0, 0, time.UTC)
+	startTime := time.Date(2018, 9, 15, 0, 0, 0, 0, time.UTC).UnixMilli()
+	endTime := time.Date(2018, 9, 16, 0, 0, 0, 0, time.UTC).UnixMilli()
 
 	s.assertReq(func(r *request) {
 		e := newSignedRequest().setParams(params{
 			"type":      int(transferType),
-			"startTime": startTime.UnixMilli(),
-			"endTime":   endTime.UnixMilli(),
+			"startTime": startTime,
+			"endTime":   endTime,
 		})
 		s.assertRequestEqual(e, r)
 	})

--- a/v2/user_universal_transfer.go
+++ b/v2/user_universal_transfer.go
@@ -11,6 +11,7 @@ package binance
 
 import (
 	"context"
+	"net/http"
 )
 
 // CreateUserUniversalTransferService submits a transfer request.
@@ -18,7 +19,7 @@ import (
 // See https://binance-docs.github.io/apidocs/spot/en/#user-universal-transfer-user_data
 type CreateUserUniversalTransferService struct {
 	c          *Client
-	types      string
+	types      UserUniversalTransferType
 	asset      string
 	amount     float64
 	fromSymbol *string
@@ -26,7 +27,7 @@ type CreateUserUniversalTransferService struct {
 }
 
 // Coin sets the coin parameter (MANDATORY).
-func (s *CreateUserUniversalTransferService) Type(v string) *CreateUserUniversalTransferService {
+func (s *CreateUserUniversalTransferService) Type(v UserUniversalTransferType) *CreateUserUniversalTransferService {
 	s.types = v
 	return s
 }
@@ -94,108 +95,108 @@ type CreateUserUniversalTransferResponse struct {
 // ListUserUniversalTransfer fetches transfer history.
 //
 // See https://binance-docs.github.io/apidocs/spot/en/#query-user-universal-transfer-history-user_data
-// type ListUserUniversalTransfer struct {
-// 	c          *Client
-// 	types      string
-// 	startTime  *int64
-// 	endTime    *int64
-// 	current    *int
-// 	size       *int
-// 	fromSymbol *string
-// 	toSymbol   *string
-// }
+type ListUserUniversalTransferService struct {
+	c            *Client
+	transferType UserUniversalTransferType
+	startTime    *int64
+	endTime      *int64
+	current      *int
+	size         *int
+	fromSymbol   *string
+	toSymbol     *string
+}
 
-// // Type sets the type parameter.
-// func (s *ListUserUniversalTransfer) Type(v string) *ListUserUniversalTransfer {
-// 	s.types = v
-// 	return s
-// }
+// Type sets the type parameter.
+func (s *ListUserUniversalTransferService) Type(v UserUniversalTransferType) *ListUserUniversalTransferService {
+	s.transferType = v
+	return s
+}
 
-// // StartTime sets the startTime parameter.
-// func (s *ListUserUniversalTransfer) StartTime(v int64) *ListUserUniversalTransfer {
-// 	s.startTime = &v
-// 	return s
-// }
+// StartTime sets the startTime parameter.
+func (s *ListUserUniversalTransferService) StartTime(v int64) *ListUserUniversalTransferService {
+	s.startTime = &v
+	return s
+}
 
-// // EndTime sets the startTime parameter.
-// func (s *ListUserUniversalTransfer) EndTime(v int64) *ListUserUniversalTransfer {
-// 	s.startTime = &v
-// 	return s
-// }
+// EndTime sets the startTime parameter.
+func (s *ListUserUniversalTransferService) EndTime(v int64) *ListUserUniversalTransferService {
+	s.endTime = &v
+	return s
+}
 
-// // Current sets the current parameter.
-// func (s *ListUserUniversalTransfer) Current(v int) *ListUserUniversalTransfer {
-// 	s.current = &v
-// 	return s
-// }
+// Current sets the current parameter.
+func (s *ListUserUniversalTransferService) Current(v int) *ListUserUniversalTransferService {
+	s.current = &v
+	return s
+}
 
-// // Size sets the size parameter.
-// func (s *ListUserUniversalTransfer) Size(v int) *ListUserUniversalTransfer {
-// 	s.current = &v
-// 	return s
-// }
+// Size sets the size parameter.
+func (s *ListUserUniversalTransferService) Size(v int) *ListUserUniversalTransferService {
+	s.size = &v
+	return s
+}
 
-// // FromSymbol set fromSymbol
-// func (s *ListUserUniversalTransfer) FromSymbol(v string) *ListUserUniversalTransfer {
-// 	s.fromSymbol = &v
-// 	return s
-// }
+// FromSymbol set fromSymbol
+func (s *ListUserUniversalTransferService) FromSymbol(v string) *ListUserUniversalTransferService {
+	s.fromSymbol = &v
+	return s
+}
 
-// // ToSymbol set toSymbol
-// func (s *ListUserUniversalTransfer) ToSymbol(v string) *ListUserUniversalTransfer {
-// 	s.toSymbol = &v
-// 	return s
-// }
+// ToSymbol set toSymbol
+func (s *ListUserUniversalTransferService) ToSymbol(v string) *ListUserUniversalTransferService {
+	s.toSymbol = &v
+	return s
+}
 
 // // Do sends the request.
-// func (s *ListUserUniversalTransfer) Do(ctx context.Context) (res []*TransferResult, err error) {
-// 	r := &request{
-// 		method:   "GET",
-// 		endpoint: "/sapi/v1/asset/transfer",
-// 		secType:  secTypeSigned,
-// 	}
-// 	r.setParam("types", s.types)
-// 	if s.startTime != nil {
-// 		r.setParam("startTime", *s.startTime)
-// 	}
-// 	if s.endTime != nil {
-// 		r.setParam("endTime", *s.endTime)
-// 	}
-// 	if s.current != nil {
-// 		r.setParam("current", *s.current)
-// 	}
-// 	if s.size != nil {
-// 		r.setParam("size", *s.size)
-// 	}
-// 	if s.fromSymbol != nil {
-// 		r.setParam("fromSymbol", *s.fromSymbol)
-// 	}
-// 	if s.toSymbol != nil {
-// 		r.setParam("toSymbol", *s.toSymbol)
-// 	}
-// 	data, err := s.c.callAPI(ctx, r)
-// 	if err != nil {
-// 		return
-// 	}
-// 	res = make([]*TransferResult, 0)
-// 	err = json.Unmarshal(data, &res)
-// 	if err != nil {
-// 		return
-// 	}
-// 	return res, nil
-// }
+func (s *ListUserUniversalTransferService) Do(ctx context.Context) (res *UserUniversalTransferResponse, err error) {
+	r := &request{
+		method:   http.MethodGet,
+		endpoint: "/sapi/v1/asset/transfer",
+		secType:  secTypeSigned,
+	}
+	r.setParam("type", s.transferType)
+	if s.startTime != nil {
+		r.setParam("startTime", *s.startTime)
+	}
+	if s.endTime != nil {
+		r.setParam("endTime", *s.endTime)
+	}
+	if s.current != nil {
+		r.setParam("current", *s.current)
+	}
+	if s.size != nil {
+		r.setParam("size", *s.size)
+	}
+	if s.fromSymbol != nil {
+		r.setParam("fromSymbol", *s.fromSymbol)
+	}
+	if s.toSymbol != nil {
+		r.setParam("toSymbol", *s.toSymbol)
+	}
+	data, err := s.c.callAPI(ctx, r)
+	if err != nil {
+		return
+	}
+	res = new(UserUniversalTransferResponse)
+	err = json.Unmarshal(data, &res)
+	if err != nil {
+		return
+	}
+	return res, nil
+}
 
 // // Withdraw represents a single withdraw entry.
-// type TransferResult struct {
-// 	Total    uint8      `json:"total"`
-// 	Transfer []Transfer `json:"rows"`
-// }
+type UserUniversalTransferResponse struct {
+	Total   int64                    `json:"total"`
+	Results []*UserUniversalTransfer `json:"rows"`
+}
 
-// type Transfer struct {
-// 	Asset     string `json:"asset"`
-// 	Amount    string `json:"amount"`
-// 	Type      string `json:"type"`
-// 	Status    string `json:"status"`
-// 	TranId    string `json:"tranId"`
-// 	Timestamp string `json:"timestamp"`
-// }
+type UserUniversalTransfer struct {
+	Asset     string                          `json:"asset"`
+	Amount    string                          `json:"amount"`
+	Type      UserUniversalTransferType       `json:"type"`
+	Status    UserUniversalTransferStatusType `json:"status"`
+	TranId    int64                           `json:"tranId"`
+	Timestamp int64                           `json:"timestamp"`
+}

--- a/v2/user_universal_transfer_test.go
+++ b/v2/user_universal_transfer_test.go
@@ -1,7 +1,9 @@
 package binance
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 )
@@ -23,7 +25,7 @@ func (s *userUniversalTransferTestSuite) TestUserUniversalTransfer() {
 	s.mockDo(data, nil)
 	defer s.assertDo()
 
-	types := "MAIN_C2C"
+	types := UserUniversalTransferTypeMainToUmFutures
 	asset := "USDT"
 	amount := 0.1
 	fromSymbol := "USDT"
@@ -51,4 +53,67 @@ func (s *userUniversalTransferTestSuite) TestUserUniversalTransfer() {
 	r := s.r()
 	r.NoError(err)
 	r.Equal(int64(13526853623), res.ID)
+}
+
+func (s *userUniversalTransferTestSuite) TestListUserUniversalTransfer() {
+	data := []byte(`{
+		"total":2,
+		"rows":[
+			{
+				"asset":"USDT",
+				"amount":"1",
+				"type":"MAIN_UMFUTURE",
+				"status": "CONFIRMED",
+				"tranId": 11415955596,
+				"timestamp":1544433328000
+			},
+			{
+				"asset":"USDT",
+				"amount":"2",
+				"type":"MAIN_UMFUTURE",
+				"status": "CONFIRMED",
+				"tranId": 11366865406,
+				"timestamp":1544433328000
+			}
+		]
+	}`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	types := UserUniversalTransferTypeMainToUmFutures
+	startTime := time.Date(2018, 12, 10, 0, 0, 0, 0, time.UTC).UnixMilli()
+	endTime := time.Date(2018, 12, 11, 0, 0, 0, 0, time.UTC).UnixMilli()
+	current := 1
+	size := 10
+
+	s.assertReq(func(r *request) {
+		fmt.Println(r.query)
+		e := newSignedRequest().setParams(params{
+			"type":      string(types),
+			"startTime": startTime,
+			"endTime":   endTime,
+			"current":   current,
+			"size":      size,
+		})
+		s.assertRequestEqual(e, r)
+	})
+
+	res, err := s.client.NewListUserUniversalTransferService().
+		Type(types).
+		StartTime(startTime).
+		EndTime(endTime).
+		Current(current).
+		Size(size).
+		Do(newContext())
+
+	r := s.r()
+	r.NoError(err)
+	r.Equal(res.Total, int64(2))
+	results := res.Results
+	r.Equal(int64(11415955596), results[0].TranId)
+	r.Equal("USDT", results[0].Asset)
+	r.Equal("1", results[0].Amount)
+	r.Equal(UserUniversalTransferTypeMainToUmFutures, results[0].Type)
+	r.Equal(UserUniversalTransferStatusTypeConfirmed, results[0].Status)
+	r.Equal(int64(1544433328000), results[0].Timestamp)
 }


### PR DESCRIPTION

### Spot Sub-Account

1. Implement [Sub-account Transfer History (For Sub-account)](https://binance-docs.github.io/apidocs/spot/en/#sub-account-transfer-history-for-sub-account)

### Spot Wallet

1. Implement [Query User Universal Transfer History](https://binance-docs.github.io/apidocs/spot/en/#query-user-universal-transfer-history-user_data)
2. Refactor CreateUserUniversalTransferService, add `UserUniversalTransferType` and `UserUniversalTransferStatusType`