### PR TITLE
fix(futures): use listenKey query param for user data WebSocket

### DIFF
--- a/v2/futures/websocket_service.go
+++ b/v2/futures/websocket_service.go
@@ -1438,7 +1438,7 @@ type WsUserDataHandler func(event *WsUserDataEvent)
 
 // WsUserDataServe serve user data handler with listen key
 func WsUserDataServe(listenKey string, handler WsUserDataHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
-	endpoint := fmt.Sprintf("%s/%s", getWsPrivateEndpoint(), listenKey)
+	endpoint := fmt.Sprintf("%s?listenKey=%s", getWsPrivateEndpoint(), listenKey)
 	cfg := newWsConfig(endpoint)
 	wsHandler := func(message []byte) {
 		event := new(WsUserDataEvent)


### PR DESCRIPTION
## Background

Binance has changed USDS-M futures user data WebSocket URLs. The **legacy pattern no longer receives user data** over the WebSocket; clients must migrate to the new private endpoint and pass `listenKey` as a **query parameter** instead of a path segment.

**Reference:** [Important WebSocket Change Notice – Compatibility & migration guidance](https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Important-WebSocket-Change-Notice#compatibility--migration-guidance)

## Changes

- `WsUserDataServe` in `v2/futures/websocket_service.go`: build the URL as `{private/ws base}?listenKey=<key>` instead of `{private/ws base}/<key>`.
