### PR TITLE
fix batchOrder response and fix futures.WsUserDataEvent.Time error while calling json.Unmarshal

### DIFF
--- a/v2/delivery/websocket_service.go
+++ b/v2/delivery/websocket_service.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -669,6 +670,43 @@ type WsUserDataEvent struct {
 	TransactionTime     int64              `json:"T"`
 	AccountUpdate       WsAccountUpdate    `json:"a"`
 	OrderTradeUpdate    WsOrderTradeUpdate `json:"o"`
+}
+
+func (e *WsUserDataEvent) UnmarshalJSON(data []byte) error {
+	var tmp struct {
+		Event               UserDataEventType  `json:"e"`
+		Time                interface{}        `json:"E"`
+		Alias               string             `json:"i"`
+		CrossWalletBalance  string             `json:"cw"`
+		MarginCallPositions []WsPosition       `json:"p"`
+		TransactionTime     int64              `json:"T"`
+		AccountUpdate       WsAccountUpdate    `json:"a"`
+		OrderTradeUpdate    WsOrderTradeUpdate `json:"o"`
+	}
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+
+	e.Event = tmp.Event
+	switch v := tmp.Time.(type) {
+	case float64:
+		e.Time = int64(v)
+	case string:
+		parsedTime, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			return err
+		}
+		e.Time = parsedTime
+	default:
+		return fmt.Errorf("unexpected type for E: %T", tmp.Time)
+	}
+	e.Alias = tmp.Alias
+	e.CrossWalletBalance = tmp.CrossWalletBalance
+	e.MarginCallPositions = tmp.MarginCallPositions
+	e.TransactionTime = tmp.TransactionTime
+	e.AccountUpdate = tmp.AccountUpdate
+	e.OrderTradeUpdate = tmp.OrderTradeUpdate
+	return nil
 }
 
 // WsAccountUpdate define account update


### PR DESCRIPTION
1. When calling `batch ordering and batch cancellation` in the options package, the response may contain `{"code": -1121, "msg": "Invalid symbol."}` objects. Adjust the return value type of the current interface to handle this case.
2. When the `listenKey` expires, the `Time` field in the JSON string for `futures.WsUserDataEvent` may be of type `string`, which can cause JSON deserialization errors. Fix this issue. #524 