### PR TITLE
fix: set symbol param only when isIsolated is true

### DIFF
--- a/v2/margin_service.go
+++ b/v2/margin_service.go
@@ -242,9 +242,12 @@ func (s *MarginBorrowRepayService) Do(ctx context.Context, opts ...RequestOption
 	m := params{
 		"asset":      s.asset,
 		"isIsolated": s.isIsolated,
-		"symbol":     s.symbol,
-		"amount":     s.amount,
-		"type":       string(s._type),
+		//"symbol":     s.symbol,
+		"amount": s.amount,
+		"type":   string(s._type),
+	}
+	if s.isIsolated {
+		m["symbol"] = s.symbol // set symbol param only when isIsolated is true
 	}
 	r.setFormParams(m)
 	res = new(TransactionResponse)

--- a/v2/margin_service.go
+++ b/v2/margin_service.go
@@ -3,6 +3,7 @@ package binance
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 )
@@ -242,12 +243,14 @@ func (s *MarginBorrowRepayService) Do(ctx context.Context, opts ...RequestOption
 	m := params{
 		"asset":      s.asset,
 		"isIsolated": s.isIsolated,
-		//"symbol":     s.symbol,
-		"amount": s.amount,
-		"type":   string(s._type),
+		"amount":     s.amount,
+		"type":       string(s._type),
 	}
 	if s.isIsolated {
-		m["symbol"] = s.symbol // set symbol param only when isIsolated is true
+		if s.symbol == "" {
+			return nil, fmt.Errorf("symbol is required for isolated margin borrow/repay")
+		}
+		m["symbol"] = s.symbol // Only set symbol param when isIsolated is true
 	}
 	r.setFormParams(m)
 	res = new(TransactionResponse)
@@ -330,13 +333,6 @@ func (s *ListMarginBorrowRepayService) Do(ctx context.Context, opts ...RequestOp
 		secType:  secTypeSigned,
 	}
 	m := params{
-		//"asset":          s.asset,
-		//"isolatedSymbol": s.isolatedSymbol,
-		//"txId":           s.txId,
-		//"startTime":      s.startTime,
-		//"endTime":        s.endTime,
-		//"current":        s.current,
-		//"size":           s.size,
 		"type": string(s._type),
 	}
 	r.setParams(m)

--- a/v2/margin_service_test.go
+++ b/v2/margin_service_test.go
@@ -106,8 +106,8 @@ func (s *marginTestSuite) TestBorrowRepayBorrow() {
 			"asset":      asset,
 			"amount":     amount,
 			"isIsolated": false,
-			"symbol":     "",
-			"type":       string(_type),
+			//"symbol":     "",
+			"type": string(_type),
 		})
 		s.assertRequestEqual(e, r)
 	})
@@ -137,8 +137,8 @@ func (s *marginTestSuite) TestBorrowRepayRepay() {
 			"asset":      asset,
 			"amount":     amount,
 			"isIsolated": false,
-			"symbol":     "",
-			"type":       string(_type),
+			//"symbol":     "",
+			"type": string(_type),
 		})
 		s.assertRequestEqual(e, r)
 	})

--- a/v2/margin_service_test.go
+++ b/v2/margin_service_test.go
@@ -106,8 +106,7 @@ func (s *marginTestSuite) TestBorrowRepayBorrow() {
 			"asset":      asset,
 			"amount":     amount,
 			"isIsolated": false,
-			//"symbol":     "",
-			"type": string(_type),
+			"type":       string(_type),
 		})
 		s.assertRequestEqual(e, r)
 	})
@@ -137,8 +136,7 @@ func (s *marginTestSuite) TestBorrowRepayRepay() {
 			"asset":      asset,
 			"amount":     amount,
 			"isIsolated": false,
-			//"symbol":     "",
-			"type": string(_type),
+			"type":       string(_type),
 		})
 		s.assertRequestEqual(e, r)
 	})
@@ -152,6 +150,56 @@ func (s *marginTestSuite) TestBorrowRepayRepay() {
 		TranID: 100000001,
 	}
 	s.assertTransactionResponseEqual(e, res)
+}
+
+func (s *marginTestSuite) TestBorrowRepayBorrowIsolated() {
+	data := []byte(`{
+		"tranId": 100000001
+	}`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+	asset := "BTC"
+	amount := "1.000"
+	symbol := "BTCUSDT"
+	_type := MarginAccountBorrow
+	s.assertReq(func(r *request) {
+		e := newSignedRequest().setFormParams(params{
+			"asset":      asset,
+			"amount":     amount,
+			"isIsolated": true,
+			"symbol":     symbol,
+			"type":       string(_type),
+		})
+		s.assertRequestEqual(e, r)
+	})
+	res, err := s.client.NewMarginBorrowRepayService().
+		Asset(asset).
+		Amount(amount).
+		IsIsolated(true).
+		Symbol(symbol).
+		Type(_type).
+		Do(newContext())
+	s.r().NoError(err)
+	e := &TransactionResponse{
+		TranID: 100000001,
+	}
+	s.assertTransactionResponseEqual(e, res)
+}
+
+func (s *marginTestSuite) TestBorrowRepayBorrowIsolatedWithoutSymbol() {
+	asset := "BTC"
+	amount := "1.000"
+	_type := MarginAccountBorrow
+	res, err := s.client.NewMarginBorrowRepayService().
+		Asset(asset).
+		Amount(amount).
+		IsIsolated(true).
+		Type(_type).
+		Do(newContext())
+	s.r().Error(err)
+	s.r().EqualError(err, "symbol is required for isolated margin borrow/repay")
+	s.r().Nil(res)
+	s.client.AssertNotCalled(s.T(), "do", anyHTTPRequest())
 }
 
 func (s *marginTestSuite) TestListBorrowRepay() {


### PR DESCRIPTION
fix: stop sending symbol="" when isIsolated=false as backend upgrade now rejects it

`<APIError> code=-1022, msg=Signature for this request is not valid.`