### PR TITLE
Optimize request error handling process

### DIFF
--- a/v2/client.go
+++ b/v2/client.go
@@ -438,7 +438,7 @@ func (c *Client) parseRequest(r *request, opts ...RequestOption) (err error) {
 	if queryString != "" {
 		fullURL = fmt.Sprintf("%s?%s", fullURL, queryString)
 	}
-	c.debug("full url: %s, body: %s", fullURL, bodyString)
+	c.debug("full url: %s, body: %s\n", fullURL, bodyString)
 
 	r.fullURL = fullURL
 	r.header = header
@@ -457,7 +457,7 @@ func (c *Client) callAPI(ctx context.Context, r *request, opts ...RequestOption)
 	}
 	req = req.WithContext(ctx)
 	req.Header = r.header
-	c.debug("request: %#v", req)
+	c.debug("request: %#v\n", req)
 	f := c.do
 	if f == nil {
 		f = c.HTTPClient.Do
@@ -478,15 +478,18 @@ func (c *Client) callAPI(ctx context.Context, r *request, opts ...RequestOption)
 			err = cerr
 		}
 	}()
-	c.debug("response: %#v", res)
-	c.debug("response body: %s", string(data))
-	c.debug("response status code: %d", res.StatusCode)
+	c.debug("response: %#v\n", res)
+	c.debug("response body: %s\n", string(data))
+	c.debug("response status code: %d\n", res.StatusCode)
 
 	if res.StatusCode >= http.StatusBadRequest {
 		apiErr := new(common.APIError)
 		e := json.Unmarshal(data, apiErr)
 		if e != nil {
-			c.debug("failed to unmarshal json: %s", e)
+			c.debug("failed to unmarshal json: %s\n", e)
+		}
+		if !apiErr.IsValid() {
+			return nil, fmt.Errorf("status_code=%v body=%v", res.StatusCode, string(data))
 		}
 		return nil, apiErr
 	}

--- a/v2/client.go
+++ b/v2/client.go
@@ -489,7 +489,7 @@ func (c *Client) callAPI(ctx context.Context, r *request, opts ...RequestOption)
 			c.debug("failed to unmarshal json: %s\n", e)
 		}
 		if !apiErr.IsValid() {
-			return nil, fmt.Errorf("status_code=%v body=%v", res.StatusCode, string(data))
+			apiErr.Response = data
 		}
 		return nil, apiErr
 	}

--- a/v2/common/errors.go
+++ b/v2/common/errors.go
@@ -6,13 +6,17 @@ import (
 
 // APIError define API error when response status is 4xx or 5xx
 type APIError struct {
-	Code    int64  `json:"code"`
-	Message string `json:"msg"`
+	Code     int64  `json:"code"`
+	Message  string `json:"msg"`
+	Response []byte `json:"-"` // Assign the body value when the Code and Message fields are invalid.
 }
 
 // Error return error code and message
 func (e APIError) Error() string {
-	return fmt.Sprintf("<APIError> code=%d, msg=%s", e.Code, e.Message)
+	if e.IsValid() {
+		return fmt.Sprintf("<APIError> code=%d, msg=%s", e.Code, e.Message)
+	}
+	return fmt.Sprintf("<APIError> rsp=%s", string(e.Response))
 }
 
 func (e APIError) IsValid() bool {

--- a/v2/common/errors.go
+++ b/v2/common/errors.go
@@ -15,6 +15,10 @@ func (e APIError) Error() string {
 	return fmt.Sprintf("<APIError> code=%d, msg=%s", e.Code, e.Message)
 }
 
+func (e APIError) IsValid() bool {
+	return e.Code != 0 || e.Message != ""
+}
+
 // IsAPIError check if e is an API error
 func IsAPIError(e error) bool {
 	_, ok := e.(*APIError)

--- a/v2/delivery/client.go
+++ b/v2/delivery/client.go
@@ -268,7 +268,7 @@ func (c *Client) parseRequest(r *request, opts ...RequestOption) (err error) {
 	if queryString != "" {
 		fullURL = fmt.Sprintf("%s?%s", fullURL, queryString)
 	}
-	c.debug("full url: %s, body: %s", fullURL, bodyString)
+	c.debug("full url: %s, body: %s\n", fullURL, bodyString)
 
 	r.fullURL = fullURL
 	r.header = header
@@ -287,7 +287,7 @@ func (c *Client) callAPI(ctx context.Context, r *request, opts ...RequestOption)
 	}
 	req = req.WithContext(ctx)
 	req.Header = r.header
-	c.debug("request: %#v", req)
+	c.debug("request: %#v\n", req)
 	f := c.do
 	if f == nil {
 		f = c.HTTPClient.Do
@@ -308,15 +308,18 @@ func (c *Client) callAPI(ctx context.Context, r *request, opts ...RequestOption)
 			err = cerr
 		}
 	}()
-	c.debug("response: %#v", res)
-	c.debug("response body: %s", string(data))
-	c.debug("response status code: %d", res.StatusCode)
+	c.debug("response: %#v\n", res)
+	c.debug("response body: %s\n", string(data))
+	c.debug("response status code: %d\n", res.StatusCode)
 
 	if res.StatusCode >= http.StatusBadRequest {
 		apiErr := new(common.APIError)
 		e := json.Unmarshal(data, apiErr)
 		if e != nil {
-			c.debug("failed to unmarshal json: %s", e)
+			c.debug("failed to unmarshal json: %s\n", e)
+		}
+		if !apiErr.IsValid() {
+			return nil, fmt.Errorf("status_code=%v body=%v", res.StatusCode, string(data))
 		}
 		return nil, apiErr
 	}

--- a/v2/delivery/client.go
+++ b/v2/delivery/client.go
@@ -319,7 +319,7 @@ func (c *Client) callAPI(ctx context.Context, r *request, opts ...RequestOption)
 			c.debug("failed to unmarshal json: %s\n", e)
 		}
 		if !apiErr.IsValid() {
-			return nil, fmt.Errorf("status_code=%v body=%v", res.StatusCode, string(data))
+			apiErr.Response = data
 		}
 		return nil, apiErr
 	}

--- a/v2/futures/client.go
+++ b/v2/futures/client.go
@@ -305,7 +305,7 @@ func (c *Client) parseRequest(r *request, opts ...RequestOption) (err error) {
 	if queryString != "" {
 		fullURL = fmt.Sprintf("%s?%s", fullURL, queryString)
 	}
-	c.debug("full url: %s, body: %s", fullURL, bodyString)
+	c.debug("full url: %s, body: %s\n", fullURL, bodyString)
 
 	r.fullURL = fullURL
 	r.header = header
@@ -324,7 +324,7 @@ func (c *Client) callAPI(ctx context.Context, r *request, opts ...RequestOption)
 	}
 	req = req.WithContext(ctx)
 	req.Header = r.header
-	c.debug("request: %#v", req)
+	c.debug("request: %#v\n", req)
 	f := c.do
 	if f == nil {
 		f = c.HTTPClient.Do
@@ -345,17 +345,20 @@ func (c *Client) callAPI(ctx context.Context, r *request, opts ...RequestOption)
 			err = cerr
 		}
 	}()
-	c.debug("response: %#v", res)
-	c.debug("response body: %s", string(data))
-	c.debug("response status code: %d", res.StatusCode)
+	c.debug("response: %#v\n", res)
+	c.debug("response body: %s\n", string(data))
+	c.debug("response status code: %d\n", res.StatusCode)
 
 	if res.StatusCode >= http.StatusBadRequest {
 		apiErr := new(common.APIError)
 		e := json.Unmarshal(data, apiErr)
 		if e != nil {
-			c.debug("failed to unmarshal json: %s", e)
+			c.debug("failed to unmarshal json: %s\n", e)
 		}
-		return nil, &http.Header{}, apiErr
+		if !apiErr.IsValid() {
+			return nil, &res.Header, fmt.Errorf("status_code=%v body=%v", res.StatusCode, string(data))
+		}
+		return nil, &res.Header, apiErr
 	}
 	return data, &res.Header, nil
 }

--- a/v2/futures/client.go
+++ b/v2/futures/client.go
@@ -356,7 +356,7 @@ func (c *Client) callAPI(ctx context.Context, r *request, opts ...RequestOption)
 			c.debug("failed to unmarshal json: %s\n", e)
 		}
 		if !apiErr.IsValid() {
-			return nil, &res.Header, fmt.Errorf("status_code=%v body=%v", res.StatusCode, string(data))
+			apiErr.Response = data
 		}
 		return nil, &res.Header, apiErr
 	}

--- a/v2/options/client.go
+++ b/v2/options/client.go
@@ -359,7 +359,7 @@ func (c *Client) callAPI(ctx context.Context, r *request, opts ...RequestOption)
 			c.debug("failed to unmarshal json: %s\n", e)
 		}
 		if !apiErr.IsValid() {
-			return nil, &res.Header, fmt.Errorf("status_code=%v body=%v", res.StatusCode, string(data))
+			apiErr.Response = data
 		}
 		return nil, &res.Header, apiErr
 	}

--- a/v2/options/client.go
+++ b/v2/options/client.go
@@ -357,10 +357,11 @@ func (c *Client) callAPI(ctx context.Context, r *request, opts ...RequestOption)
 		e := json.Unmarshal(data, apiErr)
 		if e != nil {
 			c.debug("failed to unmarshal json: %s\n", e)
-			apiErr.Code = int64(res.StatusCode)
-			apiErr.Message = string(data)
 		}
-		return nil, &http.Header{}, apiErr
+		if !apiErr.IsValid() {
+			return nil, &res.Header, fmt.Errorf("status_code=%v body=%v", res.StatusCode, string(data))
+		}
+		return nil, &res.Header, apiErr
 	}
 	return data, &res.Header, nil
 }


### PR DESCRIPTION
In some cases, the REST API will return a response with the body:
```json
{"error": "Internal error: 1"}
```
When this happens, it returns an ApiError that shows nothing meaningful when the user calls the REST API interface. Optimize the request error handling process to make the error more meaningful.