### PR TITLE
Futures Position Risk backward compatibility

### DIFF
--- a/v2/futures/client.go
+++ b/v2/futures/client.go
@@ -532,12 +532,12 @@ func (c *Client) NewGetBalanceService() *GetBalanceService {
 	return &GetBalanceService{c: c}
 }
 
-func (c *Client) NewGetPositionRiskV2Service() *GetPositionRiskV2Service {
-	return &GetPositionRiskV2Service{c: c}
-}
-
 func (c *Client) NewGetPositionRiskService() *GetPositionRiskService {
 	return &GetPositionRiskService{c: c}
+}
+
+func (c *Client) NewGetPositionRiskV3Service() *GetPositionRiskV3Service {
+	return &GetPositionRiskV3Service{c: c}
 }
 
 // NewGetPositionMarginHistoryService init getting position margin history service

--- a/v2/futures/position_risk.go
+++ b/v2/futures/position_risk.go
@@ -6,20 +6,20 @@ import (
 	"net/http"
 )
 
-// GetPositionRiskService get account balance
-type GetPositionRiskV2Service struct {
+// GetPositionRiskV3Service get account balance
+type GetPositionRiskService struct {
 	c      *Client
 	symbol string
 }
 
 // Symbol set symbol
-func (s *GetPositionRiskV2Service) Symbol(symbol string) *GetPositionRiskV2Service {
+func (s *GetPositionRiskService) Symbol(symbol string) *GetPositionRiskService {
 	s.symbol = symbol
 	return s
 }
 
 // Do send request
-func (s *GetPositionRiskV2Service) Do(ctx context.Context, opts ...RequestOption) (res []*PositionRiskV2, err error) {
+func (s *GetPositionRiskService) Do(ctx context.Context, opts ...RequestOption) (res []*PositionRisk, err error) {
 	r := &request{
 		method:   http.MethodGet,
 		endpoint: "/fapi/v2/positionRisk",
@@ -30,18 +30,18 @@ func (s *GetPositionRiskV2Service) Do(ctx context.Context, opts ...RequestOption
 	}
 	data, _, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
-		return []*PositionRiskV2{}, err
+		return []*PositionRisk{}, err
 	}
-	res = make([]*PositionRiskV2, 0)
+	res = make([]*PositionRisk, 0)
 	err = json.Unmarshal(data, &res)
 	if err != nil {
-		return []*PositionRiskV2{}, err
+		return []*PositionRisk{}, err
 	}
 	return res, nil
 }
 
 // PositionRisk define position risk info
-type PositionRiskV2 struct {
+type PositionRisk struct {
 	EntryPrice       string `json:"entryPrice"`
 	BreakEvenPrice   string `json:"breakEvenPrice"`
 	MarginType       string `json:"marginType"`
@@ -59,25 +59,25 @@ type PositionRiskV2 struct {
 	IsolatedWallet   string `json:"isolatedWallet"`
 }
 
-type GetPositionRiskService struct {
+type GetPositionRiskV3Service struct {
 	c          *Client
 	symbol     string
 	recvWindow *int64
 }
 
 // Symbol set symbol
-func (s *GetPositionRiskService) Symbol(symbol string) *GetPositionRiskService {
+func (s *GetPositionRiskV3Service) Symbol(symbol string) *GetPositionRiskV3Service {
 	s.symbol = symbol
 	return s
 }
 
-func (s *GetPositionRiskService) RecvWindow(rw int64) *GetPositionRiskService {
+func (s *GetPositionRiskV3Service) RecvWindow(rw int64) *GetPositionRiskV3Service {
 	s.recvWindow = &rw
 	return s
 }
 
 // Do send request
-func (s *GetPositionRiskService) Do(ctx context.Context, opts ...RequestOption) (res []*PositionRisk, err error) {
+func (s *GetPositionRiskV3Service) Do(ctx context.Context, opts ...RequestOption) (res []*PositionRiskV3, err error) {
 	r := &request{
 		method:   http.MethodGet,
 		endpoint: "/fapi/v3/positionRisk",
@@ -92,18 +92,18 @@ func (s *GetPositionRiskService) Do(ctx context.Context, opts ...RequestOption) 
 
 	data, _, err := s.c.callAPI(ctx, r, opts...)
 	if err != nil {
-		return []*PositionRisk{}, err
+		return []*PositionRiskV3{}, err
 	}
-	res = make([]*PositionRisk, 0)
+	res = make([]*PositionRiskV3, 0)
 	err = json.Unmarshal(data, &res)
 	if err != nil {
-		return []*PositionRisk{}, err
+		return []*PositionRiskV3{}, err
 	}
 	return res, nil
 }
 
-// PositionRisk define position risk info
-type PositionRisk struct {
+// PositionRiskV3 define position risk info
+type PositionRiskV3 struct {
 	Symbol                 string `json:"symbol"`
 	PositionSide           string `json:"positionSide"`
 	PositionAmt            string `json:"positionAmt"`

--- a/v2/futures/position_risk_test.go
+++ b/v2/futures/position_risk_test.go
@@ -44,12 +44,12 @@ func (s *positionRiskServiceTestSuite) TestGetPositionRiskV2() {
 		})
 		s.assertRequestEqual(e, r)
 	})
-	res, err := s.client.NewGetPositionRiskV2Service().Symbol(symbol).
+	res, err := s.client.NewGetPositionRiskService().Symbol(symbol).
 		Do(newContext(), WithRecvWindow(recvWindow))
 	r := s.r()
 	r.NoError(err)
 	r.Len(res, 1)
-	e := &PositionRiskV2{
+	e := &PositionRisk{
 		EntryPrice:       "10359.38000",
 		BreakEvenPrice:   "10387.38000",
 		MarginType:       "isolated",
@@ -67,7 +67,7 @@ func (s *positionRiskServiceTestSuite) TestGetPositionRiskV2() {
 	s.assertPositionRiskV2Equal(e, res[0])
 }
 
-func (s *positionRiskServiceTestSuite) assertPositionRiskV2Equal(e, a *PositionRiskV2) {
+func (s *positionRiskServiceTestSuite) assertPositionRiskV2Equal(e, a *PositionRisk) {
 	r := s.r()
 	r.Equal(e.EntryPrice, a.EntryPrice, "EntryPrice")
 	r.Equal(e.BreakEvenPrice, a.BreakEvenPrice, "BreakEvenPrice")
@@ -121,12 +121,12 @@ func (s *positionRiskServiceTestSuite) TestGetPositionRisk() {
 		})
 		s.assertRequestEqual(e, r)
 	})
-	res, err := s.client.NewGetPositionRiskService().Symbol(symbol).
+	res, err := s.client.NewGetPositionRiskV3Service().Symbol(symbol).
 		Do(newContext(), WithRecvWindow(recvWindow))
 	r := s.r()
 	r.NoError(err)
 	r.Len(res, 1)
-	e := &PositionRisk{
+	e := &PositionRiskV3{
 		Symbol:                 "BTCUSDT",
 		PositionSide:           "BOTH",
 		PositionAmt:            "0.000",
@@ -151,7 +151,7 @@ func (s *positionRiskServiceTestSuite) TestGetPositionRisk() {
 	s.assertPositionRiskEqual(e, res[0])
 }
 
-func (s *positionRiskServiceTestSuite) assertPositionRiskEqual(e, a *PositionRisk) {
+func (s *positionRiskServiceTestSuite) assertPositionRiskEqual(e, a *PositionRiskV3) {
 	r := s.r()
 	r.Equal(e.Symbol, a.Symbol, "Symbol")
 	r.Equal(e.PositionSide, a.PositionSide, "PositionSide")

--- a/v2/futures/rebate_newuser.go
+++ b/v2/futures/rebate_newuser.go
@@ -52,7 +52,6 @@ func (s *GetRebateNewUserService) Do(ctx context.Context, opts ...RequestOption)
 	return res, nil
 }
 
-// PositionRisk define position risk info
 type RebateNewUser struct {
 	BrokerId      string `json:"brokerId"`
 	RebateWorking bool   `json:"rebateWorking"`


### PR DESCRIPTION
In my opinion, we shouldn't make breaking changes and replace v2 endpoints with v3 ones in terms of backward compatibility. 

This repository has 1.6k stars and almost 700 forks, and suddenly changing "Position Risk Service" from v2 behavior to v3 shouldn't be allowed, as you make breaking changes out of the blue in lots of other repositories. 

Especially, given that package is v2 library, if you add v3 endpoints in replacement of v2 ones (which are not deprecated), it makes usage of the package kind of confusing as well.

Another point is that there are several v2 endpoints that have v3 versions (e.g. Position Risk, Account, Balance), which were not updated yet. In the future, I would suggest to introduce them like "AccountServiceV3", not "AccountService".