### PR TITLE
chore: fix PayTradeHistoryService struct comment mismatch

### DIFF
--- a/v2/pay_service.go
+++ b/v2/pay_service.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 )
 
-// PayTransactionService retrieve the fiat deposit/withdraw history
+// PayTradeHistoryService retrieves the pay transaction history
 type PayTradeHistoryService struct {
 	c              *Client
 	startTimestamp *int64

--- a/v2/user_universal_transfer.go
+++ b/v2/user_universal_transfer.go
@@ -149,7 +149,7 @@ func (s *ListUserUniversalTransferService) ToSymbol(v string) *ListUserUniversal
 	return s
 }
 
-// // Do sends the request.
+// Do sends the request.
 func (s *ListUserUniversalTransferService) Do(ctx context.Context) (res *UserUniversalTransferResponse, err error) {
 	r := &request{
 		method:   http.MethodGet,


### PR DESCRIPTION

Corrected the struct comment for PayTradeHistoryService to match its actual name and purpose, changing from "PayTransactionService retrieve the fiat deposit/withdraw history" to "PayTradeHistoryService retrieves the pay transaction history" for accuracy and clarity.