### PR TITLE
Fix /sapi/v1/sub-account/universalTransfer Signature for this request is not valid.

### DIFF
--- a/v2/subaccount_service.go
+++ b/v2/subaccount_service.go
@@ -1926,21 +1926,21 @@ func (s *SubAccountUniversalTransferService) Do(ctx context.Context, opts ...Req
 		secType:  secTypeSigned,
 	}
 	if s.fromEmail != nil {
-		r.setFormParam("fromEmail", *s.fromEmail)
+		r.setParam("fromEmail", *s.fromEmail)
 	}
 	if s.toEmail != nil {
-		r.setFormParam("toEmail", *s.toEmail)
+		r.setParam("toEmail", *s.toEmail)
 	}
-	r.setFormParam("fromAccountType", s.fromAccountType)
-	r.setFormParam("toAccountType", s.toAccountType)
+	r.setParam("fromAccountType", s.fromAccountType)
+	r.setParam("toAccountType", s.toAccountType)
 	if s.clientTranId != nil {
-		r.setFormParam("clientTranId", *s.clientTranId)
+		r.setParam("clientTranId", *s.clientTranId)
 	}
 	if s.symbol != nil {
-		r.setFormParam("symbol", *s.symbol)
+		r.setParam("symbol", *s.symbol)
 	}
-	r.setFormParam("asset", s.asset)
-	r.setFormParam("amount", s.amount)
+	r.setParam("asset", s.asset)
+	r.setParam("amount", s.amount)
 	if s.recvWindow != nil {
 		r.recvWindow = *s.recvWindow
 	}

--- a/v2/subaccount_service_test.go
+++ b/v2/subaccount_service_test.go
@@ -1599,7 +1599,7 @@ func (s *subAccountUniversalTransferServiceTestSuite) TestSubAccountUniversalTra
 	var asset string = "USDT"
 	var amount string = "0.0125586"
 	s.assertReq(func(r *request) {
-		e := newSignedRequest().setFormParam("fromAccountType", fromAccountType).setFormParam("toAccountType", toAccountType).setFormParam("asset", asset).setFormParam("amount", amount)
+		e := newSignedRequest().setParam("fromAccountType", fromAccountType).setParam("toAccountType", toAccountType).setParam("asset", asset).setParam("amount", amount)
 		s.assertRequestEqual(e, r)
 	})
 	res, err := s.client.NewSubAccountUniversalTransferService().FromAccountType(fromAccountType).ToAccountType(toAccountType).Asset(asset).Amount(amount).Do(newContext())


### PR DESCRIPTION
A fix for wrong params and formParams set on api /sapi/v1/sub-account/universalTransfer