### PR TITLE
Make future order ModifyService

### DIFF
--- a/v2/futures/client.go
+++ b/v2/futures/client.go
@@ -446,6 +446,11 @@ func (c *Client) NewCreateOrderService() *CreateOrderService {
 	return &CreateOrderService{c: c}
 }
 
+// NewModifyOrderService init creating order service
+func (c *Client) NewModifyOrderService() *ModifyOrderService {
+	return &ModifyOrderService{c: c}
+}
+
 // NewCreateBatchOrdersService init creating batch order service
 func (c *Client) NewCreateBatchOrdersService() *CreateBatchOrdersService {
 	return &CreateBatchOrdersService{c: c}

--- a/v2/futures/order_service.go
+++ b/v2/futures/order_service.go
@@ -238,6 +238,210 @@ type CreateOrderResponse struct {
 	RateLimitOrder1m        string           `json:"rateLimitOrder1m,omitempty"`  //
 }
 
+// ModifyOrderService create order
+type ModifyOrderService struct {
+	c                 *Client
+	symbol            string
+	orderID           *int64
+	origClientOrderID *string
+	side              SideType
+	positionSide      *PositionSideType
+	orderType         OrderType
+	timeInForce       *TimeInForceType
+	quantity          string
+	reduceOnly        *string
+	price             *string
+	newClientOrderID  *string
+	stopPrice         *string
+	workingType       *WorkingType
+	activationPrice   *string
+	callbackRate      *string
+	priceProtect      *string
+	newOrderRespType  NewOrderRespType
+	closePosition     *string
+}
+
+// Symbol set symbol
+func (s *ModifyOrderService) Symbol(symbol string) *ModifyOrderService {
+	s.symbol = symbol
+	return s
+}
+
+func (s *ModifyOrderService) OrderID(orderID int64) *ModifyOrderService {
+	s.orderID = &orderID
+	return s
+}
+
+func (s *ModifyOrderService) OrigClientOrderID(origClientOrderID string) *ModifyOrderService {
+	s.origClientOrderID = &origClientOrderID
+	return s
+}
+
+// Side set side
+func (s *ModifyOrderService) Side(side SideType) *ModifyOrderService {
+	s.side = side
+	return s
+}
+
+// PositionSide set side
+func (s *ModifyOrderService) PositionSide(positionSide PositionSideType) *ModifyOrderService {
+	s.positionSide = &positionSide
+	return s
+}
+
+// Type set type
+func (s *ModifyOrderService) Type(orderType OrderType) *ModifyOrderService {
+	s.orderType = orderType
+	return s
+}
+
+// TimeInForce set timeInForce
+func (s *ModifyOrderService) TimeInForce(timeInForce TimeInForceType) *ModifyOrderService {
+	s.timeInForce = &timeInForce
+	return s
+}
+
+// Quantity set quantity
+func (s *ModifyOrderService) Quantity(quantity string) *ModifyOrderService {
+	s.quantity = quantity
+	return s
+}
+
+// ReduceOnly set reduceOnly
+func (s *ModifyOrderService) ReduceOnly(reduceOnly bool) *ModifyOrderService {
+	reduceOnlyStr := strconv.FormatBool(reduceOnly)
+	s.reduceOnly = &reduceOnlyStr
+	return s
+}
+
+// Price set price
+func (s *ModifyOrderService) Price(price string) *ModifyOrderService {
+	s.price = &price
+	return s
+}
+
+// NewClientOrderID set newClientOrderID
+func (s *ModifyOrderService) NewClientOrderID(newClientOrderID string) *ModifyOrderService {
+	s.newClientOrderID = &newClientOrderID
+	return s
+}
+
+// StopPrice set stopPrice
+func (s *ModifyOrderService) StopPrice(stopPrice string) *ModifyOrderService {
+	s.stopPrice = &stopPrice
+	return s
+}
+
+// WorkingType set workingType
+func (s *ModifyOrderService) WorkingType(workingType WorkingType) *ModifyOrderService {
+	s.workingType = &workingType
+	return s
+}
+
+// ActivationPrice set activationPrice
+func (s *ModifyOrderService) ActivationPrice(activationPrice string) *ModifyOrderService {
+	s.activationPrice = &activationPrice
+	return s
+}
+
+// CallbackRate set callbackRate
+func (s *ModifyOrderService) CallbackRate(callbackRate string) *ModifyOrderService {
+	s.callbackRate = &callbackRate
+	return s
+}
+
+// PriceProtect set priceProtect
+func (s *ModifyOrderService) PriceProtect(priceProtect bool) *ModifyOrderService {
+	priceProtectStr := strconv.FormatBool(priceProtect)
+	s.priceProtect = &priceProtectStr
+	return s
+}
+
+// NewOrderResponseType set newOrderResponseType
+func (s *ModifyOrderService) NewOrderResponseType(newOrderResponseType NewOrderRespType) *ModifyOrderService {
+	s.newOrderRespType = newOrderResponseType
+	return s
+}
+
+// ClosePosition set closePosition
+func (s *ModifyOrderService) ClosePosition(closePosition bool) *ModifyOrderService {
+	closePositionStr := strconv.FormatBool(closePosition)
+	s.closePosition = &closePositionStr
+	return s
+}
+
+func (s *ModifyOrderService) modifyOrder(ctx context.Context, endpoint string, opts ...RequestOption) (data []byte, header *http.Header, err error) {
+
+	r := &request{
+		method:   http.MethodPut,
+		endpoint: endpoint,
+		secType:  secTypeSigned,
+	}
+	m := params{
+		"symbol":           s.symbol,
+		"side":             s.side,
+		"type":             s.orderType,
+		"newOrderRespType": s.newOrderRespType,
+	}
+	if s.quantity != "" {
+		m["quantity"] = s.quantity
+	}
+	if s.positionSide != nil {
+		m["positionSide"] = *s.positionSide
+	}
+	if s.timeInForce != nil {
+		m["timeInForce"] = *s.timeInForce
+	}
+	if s.reduceOnly != nil {
+		m["reduceOnly"] = *s.reduceOnly
+	}
+	if s.price != nil {
+		m["price"] = *s.price
+	}
+	if s.newClientOrderID != nil {
+		m["newClientOrderId"] = *s.newClientOrderID
+	}
+	if s.stopPrice != nil {
+		m["stopPrice"] = *s.stopPrice
+	}
+	if s.workingType != nil {
+		m["workingType"] = *s.workingType
+	}
+	if s.priceProtect != nil {
+		m["priceProtect"] = *s.priceProtect
+	}
+	if s.activationPrice != nil {
+		m["activationPrice"] = *s.activationPrice
+	}
+	if s.callbackRate != nil {
+		m["callbackRate"] = *s.callbackRate
+	}
+	if s.closePosition != nil {
+		m["closePosition"] = *s.closePosition
+	}
+	r.setFormParams(m)
+	data, header, err = s.c.callAPI(ctx, r, opts...)
+	if err != nil {
+		return []byte{}, &http.Header{}, err
+	}
+	return data, header, nil
+}
+
+// Do send request
+func (s *ModifyOrderService) Do(ctx context.Context, opts ...RequestOption) (res *Order, err error) {
+	data, _, err := s.modifyOrder(ctx, "/fapi/v1/order", opts...)
+	if err != nil {
+		return nil, err
+	}
+	res = new(Order)
+	err = json.Unmarshal(data, res)
+
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
 // ListOpenOrdersService list opened orders
 type ListOpenOrdersService struct {
 	c      *Client

--- a/v2/futures/order_service_test.go
+++ b/v2/futures/order_service_test.go
@@ -436,6 +436,78 @@ func (s *orderServiceTestSuite) TestListOrders() {
 	s.assertOrderEqual(e, orders[0])
 }
 
+func (s *orderServiceTestSuite) TestModifyOrder() {
+	data := []byte(`{
+		"clientOrderId": "myOrder1",
+		"cumQty": "0",
+		"cumQuote": "0",
+		"executedQty": "0",
+		"orderId": 283194212,
+		"origQty": "11",
+		"price": "8301",
+		"reduceOnly": false,
+		"side": "BUY",
+		"status": "CANCELED",
+		"stopPrice": "8300",
+		"symbol": "BTCUSDT",
+		"timeInForce": "GTC",
+		"type": "TAKE_PROFIT",
+		"updateTime": 1571110484038,
+		"workingType": "CONTRACT_PRICE",
+		"activatePrice": "10000",
+		"priceRate":"0.1",
+		"positionSide":"BOTH",
+		"priceProtect": false
+	}`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+
+	symbol := "BTCUSDT"
+	orderID := int64(28)
+	origClientOrderID := "myOrder1"
+	price := "8301"
+	side := SideTypeSell
+	s.assertReq(func(r *request) {
+		e := newSignedRequest().setFormParams(params{
+			"symbol":            symbol,
+			"orderId":           orderID,
+			"origClientOrderId": origClientOrderID,
+			"price":             price,
+			"side":              side,
+		})
+		s.assertRequestEqual(e, r)
+	})
+
+	res, err := s.client.NewModifyOrderService().Symbol(symbol).Side(side).
+		OrderID(orderID).OrigClientOrderID(origClientOrderID).Price(price).
+		Do(newContext())
+	r := s.r()
+	r.NoError(err)
+	e := &Order{
+		ClientOrderID:    origClientOrderID,
+		CumQuantity:      "0",
+		CumQuote:         "0",
+		ExecutedQuantity: "0",
+		OrderID:          283194212,
+		OrigQuantity:     "11",
+		Price:            "8301",
+		ReduceOnly:       false,
+		Side:             SideTypeBuy,
+		Status:           OrderStatusTypeCanceled,
+		StopPrice:        "8300",
+		Symbol:           symbol,
+		TimeInForce:      TimeInForceTypeGTC,
+		Type:             OrderTypeTakeProfit,
+		UpdateTime:       1571110484038,
+		WorkingType:      WorkingTypeContractPrice,
+		ActivatePrice:    "10000",
+		PriceRate:        "0.1",
+		PositionSide:     "BOTH",
+		PriceProtect:     false,
+	}
+	s.assertOrderEqual(e, res)
+}
+
 func (s *orderServiceTestSuite) TestCancelOrder() {
 	data := []byte(`{
 		"clientOrderId": "myOrder1",


### PR DESCRIPTION
I just used copy past strategy to make modify order service for futures-api which uses 'put' method in request to perform this operation