### PR TITLE
fix: Do not close ws conn from client side.

### DIFF
--- a/v2/portfolio/websocket_service.go
+++ b/v2/portfolio/websocket_service.go
@@ -15,7 +15,7 @@ var (
 
 var (
 	// WebsocketTimeout is an interval for sending ping/pong messages if WebsocketKeepalive is enabled
-	WebsocketTimeout = time.Second * 60
+	WebsocketTimeout = time.Second * 600
 	// WebsocketPongTimeout is an interval for sending a PONG frame in response to PING frame from server
 	WebsocketPongTimeout = time.Second * 10
 	// WebsocketKeepalive enables sending ping/pong messages to check the connection stability


### PR DESCRIPTION
Now the websocket in the portfolio will always close after 60 seconds, and it was found that it had been [fixed](https://github.com/ccxt/go-binance/commit/ccbb4e50) before, but the part of the portfolio was missed.

@adshao @carlosmiei 