### PR TITLE
Feature: Add futures websocket account balance&info

### DIFF
--- a/v2/common/websocket/mock/client.go
+++ b/v2/common/websocket/mock/client.go
@@ -112,6 +112,13 @@ func (m *MockClient) WriteSync(id string, data []byte, timeout time.Duration) ([
 	return ret0, ret1
 }
 
+func (m *MockClient) Close() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Close")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
 // WriteSync indicates an expected call of WriteSync.
 func (mr *MockClientMockRecorder) WriteSync(id, data, timeout interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()

--- a/v2/futures/account_service_ws.go
+++ b/v2/futures/account_service_ws.go
@@ -1,0 +1,208 @@
+package futures
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/adshao/go-binance/v2/common"
+	"github.com/adshao/go-binance/v2/common/websocket"
+	"github.com/google/uuid"
+)
+
+type WsAccountService struct {
+	c          websocket.Client
+	ApiKey     string
+	SecretKey  string
+	KeyType    string
+	TimeOffset int64
+	RecvWindow int64
+}
+
+func NewWsAccountService(apiKey, secretKey string, recvWindow ...int64) (*WsAccountService, error) {
+	conn, err := websocket.NewConnection(WsApiInitReadWriteConn, WebsocketKeepalive, WebsocketTimeoutReadWriteConnection)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := websocket.NewClient(conn)
+	if err != nil {
+		return nil, err
+	}
+
+	window := int64(5000)
+	if len(recvWindow) > 0 {
+		window = recvWindow[0]
+	}
+
+	return &WsAccountService{
+		c:          client,
+		ApiKey:     apiKey,
+		SecretKey:  secretKey,
+		KeyType:    common.KeyTypeHmac,
+		RecvWindow: window,
+	}, nil
+}
+
+type WsAccountV2InfoResponse struct {
+	ID        string             `json:"id"`
+	Status    int                `json:"status"`
+	Result    AccountV3          `json:"result"`
+	RateLimit []AccountRateLimit `json:"rateLimits"`
+	Error     *common.APIError   `json:"error,omitempty"`
+}
+
+type WsAccountV2BalanceResponse struct {
+	ID        string             `json:"id"`
+	Status    int                `json:"status"`
+	Result    []*Balance         `json:"result"`
+	RateLimit []AccountRateLimit `json:"rateLimits"`
+	Error     *common.APIError   `json:"error,omitempty"`
+}
+
+type AccountRateLimit struct {
+	RateLimitType string `json:"rateLimitType"`
+	Interval      string `json:"interval"`
+	IntervalNum   int    `json:"intervalNum"`
+	Limit         int    `json:"limit"`
+	Count         int    `json:"count"`
+}
+
+const (
+	AccountV2InfoMethod    websocket.WsApiMethodType = "v2/account.status"
+	AccountV2BalanceMethod websocket.WsApiMethodType = "v2/account.balance"
+)
+
+func (s *WsAccountService) GetAccountInfo(requestID string) error {
+	rawData, err := s.buildRequest(requestID, AccountV2InfoMethod)
+	if err != nil {
+		return err
+	}
+
+	if err := s.c.Write(requestID, rawData); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *WsAccountService) SyncGetAccountInfo(requestID string) (*WsAccountV2InfoResponse, error) {
+	rawData, err := s.buildRequest(requestID, AccountV2InfoMethod)
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := s.c.WriteSync(requestID, rawData, websocket.WriteSyncWsTimeout)
+	if err != nil {
+		return nil, err
+	}
+
+	info := &WsAccountV2InfoResponse{}
+	if err := json.Unmarshal(response, info); err != nil {
+		return nil, err
+	}
+
+	return info, nil
+}
+
+func (s *WsAccountService) GetAccountBalance(requestID string) error {
+	rawData, err := s.buildRequest(requestID, AccountV2BalanceMethod)
+	if err != nil {
+		return err
+	}
+
+	if err := s.c.Write(requestID, rawData); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *WsAccountService) SyncGetAccountBalance(requestID string) (*WsAccountV2BalanceResponse, error) {
+	rawData, err := s.buildRequest(requestID, AccountV2BalanceMethod)
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := s.c.WriteSync(requestID, rawData, websocket.WriteSyncWsTimeout)
+	if err != nil {
+		return nil, err
+	}
+
+	balance := &WsAccountV2BalanceResponse{}
+	if err := json.Unmarshal(response, balance); err != nil {
+		return nil, err
+	}
+
+	return balance, nil
+}
+
+func (s *WsAccountService) buildRequest(requestID string, method websocket.WsApiMethodType) ([]byte, error) {
+	return websocket.CreateRequest(
+		websocket.NewRequestData(
+			requestID,
+			s.ApiKey,
+			s.SecretKey,
+			s.TimeOffset,
+			s.KeyType,
+		),
+		method,
+		map[string]interface{}{
+			"recvWindow": s.RecvWindow,
+		},
+	)
+}
+
+// ReceiveAllDataBeforeStop waits until all responses will be received from websocket until timeout expired
+func (s *WsAccountService) ReceiveAllDataBeforeStop(timeout time.Duration) {
+	s.c.Wait(timeout)
+}
+
+// GetReadChannel returns channel with API response data (including API errors)
+func (s *WsAccountService) GetReadChannel() <-chan []byte {
+	return s.c.GetReadChannel()
+}
+
+// GetReadErrorChannel returns channel with errors which are occurred while reading websocket connection
+func (s *WsAccountService) GetReadErrorChannel() <-chan error {
+	return s.c.GetReadErrorChannel()
+}
+
+// GetReconnectCount returns count of reconnect attempts by client
+func (s *WsAccountService) GetReconnectCount() int64 {
+	return s.c.GetReconnectCount()
+}
+
+func (c *Client) NewWsAccountService(recvWindow ...int64) (*WsAccountService, error) {
+	return NewWsAccountService(c.APIKey, c.SecretKey, recvWindow...)
+}
+
+// GetAccountInfoWs Get account info by websocket like RESTful
+func (c *Client) GetAccountInfoWs(recvWindow ...int64) (*WsAccountV2InfoResponse, error) {
+	service, err := c.NewWsAccountService(recvWindow...)
+	if err != nil {
+		return nil, err
+	}
+	defer service.c.Close()
+
+	response, err := service.SyncGetAccountInfo(uuid.New().String())
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+func (c *Client) GetAccountBalanceWs(recvWindow ...int64) (*WsAccountV2BalanceResponse, error) {
+	service, err := c.NewWsAccountService(recvWindow...)
+	if err != nil {
+		return nil, err
+	}
+	defer service.c.Close()
+
+	response, err := service.SyncGetAccountBalance(uuid.New().String())
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}

--- a/v2/futures/account_service_ws_test.go
+++ b/v2/futures/account_service_ws_test.go
@@ -1,0 +1,206 @@
+package futures
+
+import (
+	"testing"
+
+	"github.com/adshao/go-binance/v2/common"
+	"github.com/adshao/go-binance/v2/common/websocket/mock"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/suite"
+)
+
+type accountWsServiceTestSuite struct {
+	suite.Suite
+	apiKey     string
+	secretKey  string
+	mockClient *mock.MockClient
+	mockCtrl   *gomock.Controller
+}
+
+func TestAccountWsService(t *testing.T) {
+	suite.Run(t, new(accountWsServiceTestSuite))
+}
+
+func (s *accountWsServiceTestSuite) SetupTest() {
+	s.apiKey = "dummyAPIKey"
+	s.secretKey = "dummySecretKey"
+	s.mockCtrl = gomock.NewController(s.T())
+	s.mockClient = mock.NewMockClient(s.mockCtrl)
+}
+
+func (s *accountWsServiceTestSuite) TearDownTest() {
+	s.mockCtrl.Finish()
+}
+
+func (s *accountWsServiceTestSuite) TestGetAccountInfo() {
+	data := []byte(`{
+  "id": "873a969f-2d36-472a-ace5-0a61c5fc7d39",
+  "status": 200,
+  "result": {
+    "totalInitialMargin": "13.63585026",
+    "totalMaintMargin": "0.68179251",
+    "totalWalletBalance": "192.32494207",
+    "totalUnrealizedProfit": "6.95279735",
+    "totalMarginBalance": "199.27773942",
+    "totalPositionInitialMargin": "13.63585026",
+    "totalOpenOrderInitialMargin": "0.00000000",
+    "totalCrossWalletBalance": "192.32494207",
+    "totalCrossUnPnl": "6.95279735",
+    "availableBalance": "185.64188916",
+    "maxWithdrawAmount": "185.64188916",
+    "assets": [
+      {
+        "asset": "USDT",
+        "walletBalance": "192.32494207",
+        "unrealizedProfit": "6.95279735",
+        "marginBalance": "199.27773942",
+        "maintMargin": "0.68179251",
+        "initialMargin": "13.63585026",
+        "positionInitialMargin": "13.63585026",
+        "openOrderInitialMargin": "0.00000000",
+        "crossWalletBalance": "192.32494207",
+        "crossUnPnl": "6.95279735",
+        "availableBalance": "185.64188916",
+        "maxWithdrawAmount": "185.64188916",
+        "updateTime": 1747995976003
+      },
+      {
+        "asset": "USDC",
+        "walletBalance": "0.00000000",
+        "unrealizedProfit": "0.00000000",
+        "marginBalance": "0.00000000",
+        "maintMargin": "0.00000000",
+        "initialMargin": "0.00000000",
+        "positionInitialMargin": "0.00000000",
+        "openOrderInitialMargin": "0.00000000",
+        "crossWalletBalance": "0.00000000",
+        "crossUnPnl": "0.00000000",
+        "availableBalance": "0.00000000",
+        "maxWithdrawAmount": "0.00000000",
+        "updateTime": 0
+      }
+    ],
+    "positions": [
+      {
+        "symbol": "SOLUSDT",
+        "positionSide": "SHORT",
+        "positionAmt": "-0.77",
+        "unrealizedProfit": "6.95279735",
+        "isolatedMargin": "0",
+        "notional": "-136.35850264",
+        "isolatedWallet": "0",
+        "initialMargin": "13.63585026",
+        "maintMargin": "0.68179251",
+        "updateTime": 1747995976003
+      }
+    ]
+  },
+  "rateLimits": [
+    {
+      "rateLimitType": "REQUEST_WEIGHT",
+      "interval": "MINUTE",
+      "intervalNum": 1,
+      "limit": 2400,
+      "count": 50
+    }
+  ]
+}`)
+
+	requestID := "873a969f-2d36-472a-ace5-0a61c5fc7d39"
+	s.mockClient.EXPECT().WriteSync(requestID, gomock.Any(), gomock.Any()).Return(data, nil)
+
+	wsAccountV2Service := &WsAccountService{
+		c:          s.mockClient,
+		ApiKey:     s.apiKey,
+		SecretKey:  s.secretKey,
+		KeyType:    common.KeyTypeHmac,
+		RecvWindow: 5000,
+	}
+
+	response, err := wsAccountV2Service.SyncGetAccountInfo(requestID)
+	s.NoError(err)
+
+	// verify
+	s.Equal(200, response.Status)
+	s.Equal(requestID, response.ID)
+
+	// verify account info
+	s.Equal("13.63585026", response.Result.TotalInitialMargin)
+	s.Equal("192.32494207", response.Result.TotalWalletBalance)
+	s.Equal("185.64188916", response.Result.AvailableBalance)
+
+	// verify assets info
+	s.Len(response.Result.Assets, 2)
+	s.Equal("USDT", response.Result.Assets[0].Asset)
+	s.Equal("192.32494207", response.Result.Assets[0].WalletBalance)
+
+	// verify positions info
+	s.Len(response.Result.Positions, 1)
+	s.Equal("SOLUSDT", response.Result.Positions[0].Symbol)
+	s.Equal("SHORT", response.Result.Positions[0].PositionSide)
+	s.Equal("-0.77", response.Result.Positions[0].PositionAmt)
+}
+
+func (s *accountWsServiceTestSuite) TestGetAccountBalance() {
+	data := []byte(`{
+  "id": "7fe4c481-9784-4c02-8121-aacae6d2d38f",
+  "status": 200,
+  "result": [
+    {
+      "accountAlias": "SgsR",
+      "asset": "USDT",
+      "balance": "192.32494207",
+      "crossWalletBalance": "192.32494207",
+      "crossUnPnl": "6.86729999",
+      "availableBalance": "185.54784206",
+      "maxWithdrawAmount": "185.54784206",
+      "marginAvailable": true,
+      "updateTime": 1747995976003
+    },
+    {
+      "accountAlias": "SgsR",
+      "asset": "USDC",
+      "balance": "0.00000000",
+      "crossWalletBalance": "0.00000000",
+      "crossUnPnl": "0.00000000",
+      "availableBalance": "0.00000000",
+      "maxWithdrawAmount": "0.00000000",
+      "marginAvailable": true,
+      "updateTime": 0
+    }
+  ],
+  "rateLimits": [
+    {
+      "rateLimitType": "REQUEST_WEIGHT",
+      "interval": "MINUTE",
+      "intervalNum": 1,
+      "limit": 2400,
+      "count": 10
+    }
+  ]
+}`)
+
+	requestID := "7fe4c481-9784-4c02-8121-aacae6d2d38f"
+	s.mockClient.EXPECT().WriteSync(requestID, gomock.Any(), gomock.Any()).Return(data, nil)
+
+	wsAccountV2Service := &WsAccountService{
+		c:          s.mockClient,
+		ApiKey:     s.apiKey,
+		SecretKey:  s.secretKey,
+		KeyType:    common.KeyTypeHmac,
+		RecvWindow: 5000,
+	}
+
+	response, err := wsAccountV2Service.SyncGetAccountBalance(requestID)
+	s.NoError(err)
+
+	// verify
+	s.Equal(200, response.Status)
+	s.Equal(requestID, response.ID)
+
+	// verify balance info
+	s.Len(response.Result, 2)
+	s.Equal("USDT", response.Result[0].Asset)
+	s.Equal("192.32494207", response.Result[0].Balance)
+	s.Equal("185.54784206", response.Result[0].AvailableBalance)
+}


### PR DESCRIPTION
Add the Websocket interface of futures account info & balance, the corresponding interface document is:
- https://developers.binance.com/docs/zh-CN/derivatives/usds-margined-futures/account/websocket-api
- https://developers.binance.com/docs/zh-CN/derivatives/usds-margined-futures/account/websocket-api/Account-Information-V2

Usage:
```go
apiKey, apiSecret := "xxx", "xxx"
service, err := futures.NewClient(apiKey, apiSecret).NewWsAccountService()
if err != nil {
	log.Fatalf("connect failed: %v", err)
}

ticker := time.NewTicker(1 * time.Second)
for {
	select {
	case <-ticker.C:
		// resp, err := service.SyncGetAccountInfo(uuid.New().String())
		resp, err := service.SyncGetAccountBalance(uuid.New().String())
		// TODO...
	}
}
```