### PR TITLE
Added support for getting the non-zero balances of an account

### DIFF
--- a/v2/account_service.go
+++ b/v2/account_service.go
@@ -7,7 +7,15 @@ import (
 
 // GetAccountService get account info
 type GetAccountService struct {
-	c *Client
+	c                *Client
+	omitZeroBalances *bool
+}
+
+// OmitZeroBalances sets the omitZeroBalances parameter on the request.
+// When set to true, the API will return the non-zero balances of an account.
+func (s *GetAccountService) OmitZeroBalances(v bool) *GetAccountService {
+	s.omitZeroBalances = &v
+	return s
 }
 
 // Do send request
@@ -17,6 +25,10 @@ func (s *GetAccountService) Do(ctx context.Context, opts ...RequestOption) (res 
 		endpoint: "/api/v3/account",
 		secType:  secTypeSigned,
 	}
+	if s.omitZeroBalances != nil {
+		r.setParam("omitZeroBalances", *s.omitZeroBalances)
+	}
+
 	data, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
 		return nil, err

--- a/v2/account_service_test.go
+++ b/v2/account_service_test.go
@@ -50,12 +50,17 @@ func (s *accountServiceTestSuite) TestGetAccount() {
   }`)
 	s.mockDo(data, nil)
 	defer s.assertDo()
+
+	omitZeroBalances := true
+
 	s.assertReq(func(r *request) {
-		e := newSignedRequest()
+		e := newSignedRequest().setParams(params{
+			"omitZeroBalances": omitZeroBalances,
+		})
 		s.assertRequestEqual(e, r)
 	})
 
-	res, err := s.client.NewGetAccountService().Do(newContext())
+	res, err := s.client.NewGetAccountService().OmitZeroBalances(omitZeroBalances).Do(newContext())
 	s.r().NoError(err)
 	e := &Account{
 		MakerCommission:  15,


### PR DESCRIPTION
This pull request adds the function `OmitZeroBalances` on `GetAccountService` to set the `omitZeroBalances` query parameter on the request.

Docs: https://developers.binance.com/docs/binance-spot-api-docs/rest-api#account-endpoints

By default all the balances will be returned, this param makes the API return the non zero balances of an account only.

Usage:

```go
apiKey := os.Getenv("API_KEY")
secretKey := os.Getenv("SECRET_KEY")

client := binance.NewClient(apiKey, secretKey)

account, err := client.NewGetAccountService().OmitZeroBalances(true).Do(context.TODO())
```