### PR TITLE
finish futures algo services

### DIFF
--- a/v2/client.go
+++ b/v2/client.go
@@ -112,6 +112,15 @@ type UserUniversalTransferStatusType string
 // FuturesOrderBookHistoryDataType define the futures order book history data types
 type FuturesOrderBookHistoryDataType string
 
+// FutureAlgoType define future algo types
+type FuturesAlgoType string
+
+// FutureAlgoUrgencyType define future algo urgency type
+type FuturesAlgoUrgencyType string
+
+// FutureAlgoOrderStatusType define future algo order status
+type FuturesAlgoOrderStatusType string
+
 // Endpoints
 var (
 	BaseAPIMainURL    = "https://api.binance.com"
@@ -295,6 +304,17 @@ const (
 
 	FuturesOrderBookHistoryDataTypeTDepth FuturesOrderBookHistoryDataType = "T_DEPTH"
 	FuturesOrderBookHistoryDataTypeSDepth FuturesOrderBookHistoryDataType = "S_DEPTH"
+
+	FuturesAlgoTypeVp   FuturesAlgoType = "VP"
+	FuturesAlgoTypeTwap FuturesAlgoType = "TWAP"
+
+	FuturesAlgoUrgencyTypeLow    FuturesAlgoUrgencyType = "LOW"
+	FuturesAlgoUrgencyTypeMedium FuturesAlgoUrgencyType = "MEDIUM"
+	FuturesAlgoUrgencyTypeHigh   FuturesAlgoUrgencyType = "HIGH"
+
+	FuturesAlgoOrderStatusTypeWorking   FuturesAlgoOrderStatusType = "WORKING"
+	FuturesAlgoOrderStatusTypeFinished  FuturesAlgoOrderStatusType = "FINISHED"
+	FuturesAlgoOrderStatusTypeCancelled FuturesAlgoOrderStatusType = "CANCELLED"
 )
 
 func currentTimestamp() int64 {
@@ -1303,4 +1323,34 @@ func (c *Client) NewSubAccountFuturesAccountV2Service() *SubAccountFuturesAccoun
 // Futures order book history service
 func (c *Client) NewFuturesOrderBookHistoryService() *FuturesOrderBookHistoryService {
 	return &FuturesOrderBookHistoryService{c: c}
+}
+
+// NewCreateFuturesAlgoVpOrderService create futures algo vp order
+func (c *Client) NewCreateFuturesAlgoVpOrderService() *CreateFuturesAlgoVpOrderService {
+	return &CreateFuturesAlgoVpOrderService{c: c}
+}
+
+// NewCreateFuturesAlgoTwapOrderService create futures algo twap order
+func (c *Client) NewCreateFuturesAlgoTwapOrderService() *CreateFuturesAlgoTwapOrderService {
+	return &CreateFuturesAlgoTwapOrderService{c: c}
+}
+
+// NewListOpenFuturesAlgoOrdersService list open futures algo orders
+func (c *Client) NewListOpenFuturesAlgoOrdersService() *ListOpenFuturesAlgoOrdersService {
+	return &ListOpenFuturesAlgoOrdersService{c: c}
+}
+
+// NewListHistoryFuturesAlgoOrdersService list history futures algo orders
+func (c *Client) NewListHistoryFuturesAlgoOrdersService() *ListHistoryFuturesAlgoOrdersService {
+	return &ListHistoryFuturesAlgoOrdersService{c: c}
+}
+
+// NewCancelFuturesAlgoOrderService cancel future algo order
+func (c *Client) NewCancelFuturesAlgoOrderService() *CancelFuturesAlgoOrderService {
+	return &CancelFuturesAlgoOrderService{c: c}
+}
+
+// NewGetFuturesAlgoSubOrdersService get futures algo sub orders
+func (c *Client) NewGetFuturesAlgoSubOrdersService() *GetFuturesAlgoSubOrdersService {
+	return &GetFuturesAlgoSubOrdersService{c: c}
 }

--- a/v2/futures_algo_service.go
+++ b/v2/futures_algo_service.go
@@ -1,0 +1,488 @@
+package binance
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/adshao/go-binance/v2/futures"
+)
+
+// CreateFuturesAlgoTwapOrderService create future algo order
+type CreateFuturesAlgoVpOrderService struct {
+	c            *Client
+	symbol       string
+	side         SideType
+	positionSide *futures.PositionSideType
+	quantity     float64
+	urgency      FuturesAlgoUrgencyType
+	clientAlgoId *string
+	reduceOnly   *bool
+	limitPrice   *float64
+}
+
+// Symbol set symbol
+func (s *CreateFuturesAlgoVpOrderService) Symbol(symbol string) *CreateFuturesAlgoVpOrderService {
+	s.symbol = symbol
+	return s
+}
+
+// Side set side
+func (s *CreateFuturesAlgoVpOrderService) Side(side SideType) *CreateFuturesAlgoVpOrderService {
+	s.side = side
+	return s
+}
+
+// PositionSide set side
+func (s *CreateFuturesAlgoVpOrderService) PositionSide(positionSide futures.PositionSideType) *CreateFuturesAlgoVpOrderService {
+	s.positionSide = &positionSide
+	return s
+}
+
+// Quantity set quantity
+func (s *CreateFuturesAlgoVpOrderService) Quantity(quantity float64) *CreateFuturesAlgoVpOrderService {
+	s.quantity = quantity
+	return s
+}
+
+// Urgency set urgency
+func (s *CreateFuturesAlgoVpOrderService) Urgency(urgency FuturesAlgoUrgencyType) *CreateFuturesAlgoVpOrderService {
+	s.urgency = urgency
+	return s
+}
+
+// ClientAlgoId set clientAlgoId
+func (s *CreateFuturesAlgoVpOrderService) ClientAlgoId(clientAlgoId string) *CreateFuturesAlgoVpOrderService {
+	s.clientAlgoId = &clientAlgoId
+	return s
+}
+
+// ReduceOnly set reduceOnly
+func (s *CreateFuturesAlgoVpOrderService) ReduceOnly(reduceOnly bool) *CreateFuturesAlgoVpOrderService {
+	s.reduceOnly = &reduceOnly
+	return s
+}
+
+// LimitPrice set limitPrice
+func (s *CreateFuturesAlgoVpOrderService) LimitPrice(limitPrice float64) *CreateFuturesAlgoVpOrderService {
+	s.limitPrice = &limitPrice
+	return s
+}
+
+func (s *CreateFuturesAlgoVpOrderService) createOrder(ctx context.Context, endpoint string, opts ...RequestOption) (data []byte, err error) {
+	r := &request{
+		method:   http.MethodPost,
+		endpoint: endpoint,
+		secType:  secTypeSigned,
+	}
+	m := params{
+		"symbol":   s.symbol,
+		"side":     s.side,
+		"quantity": s.quantity,
+		"urgency":  s.urgency,
+	}
+	if s.positionSide != nil {
+		m["positionSide"] = *s.positionSide
+	}
+	if s.reduceOnly != nil {
+		m["reduceOnly"] = *s.reduceOnly
+	}
+	if s.clientAlgoId != nil {
+		m["clientAlgoId"] = *s.clientAlgoId
+	}
+	if s.limitPrice != nil {
+		m["limitPrice"] = *s.limitPrice
+	}
+	r.setFormParams(m)
+	data, err = s.c.callAPI(ctx, r, opts...)
+	if err != nil {
+		return []byte{}, err
+	}
+	return data, nil
+}
+
+// Do send request
+func (s *CreateFuturesAlgoVpOrderService) Do(ctx context.Context, opts ...RequestOption) (res *CreateFuturesAlgoOrderResponse, err error) {
+	data, err := s.createOrder(ctx, "/sapi/v1/algo/futures/newOrderVp", opts...)
+	if err != nil {
+		return nil, err
+	}
+	res = new(CreateFuturesAlgoOrderResponse)
+	err = json.Unmarshal(data, res)
+
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+// CreateFutureAlgoOrderResponse define create future algo order response
+type CreateFuturesAlgoOrderResponse struct {
+	ClientAlgoId string `json:"clientAlgoId"`
+	Success      bool   `json:"success"`
+	Code         int    `json:"code"`
+	Msg          string `json:"msg"`
+}
+
+// CreateFuturesAlgoTwapOrderService create future algo order
+type CreateFuturesAlgoTwapOrderService struct {
+	c            *Client
+	symbol       string
+	side         SideType
+	positionSide *futures.PositionSideType
+	quantity     float64
+	duration     int64
+	clientAlgoId *string
+	reduceOnly   *bool
+	limitPrice   *float64
+}
+
+// Symbol set symbol
+func (s *CreateFuturesAlgoTwapOrderService) Symbol(symbol string) *CreateFuturesAlgoTwapOrderService {
+	s.symbol = symbol
+	return s
+}
+
+// Side set side
+func (s *CreateFuturesAlgoTwapOrderService) Side(side SideType) *CreateFuturesAlgoTwapOrderService {
+	s.side = side
+	return s
+}
+
+// PositionSide set side
+func (s *CreateFuturesAlgoTwapOrderService) PositionSide(positionSide futures.PositionSideType) *CreateFuturesAlgoTwapOrderService {
+	s.positionSide = &positionSide
+	return s
+}
+
+// Quantity set quantity
+func (s *CreateFuturesAlgoTwapOrderService) Quantity(quantity float64) *CreateFuturesAlgoTwapOrderService {
+	s.quantity = quantity
+	return s
+}
+
+// Duration set duration
+func (s *CreateFuturesAlgoTwapOrderService) Duration(duration int64) *CreateFuturesAlgoTwapOrderService {
+	s.duration = duration
+	return s
+}
+
+// ClientAlgoId set clientAlgoId
+func (s *CreateFuturesAlgoTwapOrderService) ClientAlgoId(clientAlgoId string) *CreateFuturesAlgoTwapOrderService {
+	s.clientAlgoId = &clientAlgoId
+	return s
+}
+
+// ReduceOnly set reduceOnly
+func (s *CreateFuturesAlgoTwapOrderService) ReduceOnly(reduceOnly bool) *CreateFuturesAlgoTwapOrderService {
+	s.reduceOnly = &reduceOnly
+	return s
+}
+
+// LimitPrice set limitPrice
+func (s *CreateFuturesAlgoTwapOrderService) LimitPrice(limitPrice float64) *CreateFuturesAlgoTwapOrderService {
+	s.limitPrice = &limitPrice
+	return s
+}
+
+func (s *CreateFuturesAlgoTwapOrderService) createOrder(ctx context.Context, endpoint string, opts ...RequestOption) (data []byte, err error) {
+	r := &request{
+		method:   http.MethodPost,
+		endpoint: endpoint,
+		secType:  secTypeSigned,
+	}
+	m := params{
+		"symbol":   s.symbol,
+		"side":     s.side,
+		"quantity": s.quantity,
+		"duration": s.duration,
+	}
+	if s.positionSide != nil {
+		m["positionSide"] = *s.positionSide
+	}
+	if s.reduceOnly != nil {
+		m["reduceOnly"] = *s.reduceOnly
+	}
+	if s.clientAlgoId != nil {
+		m["clientAlgoId"] = *s.clientAlgoId
+	}
+	if s.limitPrice != nil {
+		m["limitPrice"] = *s.limitPrice
+	}
+	r.setFormParams(m)
+	data, err = s.c.callAPI(ctx, r, opts...)
+	if err != nil {
+		return []byte{}, err
+	}
+	return data, nil
+}
+
+// Do send request
+func (s *CreateFuturesAlgoTwapOrderService) Do(ctx context.Context, opts ...RequestOption) (res *CreateFuturesAlgoOrderResponse, err error) {
+	data, err := s.createOrder(ctx, "/sapi/v1/algo/futures/newOrderTwap", opts...)
+	if err != nil {
+		return nil, err
+	}
+	res = new(CreateFuturesAlgoOrderResponse)
+	err = json.Unmarshal(data, res)
+	fmt.Printf("response is %v", data)
+
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+// ListOpenFuturesAlgoOrdersService list current open futures algo orders
+type ListOpenFuturesAlgoOrdersService struct {
+	c *Client
+}
+
+// Do send request
+func (s *ListOpenFuturesAlgoOrdersService) Do(ctx context.Context, opts ...RequestOption) (res *ListOpenFuturesAlgoOrdersResponse, err error) {
+	r := &request{
+		method:   http.MethodGet,
+		endpoint: "/sapi/v1/algo/futures/openOrders",
+		secType:  secTypeSigned,
+	}
+	data, err := s.c.callAPI(ctx, r, opts...)
+	if err != nil {
+		return nil, err
+	}
+	res = new(ListOpenFuturesAlgoOrdersResponse)
+	err = json.Unmarshal(data, res)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+type FuturesAlgoOrder struct {
+	//策略订单ID
+	AlgoId           int64                      `json:"algoId"`
+	Symbol           string                     `json:"symbol"`
+	Side             SideType                   `json:"side"`
+	PositionSide     futures.PositionSideType   `json:"positionSide"`
+	TotalQuantity    string                     `json:"totalQty"`
+	ExecutedQuantity string                     `json:"executedQty"`
+	ExecutedAmount   string                     `json:"executedAmt"`
+	AvgPrice         string                     `json:"avgPrice"`
+	ClientAlgoId     string                     `json:"clientAlgoId"`
+	BookTime         int64                      `json:"bookTime"`
+	EndTime          int64                      `json:"endTime"`
+	AlgoStatus       FuturesAlgoOrderStatusType `json:"algoStatus"`
+	AlgoType         FuturesAlgoType            `json:"algoType"`
+	Urgency          FuturesAlgoUrgencyType     `json:"urgency"`
+}
+
+// ListOpenFuturesAlgoOrdersResponse define response of list open future algo orders
+type ListOpenFuturesAlgoOrdersResponse struct {
+	Total  int64               `json:"total"`
+	Orders []*FuturesAlgoOrder `json:"orders"`
+}
+
+// ListHistoryFuturesAlgoOrdersService list future algo historical orders
+type ListHistoryFuturesAlgoOrdersService struct {
+	c         *Client
+	symbol    *string
+	side      *SideType
+	startTime *int64
+	endTime   *int64
+	page      *int
+	pageSize  *int
+}
+
+// Symbol set symbol
+func (s *ListHistoryFuturesAlgoOrdersService) Symbol(symbol string) *ListHistoryFuturesAlgoOrdersService {
+	s.symbol = &symbol
+	return s
+}
+
+// Side set side
+func (s *ListHistoryFuturesAlgoOrdersService) Side(side SideType) *ListHistoryFuturesAlgoOrdersService {
+	s.side = &side
+	return s
+}
+
+// StartTime set startTime
+func (s *ListHistoryFuturesAlgoOrdersService) StartTime(startTime int64) *ListHistoryFuturesAlgoOrdersService {
+	s.startTime = &startTime
+	return s
+}
+
+// EndTime set endTime
+func (s *ListHistoryFuturesAlgoOrdersService) EndTime(endTime int64) *ListHistoryFuturesAlgoOrdersService {
+	s.endTime = &endTime
+	return s
+}
+
+// Page set page
+func (s *ListHistoryFuturesAlgoOrdersService) Page(page int) *ListHistoryFuturesAlgoOrdersService {
+	s.page = &page
+	return s
+}
+
+// PageSize set pageSize
+func (s *ListHistoryFuturesAlgoOrdersService) PageSize(pageSize int) *ListHistoryFuturesAlgoOrdersService {
+	s.pageSize = &pageSize
+	return s
+}
+
+// Do send request
+func (s *ListHistoryFuturesAlgoOrdersService) Do(ctx context.Context, opts ...RequestOption) (res *ListHistoryFuturesAlgoOrdersResponse, err error) {
+	r := &request{
+		method:   http.MethodGet,
+		endpoint: "/sapi/v1/algo/futures/historicalOrders",
+		secType:  secTypeSigned,
+	}
+	if s.symbol != nil {
+		r.setParam("symbol", *s.symbol)
+	}
+	if s.side != nil {
+		r.setParam("side", *s.side)
+	}
+	if s.startTime != nil {
+		r.setParam("startTime", *s.startTime)
+	}
+	if s.endTime != nil {
+		r.setParam("endTime", *s.endTime)
+	}
+	if s.page != nil {
+		r.setParam("page", *s.page)
+	}
+	if s.pageSize != nil {
+		r.setParam("pageSize", *s.pageSize)
+	}
+	data, err := s.c.callAPI(ctx, r, opts...)
+	if err != nil {
+		return nil, err
+	}
+	res = new(ListHistoryFuturesAlgoOrdersResponse)
+	err = json.Unmarshal(data, res)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+// ListFutureAlgoOrderHistoryResponse defines response of list future algo historical orders
+type ListHistoryFuturesAlgoOrdersResponse struct {
+	Total  int64               `json:"total"`
+	Orders []*FuturesAlgoOrder `json:"orders"`
+}
+
+// CancelFuturesAlgoOrderService cancel future algo twap order
+type CancelFuturesAlgoOrderService struct {
+	c      *Client
+	algoId int64
+}
+
+func (s *CancelFuturesAlgoOrderService) AlgoId(algoId int64) *CancelFuturesAlgoOrderService {
+	s.algoId = algoId
+	return s
+}
+
+// Do send request
+func (s *CancelFuturesAlgoOrderService) Do(ctx context.Context, opts ...RequestOption) (res *CancelFuturesAlgoOrderResponse, err error) {
+	r := &request{
+		method:   http.MethodDelete,
+		endpoint: "/sapi/v1/algo/futures/order",
+		secType:  secTypeSigned,
+	}
+	r.setFormParam("algoId", s.algoId)
+	data, err := s.c.callAPI(ctx, r, opts...)
+	if err != nil {
+		return nil, err
+	}
+	res = new(CancelFuturesAlgoOrderResponse)
+	err = json.Unmarshal(data, res)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+// CancelFuturesAlgoOrderResponse define response of cancel future algo twap order
+type CancelFuturesAlgoOrderResponse struct {
+	AlgoId  int64  `json:"algoId"`
+	Success bool   `json:"success"`
+	Code    int    `json:"code"`
+	Msg     string `json:"msg"`
+}
+
+// GetFuturesAlgoSubOrdersService get future algo sub orders
+type GetFuturesAlgoSubOrdersService struct {
+	c        *Client
+	algoId   int64
+	page     *int
+	pageSize *int
+}
+
+// AlgoId set algoId
+func (s *GetFuturesAlgoSubOrdersService) AlgoId(algoId int64) *GetFuturesAlgoSubOrdersService {
+	s.algoId = algoId
+	return s
+}
+
+// Page set page
+func (s *GetFuturesAlgoSubOrdersService) Page(page int) *GetFuturesAlgoSubOrdersService {
+	s.page = &page
+	return s
+}
+
+// PageSize set pageSize
+func (s *GetFuturesAlgoSubOrdersService) PageSize(pageSize int) *GetFuturesAlgoSubOrdersService {
+	s.pageSize = &pageSize
+	return s
+}
+
+// Do send request
+func (s *GetFuturesAlgoSubOrdersService) Do(ctx context.Context, opts ...RequestOption) (res *GetFuturesAlgoSubOrdersResponse, err error) {
+	r := &request{
+		method:   http.MethodGet,
+		endpoint: "/sapi/v1/algo/futures/subOrders",
+		secType:  secTypeSigned,
+	}
+	r.setParam("algoId", s.algoId)
+	if s.page != nil {
+		r.setParam("page", *s.page)
+	}
+	if s.pageSize != nil {
+		r.setParam("pageSize", *s.pageSize)
+	}
+	data, err := s.c.callAPI(ctx, r, opts...)
+	if err != nil {
+		return nil, err
+	}
+	res = new(GetFuturesAlgoSubOrdersResponse)
+	err = json.Unmarshal(data, res)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+// FutureAlgoSubOrder definen sub order of future algo order
+type FuturesAlgoSubOrder struct {
+	AlgoId           int64           `json:"algoId"`
+	OrderId          int64           `json:"orderId"`
+	Symbol           string          `json:"symbol"`
+	Side             SideType        `json:"side"`
+	OrderStatus      OrderStatusType `json:"orderStatus"`
+	ExecutedQuantity string          `json:"executedQty"`
+	ExecutedAmount   string          `json:"executedAmt"`
+	FeeAmount        string          `json:"feeAmt"`
+	FeeAsset         string          `json:"feeAsset"`
+	AvgPrice         string          `json:"avgPrice"`
+	BookTime         int64           `json:"bookTime"`
+	SubId            int64           `json:"subId"`
+	TimeInForce      TimeInForceType `json:"timeInForce"`
+	OriginQuantity   string          `json:"origQty"`
+}
+
+type GetFuturesAlgoSubOrdersResponse struct {
+	Total            int64                  `json:"total"`
+	ExecutedQuantity string                 `json:"executedQty"`
+	ExecutedAmount   string                 `json:"executedAmt"`
+	SubOrders        []*FuturesAlgoSubOrder `json:"subOrders"`
+}

--- a/v2/futures_algo_service_test.go
+++ b/v2/futures_algo_service_test.go
@@ -1,0 +1,390 @@
+package binance
+
+import (
+	"testing"
+
+	"github.com/adshao/go-binance/v2/futures"
+	"github.com/stretchr/testify/suite"
+)
+
+type baseFuturesAlgoOrderTestSuite struct {
+	baseTestSuite
+}
+
+type futuresAlgoOrderTestSuite struct {
+	baseFuturesAlgoOrderTestSuite
+}
+
+func TestFuturesAlgoOrderService(t *testing.T) {
+	suite.Run(t, new(futuresAlgoOrderTestSuite))
+}
+
+func (s *baseFuturesAlgoOrderTestSuite) assertFuturesAlgoOrderEqual(e, a *FuturesAlgoOrder) {
+	r := s.r()
+	r.Equal(e.AlgoId, a.AlgoId, "AlgoId")
+	r.Equal(e.Symbol, a.Symbol, "Symbol")
+	r.Equal(e.Side, a.Side, "Side")
+	r.Equal(e.PositionSide, a.PositionSide, "PositionSide")
+	r.Equal(e.TotalQuantity, a.TotalQuantity, "TotalQuantity")
+	r.Equal(e.ExecutedQuantity, a.ExecutedQuantity, "ExecutedQuantity")
+	r.Equal(e.ExecutedAmount, a.ExecutedAmount, "ExecutedAmount")
+	r.Equal(e.AvgPrice, a.AvgPrice, "AvgPrice")
+	r.Equal(e.ClientAlgoId, a.ClientAlgoId, "ClientAlgoId")
+	r.Equal(e.BookTime, a.BookTime, "BookTime")
+	r.Equal(e.EndTime, a.EndTime, "EndTime")
+	r.Equal(e.AlgoStatus, a.AlgoStatus, "AlgoStatus")
+	r.Equal(e.AlgoType, a.AlgoType, "AlgoType")
+	r.Equal(e.Urgency, a.Urgency, "Urgency")
+}
+
+func (s *baseFuturesAlgoOrderTestSuite) assertFuturesAlgoSubOrderEqual(a, e *FuturesAlgoSubOrder) {
+	r := s.r()
+	r.Equal(e.Symbol, a.Symbol, "Symbol")
+	r.Equal(e.OrderId, a.OrderId, "OrderId")
+	r.Equal(e.AlgoId, a.AlgoId, "AlgoId")
+	r.Equal(e.Side, a.Side, "Side")
+	r.Equal(e.OrderStatus, a.OrderStatus, "OrderStatus")
+	r.Equal(e.ExecutedQuantity, a.ExecutedQuantity, "ExecutedQuantity")
+	r.Equal(e.ExecutedAmount, a.ExecutedAmount, "ExecutedAmount")
+	r.Equal(e.FeeAmount, a.FeeAmount, "FeeAmount")
+	r.Equal(e.FeeAsset, a.FeeAsset, "FeeAsset")
+	r.Equal(e.AvgPrice, a.AvgPrice, "AvgPrice")
+	r.Equal(e.BookTime, a.BookTime, "BookTime")
+	r.Equal(e.SubId, a.SubId, "SubId")
+	r.Equal(e.TimeInForce, a.TimeInForce, "TimeInForce")
+	r.Equal(e.OriginQuantity, a.OriginQuantity, "OriginQuantity")
+}
+
+func (s *futuresAlgoOrderTestSuite) TestCreateVpOrder() {
+	data := []byte(`{
+		"clientAlgoId": "12345678",
+		"success": true, 
+		"code": 0,
+		"msg": "OK"
+	}`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+	symbol := "BTCUSDT"
+	side := SideTypeBuy
+	positionSide := futures.PositionSideTypeLong
+	quantity := 1.1
+	urgency := FuturesAlgoUrgencyTypeMedium
+	clientAlgoId := "12345678"
+	s.assertReq(func(r *request) {
+		e := newSignedRequest().setFormParams(params{
+			"symbol":       symbol,
+			"side":         string(side),
+			"positionSide": string(positionSide),
+			"quantity":     quantity,
+			"urgency":      string(urgency),
+			"clientAlgoId": clientAlgoId,
+		})
+		s.assertRequestEqual(e, r)
+	})
+	res, err := s.client.NewCreateFuturesAlgoVpOrderService().Symbol(symbol).Side(side).PositionSide(positionSide).Quantity(quantity).
+		Urgency(urgency).ClientAlgoId(clientAlgoId).Do(newContext())
+	s.r().NoError(err)
+	e := &CreateFuturesAlgoOrderResponse{
+		ClientAlgoId: "12345678",
+		Success:      true,
+		Code:         0,
+		Msg:          "OK",
+	}
+	s.assertCreateAlgoOrderResponseEqual(e, res)
+}
+
+func (s *futuresAlgoOrderTestSuite) TestCreateTwapOrder() {
+	data := []byte(`{
+		"clientAlgoId": "12345678",
+		"success": true, 
+		"code": 0,
+		"msg": "OK"
+	}`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+	symbol := "BTCUSDT"
+	side := SideTypeBuy
+	positionSide := futures.PositionSideTypeLong
+	quantity := 1.1
+	duration := int64(60)
+	clientAlgoId := "12345678"
+	limitPrice := 60000.0
+	s.assertReq(func(r *request) {
+		e := newSignedRequest().setFormParams(params{
+			"symbol":       symbol,
+			"side":         string(side),
+			"positionSide": string(positionSide),
+			"quantity":     quantity,
+			"duration":     duration,
+			"clientAlgoId": clientAlgoId,
+			"limitPrice":   limitPrice,
+		})
+		s.assertRequestEqual(e, r)
+	})
+	res, err := s.client.NewCreateFuturesAlgoTwapOrderService().Symbol(symbol).Side(side).PositionSide(positionSide).Quantity(quantity).
+		Duration(duration).ClientAlgoId(clientAlgoId).LimitPrice(limitPrice).Do(newContext())
+	s.r().NoError(err)
+	e := &CreateFuturesAlgoOrderResponse{
+		ClientAlgoId: "12345678",
+		Success:      true,
+		Code:         0,
+		Msg:          "OK",
+	}
+	s.assertCreateAlgoOrderResponseEqual(e, res)
+}
+
+func (s *baseFuturesAlgoOrderTestSuite) assertCreateAlgoOrderResponseEqual(e, a *CreateFuturesAlgoOrderResponse) {
+	r := s.r()
+	r.Equal(e.ClientAlgoId, a.ClientAlgoId, "ClientAlgoId")
+	r.Equal(e.Success, a.Success, "Success")
+	r.Equal(e.Code, a.Code, "Code")
+	r.Equal(e.Msg, a.Msg, "Msg")
+}
+
+func (s *futuresAlgoOrderTestSuite) TestListOpenOrders() {
+	data := []byte(`{
+		"total": 1,
+		"orders": [
+			{ 
+				"algoId": 14517,
+				"symbol": "ETHUSDT",
+				"side": "SELL",
+				"positionSide": "SHORT",
+				"totalQty": "5.000",
+				"executedQty": "0.000", 
+				"executedAmt": "0.00000000",
+				"avgPrice": "0.00",
+				"clientAlgoId": "d7096549481642f8a0bb69e9e2e31f2e",
+				"bookTime": 1649756817004,
+				"endTime": 0,
+				"algoStatus": "WORKING",
+				"algoType": "VP",
+				"urgency": "LOW"
+			}
+		]
+	}`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+	s.assertReq(func(r *request) {
+		e := newSignedRequest()
+		s.assertRequestEqual(e, r)
+	})
+	res, err := s.client.NewListOpenFuturesAlgoOrdersService().Do(newContext())
+	s.r().NoError(err)
+	e := &ListOpenFuturesAlgoOrdersResponse{
+		Total: 1,
+		Orders: []*FuturesAlgoOrder{
+			{
+				AlgoId:           14517,
+				Symbol:           "ETHUSDT",
+				Side:             SideTypeSell,
+				PositionSide:     futures.PositionSideTypeShort,
+				TotalQuantity:    "5.000",
+				ExecutedQuantity: "0.000",
+				ExecutedAmount:   "0.00000000",
+				AvgPrice:         "0.00",
+				ClientAlgoId:     "d7096549481642f8a0bb69e9e2e31f2e",
+				BookTime:         1649756817004,
+				EndTime:          0,
+				AlgoStatus:       FuturesAlgoOrderStatusTypeWorking,
+				AlgoType:         FuturesAlgoTypeVp,
+				Urgency:          FuturesAlgoUrgencyTypeLow,
+			},
+		},
+	}
+	s.assertListAlgoOrdersResponseEqual(e, res)
+}
+
+func (s *baseFuturesAlgoOrderTestSuite) assertListAlgoOrdersResponseEqual(e, a *ListOpenFuturesAlgoOrdersResponse) {
+	r := s.r()
+	r.Equal(e.Total, a.Total, "Total")
+	for i := range e.Orders {
+		s.assertFuturesAlgoOrderEqual(e.Orders[i], a.Orders[i])
+	}
+}
+
+func (s *futuresAlgoOrderTestSuite) TestGetHistoryOrders() {
+	data := []byte(`{
+		"total": 1,
+		"orders": [
+			{
+				"algoId": 14518,
+				"symbol": "BNBUSDT",
+				"side": "BUY",
+				"positionSide": "BOTH", 
+				"totalQty": "100.00",   
+				"executedQty": "0.00",  
+				"executedAmt": "0.00000000", 
+				"avgPrice": "3000.000",
+				"clientAlgoId": "acacab56b3c44bef9f6a8f8ebd2a8408",
+				"bookTime": 1649757019503,   
+				"endTime": 1649757088101,    
+				"algoStatus": "CANCELLED",   
+				"algoType": "VP",            
+				"urgency": "LOW"             
+			}
+		]
+	}`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+	symbol := "BNBUSDT"
+	side := SideTypeBuy
+	startTime := int64(1649757019503)
+	endTime := int64(1649757088101)
+	page := 1
+	pageSize := 10
+	s.assertReq(func(r *request) {
+		e := newSignedRequest().setParams(params{
+			"symbol":    symbol,
+			"side":      string(side),
+			"startTime": startTime,
+			"endTime":   endTime,
+			"page":      page,
+			"pageSize":  pageSize,
+		})
+		s.assertRequestEqual(e, r)
+	})
+	res, err := s.client.NewListHistoryFuturesAlgoOrdersService().Symbol(symbol).Side(side).StartTime(startTime).EndTime(endTime).
+		Page(page).PageSize(pageSize).Do(newContext())
+	s.r().NoError(err)
+	e := &ListHistoryFuturesAlgoOrdersResponse{
+		Total: 1,
+		Orders: []*FuturesAlgoOrder{
+			{
+				AlgoId:           14518,
+				Symbol:           "BNBUSDT",
+				Side:             SideTypeBuy,
+				PositionSide:     futures.PositionSideTypeBoth,
+				TotalQuantity:    "100.00",
+				ExecutedQuantity: "0.00",
+				ExecutedAmount:   "0.00000000",
+				AvgPrice:         "3000.000",
+				ClientAlgoId:     "acacab56b3c44bef9f6a8f8ebd2a8408",
+				BookTime:         1649757019503,
+				EndTime:          1649757088101,
+				AlgoStatus:       FuturesAlgoOrderStatusTypeCancelled,
+				AlgoType:         FuturesAlgoTypeVp,
+				Urgency:          FuturesAlgoUrgencyTypeLow,
+			},
+		},
+	}
+	s.assertListHistoryAlgoOrdersResponseEqual(e, res)
+}
+
+func (s *baseFuturesAlgoOrderTestSuite) assertListHistoryAlgoOrdersResponseEqual(e, a *ListHistoryFuturesAlgoOrdersResponse) {
+	r := s.r()
+	r.Equal(e.Total, a.Total, "Total")
+	for i := range e.Orders {
+		s.assertFuturesAlgoOrderEqual(e.Orders[i], a.Orders[i])
+	}
+}
+
+func (s *futuresAlgoOrderTestSuite) TestCancelOrder() {
+	data := []byte(`{
+		"algoId": 14511,
+		"success": true,
+		"code": 0,
+		"msg": "OK"
+	}`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+	algoId := int64(14511)
+	s.assertReq(func(r *request) {
+		e := newSignedRequest().setFormParams(params{
+			"algoId": algoId,
+		})
+		s.assertRequestEqual(e, r)
+	})
+	res, err := s.client.NewCancelFuturesAlgoOrderService().AlgoId(algoId).Do(newContext())
+	s.r().NoError(err)
+	e := &CancelFuturesAlgoOrderResponse{
+		AlgoId:  14511,
+		Success: true,
+		Code:    0,
+		Msg:     "OK",
+	}
+	s.assertCancelAlgoOrdersResponseEqual(e, res)
+}
+
+func (s *baseFuturesAlgoOrderTestSuite) assertCancelAlgoOrdersResponseEqual(e, a *CancelFuturesAlgoOrderResponse) {
+	r := s.r()
+	r.Equal(e.AlgoId, a.AlgoId, "AlgoId")
+	r.Equal(e.Success, a.Success, "Success")
+	r.Equal(e.Code, a.Code, "Code")
+	r.Equal(e.Msg, a.Msg, "Msg")
+}
+
+func (s *futuresAlgoOrderTestSuite) TestGetSubOrders() {
+	data := []byte(`{
+		"total": 1,
+		"executedQty": "1.000",
+		"executedAmt": "3229.44000000",
+		"subOrders": [
+			{
+				"algoId": 13723,
+				"orderId": 8389765519993908929, 
+				"orderStatus": "FILLED", 
+				"executedQty": "1.000",
+				"executedAmt": "3229.44000000", 
+				"feeAmt": "-1.61471999", 
+				"feeAsset": "USDT",
+				"bookTime": 1649319001964,
+				"avgPrice": "3229.44",
+				"side": "SELL", 
+				"symbol": "ETHUSDT",
+				"subId": 1, 
+				"timeInForce": "IOC", 
+				"origQty": "1.000"           
+			}
+		]
+	}`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+	algoId := int64(14511)
+	page := 1
+	pageSize := 10
+	s.assertReq(func(r *request) {
+		e := newSignedRequest().setParams(params{
+			"algoId":   algoId,
+			"page":     page,
+			"pageSize": pageSize,
+		})
+		s.assertRequestEqual(e, r)
+	})
+	res, err := s.client.NewGetFuturesAlgoSubOrdersService().AlgoId(algoId).Page(page).PageSize(pageSize).Do(newContext())
+	s.r().NoError(err)
+	e := &GetFuturesAlgoSubOrdersResponse{
+		Total:            1,
+		ExecutedQuantity: "1.000",
+		ExecutedAmount:   "3229.44000000",
+		SubOrders: []*FuturesAlgoSubOrder{
+			{
+				AlgoId:           13723,
+				OrderId:          8389765519993908929,
+				OrderStatus:      OrderStatusTypeFilled,
+				ExecutedQuantity: "1.000",
+				ExecutedAmount:   "3229.44000000",
+				FeeAmount:        "-1.61471999",
+				FeeAsset:         "USDT",
+				BookTime:         1649319001964,
+				AvgPrice:         "3229.44",
+				Side:             SideTypeSell,
+				Symbol:           "ETHUSDT",
+				SubId:            1,
+				TimeInForce:      TimeInForceTypeIOC,
+				OriginQuantity:   "1.000",
+			},
+		},
+	}
+	s.assertGetSubOrdersResponseEqual(e, res)
+}
+
+func (s *baseFuturesAlgoOrderTestSuite) assertGetSubOrdersResponseEqual(e, a *GetFuturesAlgoSubOrdersResponse) {
+	r := s.r()
+	r.Equal(e.Total, a.Total, "Total")
+	r.Equal(e.ExecutedQuantity, a.ExecutedQuantity, "ExecutedQuantity")
+	r.Equal(e.ExecutedAmount, a.ExecutedAmount, "ExecutedAmount")
+	for i := range e.SubOrders {
+		s.assertFuturesAlgoSubOrderEqual(e.SubOrders[i], a.SubOrders[i])
+	}
+}


### PR DESCRIPTION
implement futures algo [endpoint](https://binance-docs.github.io/apidocs/spot/en/#futures-algo-endpoints), including 6 apis:
1. create futures vp order
2. create futures twap order
3. list open algo orders
4. list historical algo orders
5. cancel algo order
6. get algo sub orders

@adshao  plz review it