### PR TITLE
fix(subaccount): subUserId should be int64

### DIFF
--- a/v2/subaccount_service.go
+++ b/v2/subaccount_service.go
@@ -332,7 +332,7 @@ type SubAccountList struct {
 }
 
 type SubAccount struct {
-	SubUserID                   string `json:"subUserId"`
+	SubUserID                   int64  `json:"subUserId"`
 	Email                       string `json:"email"`
 	Remark                      string `json:"remark"`
 	IsFreeze                    bool   `json:"isFreeze"`


### PR DESCRIPTION
fix: ccxt/go-binance#767

```go
client := binance.NewClient(apiKey, secret)
binance.UseTestnet = false
res, err := client.NewSubAccountListService().
	Do(context.Background())
if err != nil {
    panic(err)
}
fmt.Println(res)