### PR TITLE
fix: keepalive data race

### DIFF
--- a/v2/delivery/websocket.go
+++ b/v2/delivery/websocket.go
@@ -87,7 +87,7 @@ var wsServe = func(cfg *WsConfig, handler WsHandler, errHandler ErrHandler) (don
 func keepAlive(c *websocket.Conn, timeout time.Duration) {
 	ticker := time.NewTicker(timeout)
 
-	var lastResponse int64 = time.Now().UnixNano()
+	lastResponse := time.Now().UnixNano()
 
 	c.SetPingHandler(func(pingData string) error {
 		// Respond with Pong using the server's PING payload

--- a/v2/futures/websocket.go
+++ b/v2/futures/websocket.go
@@ -87,7 +87,7 @@ var wsServe = func(cfg *WsConfig, handler WsHandler, errHandler ErrHandler) (don
 func keepAlive(c *websocket.Conn, timeout time.Duration) {
 	ticker := time.NewTicker(timeout)
 
-	var lastResponse int64 = time.Now().UnixNano()
+	lastResponse := time.Now().UnixNano()
 
 	c.SetPingHandler(func(pingData string) error {
 		// Respond with Pong using the server's PING payload

--- a/v2/options/websocket.go
+++ b/v2/options/websocket.go
@@ -88,7 +88,7 @@ var wsServe = func(cfg *WsConfig, handler WsHandler, errHandler ErrHandler) (don
 func keepAlive(c *websocket.Conn, timeout time.Duration) {
 	ticker := time.NewTicker(timeout)
 
-	var lastResponse int64 = time.Now().UnixNano()
+	lastResponse := time.Now().UnixNano()
 
 	c.SetPingHandler(func(pingData string) error {
 		// Respond with Pong using the server's PING payload

--- a/v2/portfolio/websocket.go
+++ b/v2/portfolio/websocket.go
@@ -87,7 +87,7 @@ var wsServe = func(cfg *WsConfig, handler WsHandler, errHandler ErrHandler) (don
 func keepAlive(c *websocket.Conn, timeout time.Duration) {
 	ticker := time.NewTicker(timeout)
 
-	var lastResponse int64 = time.Now().UnixNano()
+	lastResponse := time.Now().UnixNano()
 
 	c.SetPingHandler(func(pingData string) error {
 		// Respond with Pong using the server's PING payload

--- a/v2/websocket.go
+++ b/v2/websocket.go
@@ -91,7 +91,7 @@ var wsServe = func(cfg *WsConfig, handler WsHandler, errHandler ErrHandler) (don
 func keepAlive(c *websocket.Conn, timeout time.Duration) {
 	ticker := time.NewTicker(timeout)
 
-	var lastResponse int64 = time.Now().UnixNano()
+	lastResponse := time.Now().UnixNano()
 
 	c.SetPingHandler(func(pingData string) error {
 		// Respond with Pong using the server's PING payload


### PR DESCRIPTION
Hello, 

Some data race fixes (lastResponse shared between ping handler and ticker goroutine)

