### PR TITLE
feat: Add permissionSets field to exchange info response

### DIFF
--- a/v2/exchange_info_service.go
+++ b/v2/exchange_info_service.go
@@ -102,6 +102,7 @@ type Symbol struct {
 	IsMarginTradingAllowed     bool                     `json:"isMarginTradingAllowed"`
 	Filters                    []map[string]interface{} `json:"filters"`
 	Permissions                []string                 `json:"permissions"`
+	PermissionSets             [][]string               `json:"permissionSets"`
 }
 
 // LotSizeFilter define lot size filter of symbol

--- a/v2/exchange_info_service.go
+++ b/v2/exchange_info_service.go
@@ -9,10 +9,11 @@ import (
 
 // ExchangeInfoService exchange info service
 type ExchangeInfoService struct {
-	c           *Client
-	symbol      string
-	symbols     []string
-	permissions []string
+	c                  *Client
+	symbol             string
+	symbols            []string
+	permissions        []string
+	showPermissionSets *bool
 }
 
 // Symbol set symbol
@@ -35,6 +36,13 @@ func (s *ExchangeInfoService) Permissions(permissions ...string) *ExchangeInfoSe
 	return s
 }
 
+// ShowPermissionSets set showPermissionSets
+func (s *ExchangeInfoService) ShowPermissionSets(showPermissionSets *bool) *ExchangeInfoService {
+	s.showPermissionSets = showPermissionSets
+
+	return s
+}
+
 // Do send request
 func (s *ExchangeInfoService) Do(ctx context.Context, opts ...RequestOption) (res *ExchangeInfo, err error) {
 	r := &request{
@@ -51,6 +59,9 @@ func (s *ExchangeInfoService) Do(ctx context.Context, opts ...RequestOption) (re
 	}
 	if len(s.permissions) != 0 {
 		m["permissions"] = s.permissions
+	}
+	if s.showPermissionSets != nil {
+		m["showPermissionSets"] = *s.showPermissionSets
 	}
 	r.setParams(m)
 	data, err := s.c.callAPI(ctx, r, opts...)

--- a/v2/exchange_info_service_test.go
+++ b/v2/exchange_info_service_test.go
@@ -218,6 +218,59 @@ func (s *exchangeInfoServiceTestSuite) TestExchangeInfo() {
 	s.assertMaxNumAlgoOrdersFilterEqual(eMaxNumAlgoOrdersFilter, res.Symbols[0].MaxNumAlgoOrdersFilter())
 }
 
+func (s *exchangeInfoServiceTestSuite) TestExchangeInfoWithPermissionSets() {
+	data := []byte(`{
+		"timezone":"UTC",
+		"serverTime":1733252001653,
+		"rateLimits":[
+			{
+				"rateLimitType":"REQUEST_WEIGHT",
+				"interval":"MINUTE",
+				"intervalNum":1,
+				"limit":6000
+			}
+		],
+		"exchangeFilters":[],
+		"symbols":[
+			{
+				"symbol":"BTCUSDT",
+				"status":"TRADING",
+				"baseAsset":"BTC",
+				"baseAssetPrecision":8,
+				"quoteAsset":"USDT",
+				"quotePrecision":8,
+				"quoteAssetPrecision":8,
+				"baseCommissionPrecision":8,
+				"quoteCommissionPrecision":8,
+				"orderTypes":["LIMIT","LIMIT_MAKER","MARKET","STOP_LOSS","STOP_LOSS_LIMIT","TAKE_PROFIT","TAKE_PROFIT_LIMIT"],
+				"icebergAllowed":true,
+				"ocoAllowed":true,
+				"otoAllowed":true,
+				"quoteOrderQtyMarketAllowed":true,
+				"allowTrailingStop":true,
+				"cancelReplaceAllowed":true,
+				"isSpotTradingAllowed":true,
+				"isMarginTradingAllowed":true,
+				"filters":[
+					{
+						"filterType":"PRICE_FILTER",
+						"minPrice":"0.01000000",
+						"maxPrice":"1000000.00000000",
+						"tickSize":"0.01000000"
+					}
+				],
+				"permissions":[],
+				"permissionSets":[["SPOT","MARGIN"]]
+			}
+		]
+	}`)
+	s.mockDo(data, nil)
+	res, err := s.client.NewExchangeInfoService().Symbol("BTCUSDT").Do(newContext())
+	s.r().NoError(err)
+	s.r().Len(res.Symbols[0].PermissionSets, 1)
+	s.r().Equal([]string{"SPOT", "MARGIN"}, res.Symbols[0].PermissionSets[0])
+}
+
 func (s *exchangeInfoServiceTestSuite) assertExchangeInfoEqual(e, a *ExchangeInfo) {
 	r := s.r()
 


### PR DESCRIPTION
This PR adds support for the `permissionSets` field in the Binance Exchange Info API response. The field was recently added to the API and contains information about trading permissions for each symbol.

Closes https://github.com/adshao/go-binance/issues/640