### PR TITLE
feat(futures): add TRADIFI_PERPETUAL contract type

### DIFF
--- a/v2/futures/client.go
+++ b/v2/futures/client.go
@@ -161,9 +161,10 @@ const (
 	MarginTypeIsolated MarginType = "ISOLATED"
 	MarginTypeCrossed  MarginType = "CROSSED"
 
-	ContractTypePerpetual      ContractType = "PERPETUAL"
-	ContractTypeCurrentQuarter ContractType = "CURRENT_QUARTER"
-	ContractTypeNextQuarter    ContractType = "NEXT_QUARTER"
+	ContractTypePerpetual        ContractType = "PERPETUAL"
+	ContractTypeCurrentQuarter   ContractType = "CURRENT_QUARTER"
+	ContractTypeNextQuarter      ContractType = "NEXT_QUARTER"
+	ContractTypeTradifiPerpetual ContractType = "TRADIFI_PERPETUAL"
 
 	UserDataEventTypeListenKeyExpired              UserDataEventType = "listenKeyExpired"
 	UserDataEventTypeMarginCall                    UserDataEventType = "MARGIN_CALL"


### PR DESCRIPTION
## Summary

Adds `ContractTypeTradifiPerpetual` (`TRADIFI_PERPETUAL`) to the USDT-M futures `ContractType` constants so the client matches Binance's contract type for Tradifi perpetual symbols.

## Changes

- `v2/futures/client.go`: extend `ContractType` with `ContractTypeTradifiPerpetual`.